### PR TITLE
Use functor keyword in `ndarray_core.mli`

### DIFF
--- a/ndarray/lib/core/ndarray_core.mli
+++ b/ndarray/lib/core/ndarray_core.mli
@@ -429,7 +429,7 @@ module type Backend_intf = sig
   val matmul : context -> ('a, 'b) b_t -> ('a, 'b) b_t -> ('a, 'b) b_t -> unit
 end
 
-module Make : (B : Backend_intf) -> sig
+module Make : functor (B : Backend_intf) -> sig
   type ('a, 'b) t = ('a, 'b) B.b_t
   type context = B.context
 


### PR DESCRIPTION
I wasn't able to compile the `ndarray` library without this small change to this interface.  This project seems cool, I hope to experiment with it!