### PR TITLE
feat(nx): Initial support for fft

### DIFF
--- a/nx/lib/c/nx_c_stubs.c
+++ b/nx/lib/c/nx_c_stubs.c
@@ -2186,6 +2186,20 @@ CAMLprim value caml_nx_pad_bc(value *argv, int argn) {
     case CAML_BA_UINT8:
       nx_c_pad_uint8_t(&x, &z, padding, Int_val(v_pad_value));
       break;
+    case CAML_BA_COMPLEX32: {
+      float re = (float)Double_field(v_pad_value, 0);
+      float im = (float)Double_field(v_pad_value, 1);
+      c32_t pad_val = re + im * I;
+      nx_c_pad_c32_t(&x, &z, padding, pad_val);
+      break;
+    }
+    case CAML_BA_COMPLEX64: {
+      double re = Double_field(v_pad_value, 0);
+      double im = Double_field(v_pad_value, 1);
+      c64_t pad_val = re + im * I;
+      nx_c_pad_c64_t(&x, &z, padding, pad_val);
+      break;
+    }
     default:
       caml_leave_blocking_section();
       caml_failwith("pad: unsupported dtype");
@@ -3593,3 +3607,1185 @@ CAMLprim value caml_nx_fold_bc(value *argv, int argn) {
 // Duplicate macro definitions removed - see top of file for all definitions
 
 NATIVE_WRAPPER_15(fold)
+
+// ============================================================================
+// FFT Operations
+// ============================================================================
+
+#include <math.h>
+#include <stdbool.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+// Helper function to compute twiddle factors
+static inline void compute_twiddle(double angle, double *cos_val,
+                                   double *sin_val) {
+  *cos_val = cos(angle);
+  *sin_val = sin(angle);
+}
+
+// Bit reversal for FFT
+static inline size_t bit_reverse(size_t x, int log2n) {
+  size_t result = 0;
+  for (int i = 0; i < log2n; i++) {
+    result = (result << 1) | (x & 1);
+    x >>= 1;
+  }
+  return result;
+}
+
+// DFT implementation for arbitrary sizes
+static void dft_complex64(double *data_re, double *data_im, size_t n,
+                         int stride, size_t offset, bool inverse) {
+  double *temp_re = (double *)malloc(n * sizeof(double));
+  double *temp_im = (double *)malloc(n * sizeof(double));
+  
+  if (!temp_re || !temp_im) {
+    free(temp_re);
+    free(temp_im);
+    return;
+  }
+  
+  double sign = inverse ? 1.0 : -1.0;
+  double two_pi_n = 2.0 * M_PI / n;
+  
+  // Copy input data
+  for (size_t i = 0; i < n; i++) {
+    temp_re[i] = data_re[offset + i * stride];
+    temp_im[i] = data_im[offset + i * stride];
+  }
+  
+  // Compute DFT
+  for (size_t k = 0; k < n; k++) {
+    double sum_re = 0.0;
+    double sum_im = 0.0;
+    
+    for (size_t j = 0; j < n; j++) {
+      double angle = sign * two_pi_n * k * j;
+      double cos_angle = cos(angle);
+      double sin_angle = sin(angle);
+      
+      sum_re += temp_re[j] * cos_angle - temp_im[j] * sin_angle;
+      sum_im += temp_re[j] * sin_angle + temp_im[j] * cos_angle;
+    }
+    
+    data_re[offset + k * stride] = sum_re;
+    data_im[offset + k * stride] = sum_im;
+  }
+  
+  free(temp_re);
+  free(temp_im);
+}
+
+// 1D FFT implementation using Cooley-Tukey algorithm
+static void fft_1d_complex64(double *data_re, double *data_im, size_t n,
+                             int stride, size_t offset, bool inverse) {
+  if (n <= 1) return;
+
+  // Check if n is power of 2
+  int log2n = 0;
+  size_t temp = n;
+  bool is_power_of_2 = true;
+  while (temp > 1) {
+    if (temp & 1) {
+      is_power_of_2 = false;
+      break;
+    }
+    temp >>= 1;
+    log2n++;
+  }
+  
+  if (!is_power_of_2) {
+    // Not a power of 2, use DFT
+    dft_complex64(data_re, data_im, n, stride, offset, inverse);
+    return;
+  }
+
+  // Bit reversal permutation
+  for (size_t i = 0; i < n; i++) {
+    size_t j = bit_reverse(i, log2n);
+    if (i < j) {
+      // Swap elements
+      size_t idx_i = offset + i * stride;
+      size_t idx_j = offset + j * stride;
+
+      double temp_re = data_re[idx_i];
+      double temp_im = data_im[idx_i];
+      data_re[idx_i] = data_re[idx_j];
+      data_im[idx_i] = data_im[idx_j];
+      data_re[idx_j] = temp_re;
+      data_im[idx_j] = temp_im;
+    }
+  }
+
+  // FFT computation
+  double sign = inverse ? 1.0 : -1.0;
+
+  for (size_t stage_size = 2; stage_size <= n; stage_size *= 2) {
+    size_t half_stage = stage_size / 2;
+    double angle_step = sign * 2.0 * M_PI / stage_size;
+
+    for (size_t k = 0; k < n; k += stage_size) {
+      for (size_t j = 0; j < half_stage; j++) {
+        double angle = angle_step * j;
+        double twiddle_re, twiddle_im;
+        compute_twiddle(angle, &twiddle_re, &twiddle_im);
+
+        size_t idx1 = offset + (k + j) * stride;
+        size_t idx2 = offset + (k + j + half_stage) * stride;
+
+        double a_re = data_re[idx1];
+        double a_im = data_im[idx1];
+        double b_re = data_re[idx2];
+        double b_im = data_im[idx2];
+
+        // Complex multiplication: b * twiddle
+        double b_twiddle_re = b_re * twiddle_re - b_im * twiddle_im;
+        double b_twiddle_im = b_re * twiddle_im + b_im * twiddle_re;
+
+        // Butterfly operation
+        data_re[idx1] = a_re + b_twiddle_re;
+        data_im[idx1] = a_im + b_twiddle_im;
+        data_re[idx2] = a_re - b_twiddle_re;
+        data_im[idx2] = a_im - b_twiddle_im;
+      }
+    }
+  }
+
+  // Do NOT apply scaling here - it will be done after all transforms
+}
+
+// Multi-dimensional FFT for complex64
+static void fft_multi_complex64(ndarray_t *data, int *axes, int num_axes,
+                                bool inverse) {
+  int ndim = data->ndim;
+  const int *shape = data->shape;
+
+  // Perform FFT along each specified axis
+  for (int ax_idx = 0; ax_idx < num_axes; ax_idx++) {
+    int axis = axes[ax_idx];
+    if (axis < 0) axis += ndim;
+
+    size_t n = shape[axis];
+    if (n <= 1) continue;
+
+    // Calculate stride for this axis
+    size_t axis_stride = 1;
+    for (int d = axis + 1; d < ndim; d++) {
+      axis_stride *= shape[d];
+    }
+
+    // Iterate over all other dimensions
+    size_t total_elements = 1;
+    for (int d = 0; d < ndim; d++) {
+      total_elements *= shape[d];
+    }
+
+    size_t num_ffts = total_elements / n;
+
+    // Allocate temporary arrays for real and imaginary parts
+    double *temp_re = (double *)malloc(n * sizeof(double));
+    double *temp_im = (double *)malloc(n * sizeof(double));
+
+    if (!temp_re || !temp_im) {
+      free(temp_re);
+      free(temp_im);
+      return;
+    }
+
+    // Process each 1D FFT along the axis
+    for (size_t fft_idx = 0; fft_idx < num_ffts; fft_idx++) {
+      // Calculate starting offset for this FFT
+      size_t offset = 0;
+      size_t temp_idx = fft_idx;
+
+      for (int d = ndim - 1; d >= 0; d--) {
+        if (d != axis) {
+          size_t dim_size = (d > axis) ? shape[d] : shape[d];
+          size_t coord = temp_idx % dim_size;
+          temp_idx /= dim_size;
+
+          size_t stride_d = 1;
+          for (int dd = d + 1; dd < ndim; dd++) {
+            stride_d *= shape[dd];
+          }
+          offset += coord * stride_d;
+        }
+      }
+
+      // Extract data along the axis
+      // Note: data is stored as interleaved complex values
+      double *complex_data = (double *)data->data;
+      for (size_t i = 0; i < n; i++) {
+        size_t idx = offset + i * axis_stride;
+        temp_re[i] = complex_data[2 * idx];
+        temp_im[i] = complex_data[2 * idx + 1];
+      }
+
+      // Perform 1D FFT
+      fft_1d_complex64(temp_re, temp_im, n, 1, 0, inverse);
+
+      // Write back the result
+      for (size_t i = 0; i < n; i++) {
+        size_t idx = offset + i * axis_stride;
+        complex_data[2 * idx] = temp_re[i];
+        complex_data[2 * idx + 1] = temp_im[i];
+      }
+    }
+
+    free(temp_re);
+    free(temp_im);
+  }
+  
+  // Note: Scaling is handled by the frontend based on norm parameter
+}
+
+// Forward declarations
+CAMLprim value caml_nx_fft_complex64(value v_ndim, value v_shape, value v_input,
+                                     value v_input_strides,
+                                     value v_input_offset, value v_output,
+                                     value v_output_strides,
+                                     value v_output_offset, value v_axes,
+                                     value v_num_axes, value v_inverse);
+
+CAMLprim value caml_nx_fft_complex32(value v_ndim, value v_shape, value v_input,
+                                     value v_input_strides,
+                                     value v_input_offset, value v_output,
+                                     value v_output_strides,
+                                     value v_output_offset, value v_axes,
+                                     value v_num_axes, value v_inverse);
+
+CAMLprim value caml_nx_rfft_float64(value v_ndim, value v_shape, value v_input,
+                                    value v_input_strides, value v_input_offset,
+                                    value v_output, value v_output_strides,
+                                    value v_output_offset, value v_axes,
+                                    value v_num_axes);
+
+CAMLprim value caml_nx_irfft_complex64(value v_ndim, value v_shape,
+                                       value v_input, value v_input_strides,
+                                       value v_input_offset, value v_output,
+                                       value v_output_strides,
+                                       value v_output_offset, value v_axes,
+                                       value v_num_axes, value v_last_size);
+
+// FFT dispatch for complex64
+CAMLprim value caml_nx_fft_complex64_bc(value *argv, int argn) {
+  (void)argn;
+  value v_ndim = argv[0], v_shape = argv[1];
+  value v_input = argv[2], v_input_strides = argv[3], v_input_offset = argv[4];
+  value v_output = argv[5], v_output_strides = argv[6],
+        v_output_offset = argv[7];
+  value v_axes = argv[8], v_num_axes = argv[9], v_inverse = argv[10];
+
+  return caml_nx_fft_complex64(v_ndim, v_shape, v_input, v_input_strides,
+                               v_input_offset, v_output, v_output_strides,
+                               v_output_offset, v_axes, v_num_axes, v_inverse);
+}
+
+CAMLprim value caml_nx_fft_complex64(value v_ndim, value v_shape, value v_input,
+                                     value v_input_strides,
+                                     value v_input_offset, value v_output,
+                                     value v_output_strides,
+                                     value v_output_offset, value v_axes,
+                                     value v_num_axes, value v_inverse) {
+  // Parse input
+  int ndim = Int_val(v_ndim);
+  int num_axes = Int_val(v_num_axes);
+  bool inverse = Bool_val(v_inverse);
+  
+  int shape[ndim > 0 ? ndim : 1];
+  int input_strides[ndim > 0 ? ndim : 1];
+  int output_strides[ndim > 0 ? ndim : 1];
+  int axes[num_axes > 0 ? num_axes : 1];
+  
+  for (int i = 0; i < ndim; ++i) {
+    shape[i] = Int_val(Field(v_shape, i));
+    input_strides[i] = Int_val(Field(v_input_strides, i));
+    output_strides[i] = Int_val(Field(v_output_strides, i));
+  }
+  
+  for (int i = 0; i < num_axes; ++i) {
+    axes[i] = Int_val(Field(v_axes, i));
+  }
+
+  // Get arrays - input and output can be the same
+  ndarray_t input = {
+      .data = Caml_ba_data_val(v_input) + Long_val(v_input_offset),
+      .shape = shape,
+      .strides = input_strides,
+      .ndim = ndim};
+
+  ndarray_t output = {
+      .data = Caml_ba_data_val(v_output) + Long_val(v_output_offset),
+      .shape = shape,
+      .strides = output_strides,
+      .ndim = ndim};
+
+  // Copy input to output if different buffers
+  if (input.data != output.data) {
+    size_t total_size = 1;
+    for (int i = 0; i < ndim; i++) {
+      total_size *= shape[i];
+    }
+    memcpy(output.data, input.data, total_size * 2 * sizeof(double));
+  }
+
+  caml_enter_blocking_section();
+  fft_multi_complex64(&output, axes, num_axes, inverse);
+  caml_leave_blocking_section();
+
+  return Val_unit;
+}
+
+// DFT implementation for arbitrary sizes (single precision)
+static void dft_complex32(float *data_re, float *data_im, size_t n,
+                         int stride, size_t offset, bool inverse) {
+  float *temp_re = (float *)malloc(n * sizeof(float));
+  float *temp_im = (float *)malloc(n * sizeof(float));
+  
+  if (!temp_re || !temp_im) {
+    free(temp_re);
+    free(temp_im);
+    return;
+  }
+  
+  float sign = inverse ? 1.0f : -1.0f;
+  float two_pi_n = 2.0f * (float)M_PI / n;
+  
+  // Copy input data
+  for (size_t i = 0; i < n; i++) {
+    temp_re[i] = data_re[offset + i * stride];
+    temp_im[i] = data_im[offset + i * stride];
+  }
+  
+  // Compute DFT
+  for (size_t k = 0; k < n; k++) {
+    float sum_re = 0.0f;
+    float sum_im = 0.0f;
+    
+    for (size_t j = 0; j < n; j++) {
+      float angle = sign * two_pi_n * k * j;
+      float cos_angle = cosf(angle);
+      float sin_angle = sinf(angle);
+      
+      sum_re += temp_re[j] * cos_angle - temp_im[j] * sin_angle;
+      sum_im += temp_re[j] * sin_angle + temp_im[j] * cos_angle;
+    }
+    
+    data_re[offset + k * stride] = sum_re;
+    data_im[offset + k * stride] = sum_im;
+  }
+  
+  free(temp_re);
+  free(temp_im);
+}
+
+// FFT for complex32 (single precision)
+static void fft_1d_complex32(float *data_re, float *data_im, size_t n,
+                             int stride, size_t offset, bool inverse) {
+  if (n <= 1) return;
+
+  // Check if n is power of 2
+  int log2n = 0;
+  size_t temp = n;
+  bool is_power_of_2 = true;
+  while (temp > 1) {
+    if (temp & 1) {
+      is_power_of_2 = false;
+      break;
+    }
+    temp >>= 1;
+    log2n++;
+  }
+  
+  if (!is_power_of_2) {
+    // Not a power of 2, use DFT
+    dft_complex32(data_re, data_im, n, stride, offset, inverse);
+    return;
+  }
+
+  // Bit reversal permutation
+  for (size_t i = 0; i < n; i++) {
+    size_t j = bit_reverse(i, log2n);
+    if (i < j) {
+      size_t idx_i = offset + i * stride;
+      size_t idx_j = offset + j * stride;
+
+      float temp_re = data_re[idx_i];
+      float temp_im = data_im[idx_i];
+      data_re[idx_i] = data_re[idx_j];
+      data_im[idx_i] = data_im[idx_j];
+      data_re[idx_j] = temp_re;
+      data_im[idx_j] = temp_im;
+    }
+  }
+
+  // FFT computation
+  float sign = inverse ? 1.0f : -1.0f;
+
+  for (size_t stage_size = 2; stage_size <= n; stage_size *= 2) {
+    size_t half_stage = stage_size / 2;
+    float angle_step = sign * 2.0f * (float)M_PI / stage_size;
+
+    for (size_t k = 0; k < n; k += stage_size) {
+      for (size_t j = 0; j < half_stage; j++) {
+        float angle = angle_step * j;
+        float twiddle_re = cosf(angle);
+        float twiddle_im = sinf(angle);
+
+        size_t idx1 = offset + (k + j) * stride;
+        size_t idx2 = offset + (k + j + half_stage) * stride;
+
+        float a_re = data_re[idx1];
+        float a_im = data_im[idx1];
+        float b_re = data_re[idx2];
+        float b_im = data_im[idx2];
+
+        float b_twiddle_re = b_re * twiddle_re - b_im * twiddle_im;
+        float b_twiddle_im = b_re * twiddle_im + b_im * twiddle_re;
+
+        data_re[idx1] = a_re + b_twiddle_re;
+        data_im[idx1] = a_im + b_twiddle_im;
+        data_re[idx2] = a_re - b_twiddle_re;
+        data_im[idx2] = a_im - b_twiddle_im;
+      }
+    }
+  }
+
+  // Note: scaling is now done after all axis transforms in fft_multi_complex32
+}
+
+// Multi-dimensional FFT for complex32
+static void fft_multi_complex32(ndarray_t *data, int *axes, int num_axes,
+                                bool inverse) {
+  int ndim = data->ndim;
+  const int *shape = data->shape;
+
+  for (int ax_idx = 0; ax_idx < num_axes; ax_idx++) {
+    int axis = axes[ax_idx];
+    if (axis < 0) axis += ndim;
+
+    size_t n = shape[axis];
+    if (n <= 1) continue;
+
+    size_t axis_stride = 1;
+    for (int d = axis + 1; d < ndim; d++) {
+      axis_stride *= shape[d];
+    }
+
+    size_t total_elements = 1;
+    for (int d = 0; d < ndim; d++) {
+      total_elements *= shape[d];
+    }
+
+    size_t num_ffts = total_elements / n;
+
+    float *temp_re = (float *)malloc(n * sizeof(float));
+    float *temp_im = (float *)malloc(n * sizeof(float));
+
+    if (!temp_re || !temp_im) {
+      free(temp_re);
+      free(temp_im);
+      return;
+    }
+
+    for (size_t fft_idx = 0; fft_idx < num_ffts; fft_idx++) {
+      size_t offset = 0;
+      size_t temp_idx = fft_idx;
+
+      for (int d = ndim - 1; d >= 0; d--) {
+        if (d != axis) {
+          size_t dim_size = (d > axis) ? shape[d] : shape[d];
+          size_t coord = temp_idx % dim_size;
+          temp_idx /= dim_size;
+
+          size_t stride_d = 1;
+          for (int dd = d + 1; dd < ndim; dd++) {
+            stride_d *= shape[dd];
+          }
+          offset += coord * stride_d;
+        }
+      }
+
+      for (size_t i = 0; i < n; i++) {
+        size_t idx = offset + i * axis_stride;
+        temp_re[i] = ((float *)data->data)[2 * idx];
+        temp_im[i] = ((float *)data->data)[2 * idx + 1];
+      }
+
+      fft_1d_complex32(temp_re, temp_im, n, 1, 0, inverse);
+
+      for (size_t i = 0; i < n; i++) {
+        size_t idx = offset + i * axis_stride;
+        ((float *)data->data)[2 * idx] = temp_re[i];
+        ((float *)data->data)[2 * idx + 1] = temp_im[i];
+      }
+    }
+
+    free(temp_re);
+    free(temp_im);
+  }
+
+  // Note: Scaling is handled by the frontend based on norm parameter
+}
+
+// FFT dispatch for complex32
+CAMLprim value caml_nx_fft_complex32_bc(value *argv, int argn) {
+  (void)argn;
+  value v_ndim = argv[0], v_shape = argv[1];
+  value v_input = argv[2], v_input_strides = argv[3], v_input_offset = argv[4];
+  value v_output = argv[5], v_output_strides = argv[6],
+        v_output_offset = argv[7];
+  value v_axes = argv[8], v_num_axes = argv[9], v_inverse = argv[10];
+
+  return caml_nx_fft_complex32(v_ndim, v_shape, v_input, v_input_strides,
+                               v_input_offset, v_output, v_output_strides,
+                               v_output_offset, v_axes, v_num_axes, v_inverse);
+}
+
+CAMLprim value caml_nx_fft_complex32(value v_ndim, value v_shape, value v_input,
+                                     value v_input_strides,
+                                     value v_input_offset, value v_output,
+                                     value v_output_strides,
+                                     value v_output_offset, value v_axes,
+                                     value v_num_axes, value v_inverse) {
+  int ndim = Int_val(v_ndim);
+  int num_axes = Int_val(v_num_axes);
+  bool inverse = Bool_val(v_inverse);
+  
+  int shape[ndim > 0 ? ndim : 1];
+  int input_strides[ndim > 0 ? ndim : 1];
+  int output_strides[ndim > 0 ? ndim : 1];
+  int axes[num_axes > 0 ? num_axes : 1];
+  
+  for (int i = 0; i < ndim; ++i) {
+    shape[i] = Int_val(Field(v_shape, i));
+    input_strides[i] = Int_val(Field(v_input_strides, i));
+    output_strides[i] = Int_val(Field(v_output_strides, i));
+  }
+  
+  for (int i = 0; i < num_axes; ++i) {
+    axes[i] = Int_val(Field(v_axes, i));
+  }
+
+  ndarray_t input = {
+      .data = Caml_ba_data_val(v_input) + Long_val(v_input_offset),
+      .shape = shape,
+      .strides = input_strides,
+      .ndim = ndim};
+
+  ndarray_t output = {
+      .data = Caml_ba_data_val(v_output) + Long_val(v_output_offset),
+      .shape = shape,
+      .strides = output_strides,
+      .ndim = ndim};
+
+  if (input.data != output.data) {
+    size_t total_size = 1;
+    for (int i = 0; i < ndim; i++) {
+      total_size *= shape[i];
+    }
+    memcpy(output.data, input.data, total_size * 2 * sizeof(float));
+  }
+
+  caml_enter_blocking_section();
+  fft_multi_complex32(&output, axes, num_axes, inverse);
+  caml_leave_blocking_section();
+
+  return Val_unit;
+}
+
+// RFFT dispatch for float64
+CAMLprim value caml_nx_rfft_float64_bc(value *argv, int argn) {
+  (void)argn;
+  value v_ndim = argv[0], v_shape = argv[1];
+  value v_input = argv[2], v_input_strides = argv[3], v_input_offset = argv[4];
+  value v_output = argv[5], v_output_strides = argv[6],
+        v_output_offset = argv[7];
+  value v_axes = argv[8], v_num_axes = argv[9];
+
+  return caml_nx_rfft_float64(v_ndim, v_shape, v_input, v_input_strides,
+                              v_input_offset, v_output, v_output_strides,
+                              v_output_offset, v_axes, v_num_axes);
+}
+
+CAMLprim value caml_nx_rfft_float64(value v_ndim, value v_shape, value v_input,
+                                    value v_input_strides, value v_input_offset,
+                                    value v_output, value v_output_strides,
+                                    value v_output_offset, value v_axes,
+                                    value v_num_axes) {
+  int ndim = Int_val(v_ndim);
+  int num_axes = Int_val(v_num_axes);
+  
+  int input_shape[ndim > 0 ? ndim : 1];
+  int input_strides[ndim > 0 ? ndim : 1];
+  int output_strides[ndim > 0 ? ndim : 1];
+  int axes[num_axes > 0 ? num_axes : 1];
+  
+  for (int i = 0; i < ndim; ++i) {
+    input_shape[i] = Int_val(Field(v_shape, i));
+    input_strides[i] = Int_val(Field(v_input_strides, i));
+    output_strides[i] = Int_val(Field(v_output_strides, i));
+  }
+  
+  for (int i = 0; i < num_axes; ++i) {
+    axes[i] = Int_val(Field(v_axes, i));
+  }
+
+  // Handle multi-dimensional RFFT
+  // For multi-dimensional RFFT, we perform complex FFT on all axes except the last,
+  // then RFFT on the last axis
+
+  // Determine which axis will get the RFFT (last in the axes list)
+  int rfft_axis = axes[num_axes - 1];
+  if (rfft_axis < 0) rfft_axis += ndim;
+
+  // Calculate output shape - only the RFFT axis changes size
+  int output_shape[ndim > 0 ? ndim : 1];
+  memcpy(output_shape, input_shape, ndim * sizeof(int));
+  output_shape[rfft_axis] = (input_shape[rfft_axis] / 2) + 1;
+
+  // If we have multiple axes, we need to do complex FFTs first
+  if (num_axes > 1) {
+    // Create a complex copy of the real input
+    size_t total_size = 1;
+    for (int d = 0; d < ndim; d++) {
+      total_size *= input_shape[d];
+    }
+    
+    double *complex_data = (double *)malloc(total_size * 2 * sizeof(double));
+    if (!complex_data) {
+      caml_failwith("rfft: memory allocation failed");
+    }
+    
+    // Copy real data to complex format with proper striding
+    double *real_input = (double *)Caml_ba_data_val(v_input) + Long_val(v_input_offset);
+    for (size_t i = 0; i < total_size; i++) {
+      // Calculate the multi-dimensional index
+      size_t temp_idx = i;
+      size_t offset = 0;
+      for (int d = ndim - 1; d >= 0; d--) {
+        size_t coord = temp_idx % input_shape[d];
+        temp_idx /= input_shape[d];
+        offset += coord * input_strides[d];
+      }
+      complex_data[2 * i] = real_input[offset];
+      complex_data[2 * i + 1] = 0.0;
+    }
+    
+    // Create strides for complex data (contiguous)
+    int complex_strides[ndim > 0 ? ndim : 1];
+    complex_strides[ndim - 1] = 1;
+    for (int d = ndim - 2; d >= 0; d--) {
+      complex_strides[d] = complex_strides[d + 1] * input_shape[d + 1];
+    }
+    
+    // Create ndarray for complex data
+    ndarray_t complex_array = {
+      .data = complex_data,
+      .shape = input_shape,
+      .strides = complex_strides,
+      .ndim = ndim
+    };
+    
+    // Perform complex FFT on all axes except the last
+    int complex_axes[num_axes - 1];
+    for (int i = 0; i < num_axes - 1; i++) {
+      complex_axes[i] = axes[i];
+    }
+    
+    caml_enter_blocking_section();
+    if (num_axes > 1) {
+      fft_multi_complex64(&complex_array, complex_axes, num_axes - 1, false);
+    }
+    
+    // Now perform RFFT on the last axis
+    size_t n = input_shape[rfft_axis];
+    size_t n_out = (n / 2) + 1;
+    
+    // Calculate number of 1D RFFTs to perform
+    size_t num_rffts = total_size / n;
+    
+    // Allocate temporary arrays for single RFFT
+    double *temp_re = (double *)malloc(n * sizeof(double));
+    double *temp_im = (double *)malloc(n * sizeof(double));
+    
+    if (!temp_re || !temp_im) {
+      free(complex_data);
+      free(temp_re);
+      free(temp_im);
+      caml_leave_blocking_section();
+      caml_failwith("rfft: memory allocation failed");
+    }
+    
+    // Get output pointer
+    double *output_data = (double *)Caml_ba_data_val(v_output) + Long_val(v_output_offset);
+    
+    // Process each 1D RFFT along the RFFT axis
+    for (size_t rfft_idx = 0; rfft_idx < num_rffts; rfft_idx++) {
+      // Calculate base offset for this RFFT
+      size_t base_offset_in = 0;
+      size_t base_offset_out = 0;
+      size_t temp_idx = rfft_idx;
+      
+      for (int d = ndim - 1; d >= 0; d--) {
+        if (d != rfft_axis) {
+          size_t dim_size = input_shape[d];
+          size_t coord = temp_idx % dim_size;
+          temp_idx /= dim_size;
+          
+          base_offset_in += coord * complex_strides[d];
+          
+          // Calculate output offset with modified shape
+          size_t out_stride = 1;
+          for (int dd = d + 1; dd < ndim; dd++) {
+            out_stride *= (dd == rfft_axis) ? n_out : input_shape[dd];
+          }
+          base_offset_out += coord * out_stride;
+        }
+      }
+      
+      // Copy complex data to temp arrays
+      for (size_t i = 0; i < n; i++) {
+        size_t idx = base_offset_in + i * complex_strides[rfft_axis];
+        temp_re[i] = complex_data[2 * idx];
+        temp_im[i] = complex_data[2 * idx + 1];
+      }
+      
+      // Always perform FFT on the last axis
+      fft_1d_complex64(temp_re, temp_im, n, 1, 0, false);
+      
+      // Copy only the non-redundant part to output
+      size_t out_stride = 1;
+      for (int d = rfft_axis + 1; d < ndim; d++) {
+        out_stride *= (d == rfft_axis) ? n_out : input_shape[d];
+      }
+      
+      for (size_t i = 0; i < n_out; i++) {
+        size_t idx = base_offset_out + i * out_stride;
+        output_data[2 * idx] = temp_re[i];
+        output_data[2 * idx + 1] = temp_im[i];
+      }
+    }
+    
+    caml_leave_blocking_section();
+    
+    free(complex_data);
+    free(temp_re);
+    free(temp_im);
+    
+    return Val_unit;
+  }
+
+  // Single axis RFFT (original code)
+  int axis = axes[0];
+  if (axis < 0) axis += ndim;
+
+  size_t n = input_shape[axis];
+  size_t n_out = (n / 2) + 1;
+
+  // Calculate total number of FFTs to perform
+  size_t total_elements = 1;
+  for (int d = 0; d < ndim; d++) {
+    total_elements *= input_shape[d];
+  }
+  size_t num_ffts = total_elements / n;
+
+  ndarray_t input = {
+      .data = Caml_ba_data_val(v_input) + Long_val(v_input_offset),
+      .shape = input_shape,
+      .strides = input_strides,
+      .ndim = ndim};
+
+  // Output shape has n_out elements on the transform axis
+  int output_shape2[ndim > 0 ? ndim : 1];
+  memcpy(output_shape2, input_shape, ndim * sizeof(int));
+  output_shape2[axis] = n_out;
+
+  ndarray_t output = {
+      .data = Caml_ba_data_val(v_output) + Long_val(v_output_offset),
+      .shape = output_shape2,
+      .strides = output_strides,
+      .ndim = ndim};
+
+  // Allocate temporary arrays
+  double *temp_re = (double *)malloc(n * sizeof(double));
+  double *temp_im = (double *)malloc(n * sizeof(double));
+
+  if (!temp_re || !temp_im) {
+    free(temp_re);
+    free(temp_im);
+    caml_failwith("rfft: memory allocation failed");
+  }
+
+  caml_enter_blocking_section();
+
+  // Calculate stride for the FFT axis
+  size_t axis_stride_in = 1;
+  size_t axis_stride_out = 1;
+  for (int d = axis + 1; d < ndim; d++) {
+    axis_stride_in *= input_shape[d];
+    axis_stride_out *= output_shape2[d];
+  }
+
+  // Process each 1D RFFT
+  for (size_t fft_idx = 0; fft_idx < num_ffts; fft_idx++) {
+    // Calculate starting offset
+    size_t offset_in = 0;
+    size_t offset_out = 0;
+    size_t temp_idx = fft_idx;
+
+    for (int d = ndim - 1; d >= 0; d--) {
+      if (d != axis) {
+        size_t dim_size = input_shape[d];
+        size_t coord = temp_idx % dim_size;
+        temp_idx /= dim_size;
+
+        size_t stride_in = 1;
+        size_t stride_out = 1;
+        for (int dd = d + 1; dd < ndim; dd++) {
+          stride_in *= input_shape[dd];
+          stride_out *= output_shape2[dd];
+        }
+        offset_in += coord * stride_in;
+        offset_out += coord * stride_out;
+      }
+    }
+
+    // Copy real input to temp arrays
+    for (size_t i = 0; i < n; i++) {
+      temp_re[i] = ((double *)input.data)[offset_in + i * axis_stride_in];
+      temp_im[i] = 0.0;
+    }
+
+    // Perform FFT
+    fft_1d_complex64(temp_re, temp_im, n, 1, 0, false);
+
+    // Copy only the non-redundant part to output
+    for (size_t i = 0; i < n_out; i++) {
+      size_t idx = offset_out + i * axis_stride_out;
+      ((double *)output.data)[2 * idx] = temp_re[i];
+      ((double *)output.data)[2 * idx + 1] = temp_im[i];
+    }
+  }
+
+  caml_leave_blocking_section();
+
+  free(temp_re);
+  free(temp_im);
+
+  return Val_unit;
+}
+
+// IRFFT dispatch for complex64
+CAMLprim value caml_nx_irfft_complex64_bc(value *argv, int argn) {
+  (void)argn;
+  value v_ndim = argv[0], v_shape = argv[1];
+  value v_input = argv[2], v_input_strides = argv[3], v_input_offset = argv[4];
+  value v_output = argv[5], v_output_strides = argv[6],
+        v_output_offset = argv[7];
+  value v_axes = argv[8], v_num_axes = argv[9], v_last_size = argv[10];
+
+  return caml_nx_irfft_complex64(
+      v_ndim, v_shape, v_input, v_input_strides, v_input_offset, v_output,
+      v_output_strides, v_output_offset, v_axes, v_num_axes, v_last_size);
+}
+
+CAMLprim value caml_nx_irfft_complex64(value v_ndim, value v_shape,
+                                       value v_input, value v_input_strides,
+                                       value v_input_offset, value v_output,
+                                       value v_output_strides,
+                                       value v_output_offset, value v_axes,
+                                       value v_num_axes, value v_last_size) {
+  int ndim = Int_val(v_ndim);
+  int num_axes = Int_val(v_num_axes);
+  int last_size = Int_val(v_last_size);
+  
+  int input_shape[ndim > 0 ? ndim : 1];
+  int input_strides[ndim > 0 ? ndim : 1];
+  int output_strides[ndim > 0 ? ndim : 1];
+  int axes[num_axes > 0 ? num_axes : 1];
+  
+  for (int i = 0; i < ndim; ++i) {
+    input_shape[i] = Int_val(Field(v_shape, i));
+    input_strides[i] = Int_val(Field(v_input_strides, i));
+    output_strides[i] = Int_val(Field(v_output_strides, i));
+  }
+  
+  for (int i = 0; i < num_axes; ++i) {
+    axes[i] = Int_val(Field(v_axes, i));
+  }
+
+  // Handle multi-dimensional IRFFT
+  // For multi-dimensional IRFFT, we perform IRFFT on the last axis first,
+  // then complex IFFT on all other axes
+  
+  // Determine which axis will get the IRFFT (last in the axes list)
+  int irfft_axis = axes[num_axes - 1];
+  if (irfft_axis < 0) irfft_axis += ndim;
+  
+  // Build output shape
+  int output_shape[ndim > 0 ? ndim : 1];
+  memcpy(output_shape, input_shape, ndim * sizeof(int));
+  output_shape[irfft_axis] = last_size;
+  
+  if (num_axes > 1) {
+    // Multi-dimensional case
+    // First, allocate complex buffer for intermediate result
+    size_t total_complex_size = 1;
+    for (int d = 0; d < ndim; d++) {
+      total_complex_size *= output_shape[d];
+    }
+    
+    double *complex_data = (double *)malloc(total_complex_size * 2 * sizeof(double));
+    if (!complex_data) {
+      caml_failwith("irfft: memory allocation failed");
+    }
+    
+    // Initialize to zero
+    memset(complex_data, 0, total_complex_size * 2 * sizeof(double));
+    
+    // Create strides for complex data (contiguous)
+    int complex_strides[ndim > 0 ? ndim : 1];
+    complex_strides[ndim - 1] = 1;
+    for (int d = ndim - 2; d >= 0; d--) {
+      complex_strides[d] = complex_strides[d + 1] * output_shape[d + 1];
+    }
+    
+    caml_enter_blocking_section();
+    
+    // Perform IRFFT on the last axis
+    size_t n_in = input_shape[irfft_axis];
+    size_t n_out = output_shape[irfft_axis];
+    size_t num_irffts = total_complex_size / n_out;
+    
+    // Allocate temporary arrays for single IRFFT
+    double *temp_re = (double *)malloc(n_out * sizeof(double));
+    double *temp_im = (double *)malloc(n_out * sizeof(double));
+    
+    if (!temp_re || !temp_im) {
+      free(complex_data);
+      free(temp_re);
+      free(temp_im);
+      caml_leave_blocking_section();
+      caml_failwith("irfft: memory allocation failed");
+    }
+    
+    double *input_data = (double *)Caml_ba_data_val(v_input) + Long_val(v_input_offset);
+    
+    // Process each 1D IRFFT along the IRFFT axis
+    for (size_t irfft_idx = 0; irfft_idx < num_irffts; irfft_idx++) {
+      // Calculate base offset
+      size_t base_offset_in = 0;
+      size_t base_offset_out = 0;
+      size_t temp_idx = irfft_idx;
+      
+      for (int d = ndim - 1; d >= 0; d--) {
+        if (d != irfft_axis) {
+          size_t dim_size = output_shape[d];
+          size_t coord = temp_idx % dim_size;
+          temp_idx /= dim_size;
+          
+          // Input offset calculation
+          size_t in_stride = 1;
+          for (int dd = d + 1; dd < ndim; dd++) {
+            in_stride *= input_shape[dd];
+          }
+          base_offset_in += coord * in_stride;
+          
+          // Output offset
+          base_offset_out += coord * complex_strides[d];
+        }
+      }
+      
+      // Copy input Hermitian data
+      size_t in_stride = 1;
+      for (int d = irfft_axis + 1; d < ndim; d++) {
+        in_stride *= input_shape[d];
+      }
+      
+      for (size_t i = 0; i < n_in; i++) {
+        size_t idx = base_offset_in + i * in_stride;
+        temp_re[i] = input_data[2 * idx];
+        temp_im[i] = input_data[2 * idx + 1];
+      }
+      
+      // Reconstruct full Hermitian symmetry
+      for (size_t i = n_in; i < n_out; i++) {
+        size_t mirror_idx = n_out - i;
+        if (mirror_idx > 0 && mirror_idx < n_in) {
+          temp_re[i] = temp_re[mirror_idx];
+          temp_im[i] = -temp_im[mirror_idx];
+        } else {
+          temp_re[i] = 0.0;
+          temp_im[i] = 0.0;
+        }
+      }
+      
+      // Perform IFFT
+      fft_1d_complex64(temp_re, temp_im, n_out, 1, 0, true);
+      
+      // Copy to complex buffer
+      for (size_t i = 0; i < n_out; i++) {
+        size_t idx = base_offset_out + i * complex_strides[irfft_axis];
+        complex_data[2 * idx] = temp_re[i];
+        complex_data[2 * idx + 1] = temp_im[i];
+      }
+    }
+    
+    free(temp_re);
+    free(temp_im);
+    
+    // Now perform complex IFFTs on remaining axes
+    if (num_axes > 1) {
+      ndarray_t complex_array = {
+        .data = complex_data,
+        .shape = output_shape,
+        .strides = complex_strides,
+        .ndim = ndim
+      };
+      
+      int complex_axes[num_axes - 1];
+      for (int i = 0; i < num_axes - 1; i++) {
+        complex_axes[i] = axes[i];
+        if (complex_axes[i] < 0) complex_axes[i] += ndim;
+      }
+      
+      fft_multi_complex64(&complex_array, complex_axes, num_axes - 1, true);
+    }
+    
+    // Copy real parts to output
+    double *output_data = (double *)Caml_ba_data_val(v_output) + Long_val(v_output_offset);
+    for (size_t i = 0; i < total_complex_size; i++) {
+      // Calculate multi-dimensional index and output offset
+      size_t temp_idx = i;
+      size_t offset = 0;
+      for (int d = ndim - 1; d >= 0; d--) {
+        size_t coord = temp_idx % output_shape[d];
+        temp_idx /= output_shape[d];
+        offset += coord * output_strides[d];
+      }
+      output_data[offset] = complex_data[2 * i];
+    }
+    
+    caml_leave_blocking_section();
+    
+    free(complex_data);
+    return Val_unit;
+  }
+
+  int axis = axes[0];
+  if (axis < 0) axis += ndim;
+
+  size_t n_in = input_shape[axis];
+  size_t n = last_size;
+
+  // Calculate total number of IFFTs to perform
+  size_t total_elements = 1;
+  for (int d = 0; d < ndim; d++) {
+    if (d == axis) {
+      total_elements *= n;
+    } else {
+      total_elements *= input_shape[d];
+    }
+  }
+  size_t num_ffts = total_elements / n;
+
+  ndarray_t input = {
+      .data = Caml_ba_data_val(v_input) + Long_val(v_input_offset),
+      .shape = input_shape,
+      .strides = input_strides,
+      .ndim = ndim};
+
+  // Output shape has n elements on the transform axis
+  int output_shape_1d[ndim > 0 ? ndim : 1];
+  memcpy(output_shape_1d, input_shape, ndim * sizeof(int));
+  output_shape_1d[axis] = n;
+
+  ndarray_t output = {
+      .data = Caml_ba_data_val(v_output) + Long_val(v_output_offset),
+      .shape = output_shape_1d,
+      .strides = output_strides,
+      .ndim = ndim};
+
+  // Allocate temporary arrays
+  double *temp_re = (double *)malloc(n * sizeof(double));
+  double *temp_im = (double *)malloc(n * sizeof(double));
+
+  if (!temp_re || !temp_im) {
+    free(temp_re);
+    free(temp_im);
+    caml_failwith("irfft: memory allocation failed");
+  }
+
+  caml_enter_blocking_section();
+
+  // Calculate stride for the FFT axis
+  size_t axis_stride_in = 1;
+  size_t axis_stride_out = 1;
+  for (int d = axis + 1; d < ndim; d++) {
+    axis_stride_in *= input_shape[d];
+    axis_stride_out *= output_shape_1d[d];
+  }
+
+  // Process each 1D IRFFT
+  for (size_t fft_idx = 0; fft_idx < num_ffts; fft_idx++) {
+    // Calculate starting offset
+    size_t offset_in = 0;
+    size_t offset_out = 0;
+    size_t temp_idx = fft_idx;
+
+    for (int d = ndim - 1; d >= 0; d--) {
+      if (d != axis) {
+        size_t dim_size = input_shape[d];
+        size_t coord = temp_idx % dim_size;
+        temp_idx /= dim_size;
+
+        size_t stride_in = 1;
+        size_t stride_out = 1;
+        for (int dd = d + 1; dd < ndim; dd++) {
+          stride_in *= input_shape[dd];
+          stride_out *= output_shape_1d[dd];
+        }
+        offset_in += coord * stride_in;
+        offset_out += coord * stride_out;
+      }
+    }
+
+    // Copy input and reconstruct Hermitian symmetry
+    for (size_t i = 0; i < n_in; i++) {
+      size_t idx = offset_in + i * axis_stride_in;
+      temp_re[i] = ((double *)input.data)[2 * idx];
+      temp_im[i] = ((double *)input.data)[2 * idx + 1];
+    }
+
+    // Fill the symmetric part
+    for (size_t i = n_in; i < n; i++) {
+      size_t mirror_idx = n - i;
+      if (mirror_idx > 0 && mirror_idx < n_in) {
+        temp_re[i] = temp_re[mirror_idx];
+        temp_im[i] = -temp_im[mirror_idx];  // Complex conjugate
+      } else {
+        temp_re[i] = 0.0;
+        temp_im[i] = 0.0;
+      }
+    }
+
+    // Perform inverse FFT
+    fft_1d_complex64(temp_re, temp_im, n, 1, 0, true);
+
+    // Copy real part to output
+    for (size_t i = 0; i < n; i++) {
+      ((double *)output.data)[offset_out + i * axis_stride_out] = temp_re[i];
+    }
+  }
+
+  caml_leave_blocking_section();
+
+  free(temp_re);
+  free(temp_im);
+
+  return Val_unit;
+}

--- a/nx/lib/core/backend_intf.ml
+++ b/nx/lib/core/backend_intf.ml
@@ -233,4 +233,37 @@ module type S = sig
       multiplication on the last two dimensions, broadcasting batch dimensions
       as needed. The last dimension of the first tensor must match the
       second-to-last dimension of the second tensor. *)
+
+  (* Fourier transforms *)
+
+  val op_fft :
+    (Complex.t, 'b) t ->
+    axes:int array ->
+    s:int array option ->
+    (Complex.t, 'b) t
+  (** Compute the discrete Fourier transform (DFT) of the input tensor. *)
+
+  val op_ifft :
+    (Complex.t, 'b) t ->
+    axes:int array ->
+    s:int array option ->
+    (Complex.t, 'b) t
+  (** Compute the inverse discrete Fourier transform (IDFT) of the input tensor.
+  *)
+
+  val op_rfft :
+    (float, 'b) t ->
+    axes:int array ->
+    s:int array option ->
+    (Complex.t, Dtype.complex64_elt) t
+  (** Compute the real-valued discrete Fourier transform (RDFT) of the input
+      tensor. *)
+
+  val op_irfft :
+    (Complex.t, 'b) t ->
+    axes:int array ->
+    s:int array option ->
+    (float, Dtype.float64_elt) t
+  (** Compute the inverse real-valued discrete Fourier transform (IRDFT) of the
+      input tensor. *)
 end

--- a/nx/lib/metal/kernels/fft.metal
+++ b/nx/lib/metal/kernels/fft.metal
@@ -1,0 +1,143 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// Complex number type
+struct complex_float {
+    float real;
+    float imag;
+    
+    complex_float() : real(0.0f), imag(0.0f) {}
+    complex_float(float r, float i) : real(r), imag(i) {}
+};
+
+// Compute twiddle factor W_N^k = e^(-2πik/N) for forward FFT
+// For inverse FFT, use e^(2πik/N)
+inline complex_float twiddle_factor(int k, int N, bool inverse) {
+    float angle = (inverse ? 2.0f : -2.0f) * M_PI_F * float(k) / float(N);
+    return complex_float(cos(angle), sin(angle));
+}
+
+// Bit reversal function
+inline uint bit_reverse(uint x, uint bits) {
+    uint result = 0;
+    for (uint i = 0; i < bits; i++) {
+        result = (result << 1) | (x & 1);
+        x >>= 1;
+    }
+    return result;
+}
+
+// 1D FFT kernel using Cooley-Tukey algorithm
+kernel void fft_1d_complex64(device float2* data [[buffer(0)]],
+                            constant uint& size [[buffer(1)]],
+                            constant uint& stride [[buffer(2)]],
+                            constant uint& offset [[buffer(3)]],
+                            constant bool& inverse [[buffer(4)]],
+                            uint tid [[thread_position_in_threadgroup]],
+                            uint tg_size [[threads_per_threadgroup]],
+                            uint gid [[threadgroup_position_in_grid]]) {
+    // Each threadgroup processes one FFT
+    uint fft_offset = offset + gid * size * stride;
+    
+    // Use float2 array in threadgroup memory instead of complex_float
+    threadgroup float2 shared_data[1024]; // Max FFT size
+    
+    // Load data with bit reversal
+    uint num_bits = 0;
+    uint temp = size - 1;
+    while (temp > 0) {
+        num_bits++;
+        temp >>= 1;
+    }
+    
+    for (uint i = tid; i < size; i += tg_size) {
+        uint j = bit_reverse(i, num_bits);
+        uint idx = fft_offset + j * stride;
+        shared_data[i] = data[idx];
+    }
+    
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    
+    // FFT computation
+    for (uint stage_size = 2; stage_size <= size; stage_size *= 2) {
+        uint half_stage = stage_size / 2;
+        
+        // Each thread handles specific butterfly pairs
+        for (uint butterfly_group = tid; butterfly_group < size / 2; butterfly_group += tg_size) {
+            uint stage_idx = butterfly_group / half_stage;
+            uint butterfly_idx = butterfly_group % half_stage;
+            
+            uint idx1 = stage_idx * stage_size + butterfly_idx;
+            uint idx2 = idx1 + half_stage;
+            
+            if (idx2 < size) {
+                complex_float twiddle = twiddle_factor(butterfly_idx * size / stage_size, size, inverse);
+                
+                float2 a = shared_data[idx1];
+                float2 b = shared_data[idx2];
+                
+                // Compute b * twiddle
+                float2 b_twiddle;
+                b_twiddle.x = b.x * twiddle.real - b.y * twiddle.imag;
+                b_twiddle.y = b.x * twiddle.imag + b.y * twiddle.real;
+                
+                // Compute butterfly
+                shared_data[idx1] = float2(a.x + b_twiddle.x, a.y + b_twiddle.y);
+                shared_data[idx2] = float2(a.x - b_twiddle.x, a.y - b_twiddle.y);
+            }
+        }
+        
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    
+    // Write back results
+    for (uint i = tid; i < size; i += tg_size) {
+        uint idx = fft_offset + i * stride;
+        data[idx] = shared_data[i];
+    }
+}
+
+// Multi-dimensional FFT kernel
+kernel void fft_multi_complex64(device float2* output [[buffer(0)]],
+                               device const float2* input [[buffer(1)]],
+                               constant uint* shape [[buffer(2)]],
+                               constant int* in_strides [[buffer(3)]],
+                               constant int* out_strides [[buffer(4)]],
+                               constant uint& ndim [[buffer(5)]],
+                               constant int& in_offset [[buffer(6)]],
+                               constant int& out_offset [[buffer(7)]],
+                               constant uint* axes [[buffer(8)]],
+                               constant uint& num_axes [[buffer(9)]],
+                               constant bool& inverse [[buffer(10)]],
+                               uint3 gid [[thread_position_in_grid]]) {
+    // This kernel performs FFT along specified axes
+    // For now, we'll implement a simpler version that copies data
+    // The actual multi-dimensional FFT will be done by calling 1D FFT multiple times
+    
+    uint total_size = 1;
+    for (uint i = 0; i < ndim; i++) {
+        total_size *= shape[i];
+    }
+    
+    uint idx = gid.x;
+    if (idx >= total_size) return;
+    
+    // Compute multi-dimensional indices
+    uint coords[16]; // Max 16 dimensions
+    uint temp = idx;
+    for (int i = int(ndim) - 1; i >= 0; i--) {
+        coords[i] = temp % shape[i];
+        temp /= shape[i];
+    }
+    
+    // Compute input and output indices
+    int in_idx = in_offset;
+    int out_idx = out_offset;
+    for (uint i = 0; i < ndim; i++) {
+        in_idx += int(coords[i]) * in_strides[i];
+        out_idx += int(coords[i]) * out_strides[i];
+    }
+    
+    // Copy data (actual FFT computation will be done by multiple 1D FFT calls)
+    output[out_idx] = input[in_idx];
+}

--- a/nx/lib/metal/ops_fft.ml
+++ b/nx/lib/metal/ops_fft.ml
@@ -1,0 +1,238 @@
+open Nx_core
+open Internal
+
+(* Helper to determine FFT output shape *)
+let get_fft_output_shape input_shape axes s =
+  let ndim = Array.length input_shape in
+  match s with
+  | None -> Array.copy input_shape
+  | Some sizes ->
+      let out_shape = Array.copy input_shape in
+      Array.iteri
+        (fun i axis ->
+          let axis = if axis < 0 then ndim + axis else axis in
+          out_shape.(axis) <- sizes.(i))
+        axes;
+      out_shape
+
+(* Helper to check if a number is a power of 2 *)
+let is_power_of_two n = n > 0 && n land (n - 1) = 0
+
+(* Get next power of 2 *)
+let next_power_of_two n =
+  let rec loop p = if p >= n then p else loop (p * 2) in
+  loop 1
+
+(* Get kernel from cache *)
+let get_kernel ctx kernel_name =
+  try
+    let functions = Hashtbl.find ctx.kernels "fft" in
+    Hashtbl.find functions kernel_name
+  with Not_found ->
+    (* Create the function if not cached *)
+    let func = Metal.Library.new_function_with_name ctx.library kernel_name in
+    let functions =
+      try Hashtbl.find ctx.kernels "fft"
+      with Not_found ->
+        let h = Hashtbl.create 4 in
+        Hashtbl.add ctx.kernels "fft" h;
+        h
+    in
+    Hashtbl.add functions kernel_name func;
+    func
+
+(* Create buffer helper *)
+let create_buffer ctx dtype view =
+  let size_elements = View.numel view in
+  let elem_size = sizeof_dtype dtype in
+  let size_bytes = size_elements * elem_size in
+  let buffer = Buffer_pool.allocate ctx.pool size_bytes in
+  { context = ctx; dtype; buffer = { buffer; size_bytes }; view }
+
+(* Perform 1D FFT along a single axis *)
+let fft_1d_along_axis ctx input output axis inverse =
+  let shape = View.shape input.view in
+  let ndim = Array.length shape in
+  let axis = if axis < 0 then ndim + axis else axis in
+  let fft_size = shape.(axis) in
+
+  (* Get strides and offset *)
+  let in_strides = View.strides input.view in
+  let stride = in_strides.(axis) in
+  let offset = View.offset input.view in
+
+  (* Compute number of FFTs to perform *)
+  let num_ffts = ref 1 in
+  for i = 0 to ndim - 1 do
+    if i <> axis then num_ffts := !num_ffts * shape.(i)
+  done;
+
+  with_command_buffer ctx (fun command_buffer ->
+      let encoder = Metal.ComputeCommandEncoder.on_buffer command_buffer in
+
+      (* Get FFT kernel *)
+      let kernel_name = "fft_1d_complex64" in
+      let kernel = get_kernel ctx kernel_name in
+      let pipeline = Kernels.create_compute_pipeline ctx.device kernel in
+      Metal.ComputeCommandEncoder.set_compute_pipeline_state encoder pipeline;
+
+      (* Debug print *)
+      Printf.printf
+        "FFT dispatch: size=%d, stride=%d, offset=%d, num_ffts=%d, inverse=%b\n"
+        fft_size stride offset !num_ffts inverse;
+
+      (* Set buffers *)
+      Metal.ComputeCommandEncoder.set_buffer encoder ~offset:0 ~index:0
+        output.buffer.buffer;
+
+      (* Set size *)
+      let size_val =
+        Ctypes.(allocate uint32_t (Unsigned.UInt32.of_int fft_size))
+      in
+      Metal.ComputeCommandEncoder.set_bytes encoder
+        ~bytes:Ctypes.(to_voidp size_val)
+        ~length:4 ~index:1;
+
+      (* Set stride *)
+      let stride_val =
+        Ctypes.(allocate uint32_t (Unsigned.UInt32.of_int stride))
+      in
+      Metal.ComputeCommandEncoder.set_bytes encoder
+        ~bytes:Ctypes.(to_voidp stride_val)
+        ~length:4 ~index:2;
+
+      (* Set offset *)
+      let offset_val =
+        Ctypes.(allocate uint32_t (Unsigned.UInt32.of_int offset))
+      in
+      Metal.ComputeCommandEncoder.set_bytes encoder
+        ~bytes:Ctypes.(to_voidp offset_val)
+        ~length:4 ~index:3;
+
+      (* Set inverse flag *)
+      let inverse_val = Ctypes.(allocate bool inverse) in
+      Metal.ComputeCommandEncoder.set_bytes encoder
+        ~bytes:Ctypes.(to_voidp inverse_val)
+        ~length:1 ~index:4;
+
+      (* Dispatch threads *)
+      let threads_per_group = min fft_size 256 in
+      let grid_size = { Metal.Size.width = !num_ffts; height = 1; depth = 1 } in
+      let group_size =
+        { Metal.Size.width = threads_per_group; height = 1; depth = 1 }
+      in
+
+      Metal.ComputeCommandEncoder.dispatch_threadgroups encoder
+        ~threadgroups_per_grid:grid_size ~threads_per_threadgroup:group_size;
+
+      Metal.ComputeCommandEncoder.end_encoding encoder)
+
+(* Main FFT operation *)
+let op_fft (type b) ctx (input : (Complex.t, b) t) ~axes ~s : (Complex.t, b) t =
+  match input.dtype with
+  | Complex64 ->
+      let input_shape = View.shape input.view in
+      let output_shape = get_fft_output_shape input_shape axes s in
+
+      (* Check all FFT sizes are powers of 2 *)
+      Array.iter
+        (fun axis ->
+          let axis =
+            if axis < 0 then Array.length input_shape + axis else axis
+          in
+          let size =
+            match s with
+            | None -> input_shape.(axis)
+            | Some sizes ->
+                (* Find index of axis in axes array *)
+                let rec find_index i =
+                  if i >= Array.length axes then input_shape.(axis)
+                  else
+                    let a = axes.(i) in
+                    if a = axis || (a < 0 && Array.length input_shape + a = axis)
+                    then sizes.(i)
+                    else find_index (i + 1)
+                in
+                find_index 0
+          in
+          if not (is_power_of_two size) then
+            failwith
+              (Printf.sprintf
+                 "op_fft: FFT size %d on axis %d must be a power of 2" size axis))
+        axes;
+
+      (* Create output buffer *)
+      let output_view = View.create output_shape in
+      let output = create_buffer ctx input.dtype output_view in
+
+      (* Copy input to output first *)
+      Ops_movement.copy ctx input output;
+
+      (* Perform FFT along each axis *)
+      Array.iter
+        (fun axis -> fft_1d_along_axis ctx output output axis false)
+        axes;
+
+      output
+  | Complex32 ->
+      failwith "op_fft: Complex32 FFT not yet implemented in Metal backend"
+
+(* Inverse FFT operation *)
+let op_ifft (type b) ctx (input : (Complex.t, b) t) ~axes ~s : (Complex.t, b) t
+    =
+  match input.dtype with
+  | Complex64 ->
+      let input_shape = View.shape input.view in
+      let output_shape = get_fft_output_shape input_shape axes s in
+
+      (* Check all FFT sizes are powers of 2 *)
+      Array.iter
+        (fun axis ->
+          let axis =
+            if axis < 0 then Array.length input_shape + axis else axis
+          in
+          let size =
+            match s with
+            | None -> input_shape.(axis)
+            | Some sizes ->
+                (* Find index of axis in axes array *)
+                let rec find_index i =
+                  if i >= Array.length axes then input_shape.(axis)
+                  else
+                    let a = axes.(i) in
+                    if a = axis || (a < 0 && Array.length input_shape + a = axis)
+                    then sizes.(i)
+                    else find_index (i + 1)
+                in
+                find_index 0
+          in
+          if not (is_power_of_two size) then
+            failwith
+              (Printf.sprintf
+                 "op_ifft: FFT size %d on axis %d must be a power of 2" size
+                 axis))
+        axes;
+
+      (* Create output buffer *)
+      let output_view = View.create output_shape in
+      let output = create_buffer ctx input.dtype output_view in
+
+      (* Copy input to output first *)
+      Ops_movement.copy ctx input output;
+
+      (* Perform inverse FFT along each axis *)
+      Array.iter
+        (fun axis -> fft_1d_along_axis ctx output output axis true)
+        axes;
+
+      output
+  | Complex32 ->
+      failwith "op_ifft: Complex32 IFFT not yet implemented in Metal backend"
+
+(* Real FFT - not yet implemented *)
+let op_rfft ctx _ ~axes:_ ~s:_ =
+  failwith "op_rfft: Real FFT not yet implemented in Metal backend"
+
+(* Inverse real FFT - not yet implemented *)
+let op_irfft ctx _ ~axes:_ ~s:_ =
+  failwith "op_irfft: Inverse real FFT not yet implemented in Metal backend"

--- a/nx/lib/native/nx_native.ml
+++ b/nx/lib/native/nx_native.ml
@@ -725,3 +725,9 @@ let op_fold x ~output_size ~kernel_size ~stride ~dilation ~padding =
     ~padding
 
 let op_matmul a b = Ops_matmul.matmul a.context a b
+
+(* FFT operations *)
+let op_fft x ~axes ~s = Ops_fft.fft x.context x ~axes ~s
+let op_ifft x ~axes ~s = Ops_fft.ifft x.context x ~axes ~s
+let op_rfft x ~axes ~s = Ops_fft.rfft x.context x ~axes ~s
+let op_irfft x ~axes ~s = Ops_fft.irfft x.context x ~axes ~s

--- a/nx/lib/native/ops_fft.ml
+++ b/nx/lib/native/ops_fft.ml
@@ -1,0 +1,484 @@
+open Bigarray
+open Nx_core.Dtype
+module Shape = Nx_core.Shape
+module View = Nx_core.View
+open Internal
+
+let pi = 4.0 *. atan 1.0
+let two_pi = 2.0 *. pi
+
+(* Helper to compute twiddle factors *)
+let twiddle_factor n k inverse =
+  let sign = if inverse then 1.0 else -1.0 in
+  let angle = sign *. two_pi *. float_of_int k /. float_of_int n in
+  Complex.{ re = cos angle; im = sin angle }
+
+(* Bit reversal permutation for FFT *)
+let bit_reverse n x =
+  let rec reverse_bits bits num_bits acc =
+    if num_bits = 0 then acc
+    else reverse_bits (bits lsr 1) (num_bits - 1) ((acc lsl 1) lor (bits land 1))
+  in
+  let num_bits = int_of_float (log (float_of_int n) /. log 2.0) in
+  reverse_bits x num_bits 0
+
+(* Check if n is a power of 2 *)
+let is_power_of_2 n = n > 0 && n land (n - 1) = 0
+
+(* DFT for non-power-of-2 sizes *)
+let dft_1d ~inverse ~scale data n stride offset =
+  (* Create temporary array for result *)
+  let temp =
+    Array.init n (fun i -> Array1.unsafe_get data (offset + (i * stride)))
+  in
+
+  (* Compute DFT *)
+  let sign = if inverse then 1.0 else -1.0 in
+  for k = 0 to n - 1 do
+    let sum = ref Complex.zero in
+    for j = 0 to n - 1 do
+      let angle = sign *. two_pi *. float_of_int (k * j) /. float_of_int n in
+      let w = Complex.{ re = cos angle; im = sin angle } in
+      sum := Complex.add !sum (Complex.mul temp.(j) w)
+    done;
+    (* Apply scaling if needed *)
+    (if scale <> 1.0 then
+       sum := Complex.{ re = !sum.re *. scale; im = !sum.im *. scale });
+    Array1.unsafe_set data (offset + (k * stride)) !sum
+  done
+
+(* 1D FFT using Cooley-Tukey algorithm for power-of-2, DFT otherwise *)
+let fft_1d ~inverse ~scale data n stride offset =
+  if not (is_power_of_2 n) then dft_1d ~inverse ~scale data n stride offset
+  else (
+    (* Bit reversal permutation *)
+    for i = 0 to n - 1 do
+      let j = bit_reverse n i in
+      if i < j then (
+        let idx_i = offset + (i * stride) in
+        let idx_j = offset + (j * stride) in
+        let tmp = Array1.unsafe_get data idx_i in
+        Array1.unsafe_set data idx_i (Array1.unsafe_get data idx_j);
+        Array1.unsafe_set data idx_j tmp)
+    done;
+
+    (* FFT computation *)
+    let rec fft_stage stage_size =
+      if stage_size <= n then (
+        let half_stage = stage_size / 2 in
+        for k = 0 to (n / stage_size) - 1 do
+          for j = 0 to half_stage - 1 do
+            let twiddle = twiddle_factor stage_size j inverse in
+            let idx1 = offset + (((k * stage_size) + j) * stride) in
+            let idx2 =
+              offset + (((k * stage_size) + j + half_stage) * stride)
+            in
+            let a = Array1.unsafe_get data idx1 in
+            let b = Array1.unsafe_get data idx2 in
+            let b_twiddle = Complex.mul b twiddle in
+            Array1.unsafe_set data idx1 (Complex.add a b_twiddle);
+            Array1.unsafe_set data idx2 (Complex.sub a b_twiddle)
+          done
+        done;
+        fft_stage (stage_size * 2))
+    in
+    fft_stage 2;
+
+    (* Apply scaling if requested *)
+    if scale <> 1.0 then
+      for i = 0 to n - 1 do
+        let idx = offset + (i * stride) in
+        let v = Array1.unsafe_get data idx in
+        Array1.unsafe_set data idx
+          Complex.{ re = v.re *. scale; im = v.im *. scale }
+      done)
+
+(* Helper to determine FFT output shape *)
+let get_fft_output_shape input_shape axes s =
+  let ndim = Array.length input_shape in
+  match s with
+  | None -> Array.copy input_shape
+  | Some sizes ->
+      let out_shape = Array.copy input_shape in
+      Array.iteri
+        (fun i axis ->
+          let axis = if axis < 0 then ndim + axis else axis in
+          out_shape.(axis) <- sizes.(i))
+        axes;
+      out_shape
+
+(* Fixed Multi-dimensional FFT kernel for complex64 *)
+let kernel_fft_multi (type b) ~inverse (input : (Complex.t, b) t)
+    (output : (Complex.t, b) t) axes =
+  let output_shape = Internal.shape output in
+  let ndim = Array.length output_shape in
+
+  (* Initialize output - either copy from input or zero-fill *)
+  (if not (buffer input == buffer output) then
+     (* Check if we need to copy data *)
+     let input_shape = Internal.shape input in
+     let output_shape = Internal.shape output in
+
+     let same_shape =
+       Array.length input_shape = Array.length output_shape
+       && Array.for_all2 ( = ) input_shape output_shape
+     in
+
+     if same_shape then
+       (* Same shape, can directly copy if buffers are the same size *)
+       let input_size = Bigarray.Array1.dim (buffer input) in
+       let output_size = Bigarray.Array1.dim (buffer output) in
+       if input_size = output_size then
+         Bigarray.Array1.blit (buffer input) (buffer output)
+       else
+         (* Different buffer sizes, use element-wise copy *)
+         let size = min input_size output_size in
+         for i = 0 to size - 1 do
+           Bigarray.Array1.set (buffer output) i
+             (Bigarray.Array1.get (buffer input) i)
+         done
+     else (
+       (* Different shapes - zero fill and copy what fits *)
+       Bigarray.Array1.fill (buffer output) Complex.zero;
+
+       (* Copy the overlapping region *)
+       let rec copy_region indices dim =
+         if dim = ndim then (
+           (* Calculate linear indices *)
+           let in_idx = ref 0 in
+           let out_idx = ref 0 in
+           let in_stride = ref 1 in
+           let out_stride = ref 1 in
+
+           for d = ndim - 1 downto 0 do
+             in_idx := !in_idx + (indices.(d) * !in_stride);
+             out_idx := !out_idx + (indices.(d) * !out_stride);
+             in_stride := !in_stride * input_shape.(d);
+             out_stride := !out_stride * output_shape.(d)
+           done;
+
+           let v = Bigarray.Array1.get (buffer input) !in_idx in
+           Bigarray.Array1.set (buffer output) !out_idx v)
+         else
+           let limit = min input_shape.(dim) output_shape.(dim) in
+           for i = 0 to limit - 1 do
+             indices.(dim) <- i;
+             copy_region indices (dim + 1)
+           done
+       in
+       copy_region (Array.make ndim 0) 0));
+
+  (* Perform FFT along each specified axis *)
+  Array.iter
+    (fun axis ->
+      let axis = if axis < 0 then ndim + axis else axis in
+      let n = output_shape.(axis) in
+
+      (* Only perform FFT if n > 1 *)
+      if n > 1 then
+        if ndim = 1 then
+          (* For 1D arrays, just do the FFT directly *)
+          fft_1d ~inverse ~scale:1.0 (buffer output) n 1 0
+        else
+          (* For multi-dimensional arrays, iterate over all other dimensions *)
+          let rec iter_dims dim indices =
+            if dim = ndim then (
+              (* Compute offset for this slice *)
+              let offset = ref 0 in
+              let stride_accum = ref 1 in
+              for d = ndim - 1 downto 0 do
+                offset := !offset + (indices.(d) * !stride_accum);
+                stride_accum := !stride_accum * output_shape.(d)
+              done;
+
+              (* Calculate stride for the FFT axis *)
+              let stride =
+                let s = ref 1 in
+                for d = axis + 1 to ndim - 1 do
+                  s := !s * output_shape.(d)
+                done;
+                !s
+              in
+
+              (* Perform 1D FFT along the axis *)
+              fft_1d ~inverse ~scale:1.0 (buffer output) n stride !offset)
+            else if dim = axis then
+              (* Skip the axis we're transforming along *)
+              iter_dims (dim + 1) indices
+            else
+              (* Iterate over this dimension *)
+              for i = 0 to output_shape.(dim) - 1 do
+                indices.(dim) <- i;
+                iter_dims (dim + 1) indices
+              done
+          in
+          iter_dims 0 (Array.make ndim 0))
+    axes;
+
+  (* Do not apply scaling in backend - frontend handles normalization *)
+  ()
+
+(* Helper to determine RFFT output shape *)
+let get_rfft_output_shape input_shape axes =
+  let ndim = Array.length input_shape in
+  let output_shape = Array.copy input_shape in
+  (* Last axis in the transform is halved + 1 *)
+  let last_axis_idx = Array.length axes - 1 in
+  let last_axis = axes.(last_axis_idx) in
+  let last_axis = if last_axis < 0 then ndim + last_axis else last_axis in
+  output_shape.(last_axis) <- (input_shape.(last_axis) / 2) + 1;
+  output_shape
+
+(* Real to complex copy for float64 *)
+let real_to_complex_copy (type b c) (real_input : (float, b) t)
+    (complex_output : (Complex.t, c) t) =
+  let real_buf = buffer real_input in
+  let complex_buf = buffer complex_output in
+  let n = Internal.size real_input in
+  for i = 0 to n - 1 do
+    let v = Array1.unsafe_get real_buf i in
+    Array1.unsafe_set complex_buf i Complex.{ re = v; im = 0.0 }
+  done
+
+let kernel_rfft (type b) context (input : (float, b) t) axes _s =
+  let input_shape = Internal.shape input in
+  let ndim = Array.length input_shape in
+
+  (* For rfft, we only transform the last axis to half size *)
+  (* All other axes are transformed normally *)
+  let last_axis_idx = Array.length axes - 1 in
+  let last_axis = axes.(last_axis_idx) in
+  let last_axis = if last_axis < 0 then ndim + last_axis else last_axis in
+
+  (* First, perform FFT on all axes except the last one *)
+  let temp = empty context Complex64 input_shape in
+  real_to_complex_copy input temp;
+
+  (if Array.length axes > 1 then
+     let other_axes = Array.sub axes 0 (Array.length axes - 1) in
+     kernel_fft_multi ~inverse:false temp temp other_axes);
+
+  (* Now perform FFT on the last axis and extract only the non-redundant part *)
+  let output_shape = get_rfft_output_shape input_shape axes in
+  let output = empty context Complex64 output_shape in
+
+  (* Perform 1D FFT on the last axis for each position in other dimensions *)
+  let rec process_slices indices dim =
+    if dim = ndim then (
+      (* Calculate source offset *)
+      let src_offset = ref 0 in
+      let stride = ref 1 in
+      for d = ndim - 1 downto 0 do
+        src_offset := !src_offset + (indices.(d) * !stride);
+        stride := !stride * input_shape.(d)
+      done;
+
+      (* Calculate destination offset *)
+      let dst_offset = ref 0 in
+      let stride = ref 1 in
+      for d = ndim - 1 downto 0 do
+        dst_offset := !dst_offset + (indices.(d) * !stride);
+        stride := !stride * output_shape.(d)
+      done;
+
+      (* Perform 1D FFT and copy only non-redundant part *)
+      let n = input_shape.(last_axis) in
+      let stride_in =
+        let s = ref 1 in
+        for d = last_axis + 1 to ndim - 1 do
+          s := !s * input_shape.(d)
+        done;
+        !s
+      in
+      let stride_out =
+        let s = ref 1 in
+        for d = last_axis + 1 to ndim - 1 do
+          s := !s * output_shape.(d)
+        done;
+        !s
+      in
+
+      (* Do 1D FFT in-place on temp *)
+      fft_1d ~inverse:false ~scale:1.0 (buffer temp) n stride_in !src_offset;
+
+      (* Copy only the non-redundant part to output *)
+      for i = 0 to output_shape.(last_axis) - 1 do
+        let src_idx = !src_offset + (i * stride_in) in
+        let dst_idx = !dst_offset + (i * stride_out) in
+        let v = Bigarray.Array1.get (buffer temp) src_idx in
+        Bigarray.Array1.set (buffer output) dst_idx v
+      done)
+    else if dim = last_axis then (
+      indices.(dim) <- 0;
+      process_slices indices (dim + 1))
+    else
+      for i = 0 to input_shape.(dim) - 1 do
+        indices.(dim) <- i;
+        process_slices indices (dim + 1)
+      done
+  in
+  process_slices (Array.make ndim 0) 0;
+  output
+
+(* IRFFT kernel for complex64 *)
+let kernel_irfft (type b) context (input : (Complex.t, b) t) axes s =
+  let input_shape = Internal.shape input in
+  let ndim = Array.length input_shape in
+
+  (* For irfft, we need to handle the inverse of rfft *)
+  (* The input has half-size on the last transformed axis *)
+  let last_axis_idx = Array.length axes - 1 in
+  let last_axis = axes.(last_axis_idx) in
+  let last_axis = if last_axis < 0 then ndim + last_axis else last_axis in
+
+  (* Determine real output shape *)
+  let output_shape =
+    let shape = Array.copy input_shape in
+    (* Restore full size for last axis *)
+    shape.(last_axis) <-
+      (match s with
+      | None -> (shape.(last_axis) - 1) * 2
+      | Some sizes -> sizes.(Array.length sizes - 1));
+
+    match s with
+    | None -> shape
+    | Some sizes ->
+        Array.iteri
+          (fun i axis ->
+            let axis = if axis < 0 then ndim + axis else axis in
+            shape.(axis) <- sizes.(i))
+          axes;
+        shape
+  in
+
+  (* Create real output tensor *)
+  let output = empty context Float64 output_shape in
+
+  (* First, create a full-size complex tensor with Hermitian symmetry *)
+  let full_complex_shape = Array.copy output_shape in
+  let full_complex = empty context Complex64 full_complex_shape in
+
+  (* Copy the non-redundant part from input and reconstruct the symmetric
+     part *)
+  let rec process_slices indices dim =
+    if dim = ndim then (
+      (* Calculate source and destination offsets *)
+      let src_offset = ref 0 in
+      let src_stride = ref 1 in
+      for d = ndim - 1 downto 0 do
+        src_offset := !src_offset + (indices.(d) * !src_stride);
+        src_stride := !src_stride * input_shape.(d)
+      done;
+
+      let dst_offset = ref 0 in
+      let dst_stride = ref 1 in
+      for d = ndim - 1 downto 0 do
+        dst_offset := !dst_offset + (indices.(d) * !dst_stride);
+        dst_stride := !dst_stride * full_complex_shape.(d)
+      done;
+
+      (* Copy non-redundant part *)
+      let hermitian_size = input_shape.(last_axis) in
+      let full_size = output_shape.(last_axis) in
+
+      let src_stride_elem =
+        let s = ref 1 in
+        for d = last_axis + 1 to ndim - 1 do
+          s := !s * input_shape.(d)
+        done;
+        !s
+      in
+
+      let dst_stride_elem =
+        let s = ref 1 in
+        for d = last_axis + 1 to ndim - 1 do
+          s := !s * full_complex_shape.(d)
+        done;
+        !s
+      in
+
+      (* Copy the non-redundant part *)
+      for i = 0 to hermitian_size - 1 do
+        let src_idx = !src_offset + (i * src_stride_elem) in
+        let dst_idx = !dst_offset + (i * dst_stride_elem) in
+        let v = Bigarray.Array1.get (buffer input) src_idx in
+        Bigarray.Array1.set (buffer full_complex) dst_idx v
+      done;
+
+      (* Fill the symmetric part *)
+      for i = hermitian_size to full_size - 1 do
+        let mirror_idx = full_size - i in
+        if mirror_idx > 0 && mirror_idx < hermitian_size then
+          let src_idx = !dst_offset + (mirror_idx * dst_stride_elem) in
+          let dst_idx = !dst_offset + (i * dst_stride_elem) in
+          let v = Bigarray.Array1.get (buffer full_complex) src_idx in
+          (* Complex conjugate for Hermitian symmetry *)
+          Bigarray.Array1.set (buffer full_complex) dst_idx
+            Complex.{ re = v.re; im = -.v.im }
+      done)
+    else if dim = last_axis then (
+      indices.(dim) <- 0;
+      process_slices indices (dim + 1))
+    else
+      for i = 0 to input_shape.(dim) - 1 do
+        indices.(dim) <- i;
+        process_slices indices (dim + 1)
+      done
+  in
+  process_slices (Array.make ndim 0) 0;
+
+  (* Now perform inverse FFT on all axes *)
+  kernel_fft_multi ~inverse:true full_complex full_complex axes;
+
+  (* Extract real part *)
+  let output_buf = buffer output in
+  let complex_buf = buffer full_complex in
+  let size = Internal.size output in
+  for i = 0 to size - 1 do
+    let v = Bigarray.Array1.unsafe_get complex_buf i in
+    Bigarray.Array1.unsafe_set output_buf i v.re
+  done;
+
+  output
+
+(* Main FFT operations *)
+let fft (type b) (context : context) (input : (Complex.t, b) t) ~axes ~s :
+    (Complex.t, b) t =
+  let output_shape = get_fft_output_shape (Internal.shape input) axes s in
+
+  match dtype input with
+  | Complex32 ->
+      let output = empty context Complex32 output_shape in
+      kernel_fft_multi ~inverse:false input output axes;
+      output
+  | Complex64 ->
+      let output = empty context Complex64 output_shape in
+      kernel_fft_multi ~inverse:false input output axes;
+      output
+
+let ifft (type b) (context : context) (input : (Complex.t, b) t) ~axes ~s :
+    (Complex.t, b) t =
+  let output_shape = get_fft_output_shape (Internal.shape input) axes s in
+
+  match dtype input with
+  | Complex32 ->
+      let output = empty context Complex32 output_shape in
+      kernel_fft_multi ~inverse:true input output axes;
+      output
+  | Complex64 ->
+      let output = empty context Complex64 output_shape in
+      kernel_fft_multi ~inverse:true input output axes;
+      output
+
+let rfft (type b) (context : context) (input : (float, b) t) ~axes ~s :
+    (Complex.t, complex64_elt) t =
+  match dtype input with
+  | Float16 -> kernel_rfft context input axes s
+  | Float32 -> kernel_rfft context input axes s
+  | Float64 -> kernel_rfft context input axes s
+
+let irfft (type b) (context : context) (input : (Complex.t, b) t) ~axes ~s :
+    (float, float64_elt) t =
+  match dtype input with
+  | Complex32 -> kernel_irfft context input axes s
+  | Complex64 -> kernel_irfft context input axes s

--- a/nx/lib/nx.ml
+++ b/nx/lib/nx.ml
@@ -36,6 +36,11 @@ let randn dtype ?seed shape = F.randn (Lazy.force context) dtype ?seed shape
 let randint dtype ?seed ?high shape low =
   F.randint (Lazy.force context) dtype ?seed ?high shape low
 
+(* ───── FFT ───── *)
+
+let fftfreq ?d n = F.fftfreq (Lazy.force context) ?d n
+let rfftfreq ?d n = F.rfftfreq (Lazy.force context) ?d n
+
 (* ───── Aliases to unsafe functions ───── *)
 
 let data t = F.unsafe_data t

--- a/nx/lib/nx.mli
+++ b/nx/lib/nx.mli
@@ -1910,6 +1910,229 @@ val matmul : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
       - : int array = [|5; 3; 2|]
     ]} *)
 
+(** {2 Fourier Transform}
+
+    Fast Fourier Transform (FFT) and related signal processing functions. *)
+
+type fft_norm = [ `Backward | `Forward | `Ortho ]
+(** FFT normalization mode:
+    - [`Backward]: normalize by 1/n on inverse transform (default)
+    - [`Forward]: normalize by 1/n on forward transform
+    - [`Ortho]: normalize by 1/sqrt(n) on both transforms *)
+
+val fft :
+  ?axis:int ->
+  ?n:int ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a) t ->
+  (Complex.t, 'a) t
+(** [fft ?axis ?n ?norm x] computes discrete Fourier transform over specified
+    axis.
+
+    - [axis]: axis to transform (default: last axis)
+    - [n]: Length of the transformed axis of the output
+    - [norm]: normalization mode (default: [`Backward])
+
+    Computing 1D FFT of a signal:
+    {@ocaml[
+      # let real = Nx.create Nx.float32 [|4|] [|0.; 1.; 2.; 3.|] in
+        let imag = Nx.zeros Nx.float32 [|4|] in
+        let x = Nx.complex ~real ~imag in
+        let result = Nx.fft ~axes:[|0|] x in
+        Nx.real result
+      - : (float, float32_elt) t = [6, -2, -2, -2]
+    ]} *)
+
+val ifft :
+  ?axis:int ->
+  ?n:int ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a) t ->
+  (Complex.t, 'a) t
+(** [ifft ?axis ?s ?norm x] computes inverse discrete Fourier transform.
+
+    - [axis]: axis to transform (default: last axis)
+    - [n]: Length of the transformed axis of the output
+    - [norm]: normalization mode (default: [`Backward]) *)
+
+val fft2 :
+  ?axes:int array ->
+  ?s:int array ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a) t ->
+  (Complex.t, 'a) t
+(** [fft2 ?axes ?s ?norm x] computes 2-dimensional FFT.
+
+    Transforms last two axes by default. Truncates or pads to shape [s] if
+    given.
+
+    @raise Invalid_argument if input has less than 2 dimensions
+
+    Computing 2D FFT of a 2x2 matrix:
+    {@ocaml[
+      # let real = Nx.create Nx.float32 [|2; 2|] [|1.; 2.; 3.; 4.|] in
+        let imag = Nx.zeros Nx.float32 [|2; 2|] in
+        let x = Nx.complex ~real ~imag in
+        Nx.shape (Nx.fft2 x)
+      - : int array = [|2; 2|]
+    ]} *)
+
+val ifft2 :
+  ?axes:int array ->
+  ?s:int array ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a) t ->
+  (Complex.t, 'a) t
+(** [ifft2 ?axes ?s ?norm x] computes 2-dimensional inverse FFT.
+
+    @raise Invalid_argument if input has less than 2 dimensions *)
+
+val fftn :
+  ?axes:int array ->
+  ?s:int array ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a) t ->
+  (Complex.t, 'a) t
+(** [fftn ?axes ?s ?norm x] computes N-dimensional FFT.
+
+    Transforms all axes by default. *)
+
+val ifftn :
+  ?axes:int array ->
+  ?s:int array ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a) t ->
+  (Complex.t, 'a) t
+(** [ifftn ?axes ?s ?norm x] computes N-dimensional inverse FFT. *)
+
+val rfft :
+  ?axis:int ->
+  ?n:int ->
+  ?norm:fft_norm ->
+  (float, 'a) t ->
+  (Complex.t, complex64_elt) t
+(** [rfft ?axis ?n ?norm x] computes FFT of real input.
+
+    Returns only non-redundant positive frequencies. Output size along last
+    transformed axis is n/2+1 where n is input size.
+
+    - [axes]: axes to transform (default: last axis)
+    - [s]: shape to truncate/pad to before transform
+    - [norm]: normalization mode (default: [`Backward])
+
+    Computing real FFT:
+    {@ocaml[
+      # let x = Nx.create Nx.float32 [|4|] [|0.; 1.; 2.; 3.|] in
+        let result = Nx.rfft ~axes:[|0|] x in
+        Nx.shape result
+      - : int array = [|3|]
+    ]} *)
+
+val irfft :
+  ?axis:int ->
+  ?n:int ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a) t ->
+  (float, float64_elt) t
+(** [irfft ?axis ?n ?norm x] computes inverse FFT returning real output.
+
+    Assumes Hermitian symmetry.
+
+    - [axis]: axis to transform (default: last axis)
+    - [n]: output shape along transformed axes
+    - [norm]: normalization mode (default: [`Backward]) *)
+
+val rfft2 :
+  ?axes:int array ->
+  ?s:int array ->
+  ?norm:fft_norm ->
+  (float, 'a) t ->
+  (Complex.t, complex64_elt) t
+(** [rfft2 ?axes ?s ?norm x] computes 2D FFT of real input.
+
+    @raise Invalid_argument if input has less than 2 dimensions *)
+
+val irfft2 :
+  ?axes:int array ->
+  ?s:int array ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a) t ->
+  (float, float64_elt) t
+(** [irfft2 ?axes ?s ?norm x] computes 2D inverse FFT returning real output.
+
+    @raise Invalid_argument
+      if input has less than 2 dimensions or if [s] not specified *)
+
+val rfftn :
+  ?axes:int array ->
+  ?s:int array ->
+  ?norm:fft_norm ->
+  (float, 'a) t ->
+  (Complex.t, complex64_elt) t
+(** [rfftn ?axes ?s ?norm x] computes N-dimensional FFT of real input. *)
+
+val irfftn :
+  ?axes:int array ->
+  ?s:int array ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a) t ->
+  (float, float64_elt) t
+(** [irfftn ?axes ?s ?norm x] computes N-dimensional inverse FFT returning real
+    output.
+
+    @raise Invalid_argument if [s] not specified for inverse real transforms *)
+
+val hfft :
+  ?axis:int ->
+  ?n:int ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a) t ->
+  (float, float64_elt) t
+(** [hfft x ~n ~axis] computes FFT of Hermitian signal.
+
+    Interprets input as positive frequencies of Hermitian signal. *)
+
+val ihfft :
+  ?axis:int ->
+  ?n:int ->
+  ?norm:fft_norm ->
+  (float, 'a) t ->
+  (Complex.t, complex64_elt) t
+(** [ihfft x ~n ~axis] computes inverse FFT for Hermitian output. *)
+
+val fftfreq : ?d:float -> int -> (float, float64_elt) t
+(** [fftfreq ?d n] returns DFT sample frequencies.
+
+    For window length [n] and sample spacing [d], returns frequencies
+    [0, 1, ..., n/2-1, -n/2, ..., -1] / (d*n) if n is even.
+
+    Getting frequencies for 4-point FFT:
+    {@ocaml[
+      # Nx.fftfreq 4
+      - : (float, float64_elt) t = [0, 0.25, -0.5, -0.25]
+    ]} *)
+
+val rfftfreq : ?d:float -> int -> (float, float64_elt) t
+(** [rfftfreq ?d n] returns positive DFT frequencies.
+
+    Returns [0, 1, ..., n/2] / (d*n). *)
+
+val fftshift : ?axes:int array -> ('a, 'b) t -> ('a, 'b) t
+(** [fftshift x ?axes] shifts zero-frequency component to center.
+
+    Shifts all axes by default. For visualization of frequency spectra.
+
+    Centering frequency spectrum:
+    {@ocaml[
+      # let ctx = Nx_native.create_context () in
+        let freqs = Nx.fftfreq ctx 5 () in
+        Nx.fftshift freqs
+      - : (float, float64_elt) t = [-0.4, -0.2, 0, 0.2, 0.4]
+    ]} *)
+
+val ifftshift : ?axes:int array -> ('a, 'b) t -> ('a, 'b) t
+(** [ifftshift x ?axes] undoes fftshift. *)
+
 (** {2 Activation Functions}
 
     Neural network activation functions. *)

--- a/nx/test/fft_numpy_reference.py
+++ b/nx/test/fft_numpy_reference.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+NumPy reference implementation for FFT tests to verify expected results.
+"""
+
+import numpy as np
+
+def print_array(name, arr):
+    """Print array in OCaml format"""
+    if arr.dtype == np.complex64 or arr.dtype == np.complex128:
+        print(f"{name} = [|")
+        for val in arr.flat:
+            print(f"  Complex.{{ re = {val.real}; im = {val.imag} }};")
+        print("|]")
+    else:
+        print(f"{name} = [| {'; '.join(str(x) for x in arr.flat)} |]")
+    print()
+
+def test_fft_axes():
+    """Test FFT with specific axes on 2D array"""
+    print("=== Test FFT Axes ===")
+    shape = (4, 6)
+    size = 4 * 6
+    # Create the same input as OCaml test
+    input_data = np.array([i + 1j * ((i % 7) * 0.1) for i in range(size)], dtype=np.complex64)
+    input_arr = input_data.reshape(shape)
+    
+    print(f"Input shape: {shape}")
+    print(f"Input data (first few): {input_data[:4]}")
+    
+    # Test axis 0
+    fft_axis0 = np.fft.fft(input_arr, axis=0)
+    print(f"\nFFT axis=0 shape: {fft_axis0.shape}")
+    # Verify round-trip
+    ifft_axis0 = np.fft.ifft(fft_axis0, axis=0)
+    print(f"Round-trip error axis=0: {np.max(np.abs(ifft_axis0 - input_arr))}")
+    
+    # Test axis 1
+    fft_axis1 = np.fft.fft(input_arr, axis=1)
+    print(f"\nFFT axis=1 shape: {fft_axis1.shape}")
+    ifft_axis1 = np.fft.ifft(fft_axis1, axis=1)
+    print(f"Round-trip error axis=1: {np.max(np.abs(ifft_axis1 - input_arr))}")
+    
+    # Test negative axis
+    fft_neg2 = np.fft.fft(input_arr, axis=-2)
+    print(f"\nFFT axis=-2 shape: {fft_neg2.shape}")
+    print(f"axis=-2 equivalent to axis=0: {np.allclose(fft_neg2, fft_axis0)}")
+
+def test_hfft_ihfft():
+    """Test Hermitian FFT"""
+    print("\n=== Test HFFT/IHFFT ===")
+    n = 8
+    # Create real signal
+    signal = np.array([np.sin(2*np.pi*i/n) for i in range(n)])
+    print(f"Input signal shape: {signal.shape}")
+    print(f"Input signal: {signal}")
+    
+    # ihfft expects real input and outputs complex with hermitian symmetry
+    # For a real input of length n, ihfft outputs (n//2 + 1) complex values
+    ihfft_out = np.fft.ihfft(signal, n=n)
+    print(f"\nihfft output shape: {ihfft_out.shape}")
+    print(f"ihfft output: {ihfft_out}")
+    
+    # hfft expects complex hermitian input and outputs real
+    hfft_out = np.fft.hfft(ihfft_out, n=n)
+    print(f"\nhfft output shape: {hfft_out.shape}")
+    print(f"hfft output: {hfft_out}")
+    print(f"Round-trip error: {np.max(np.abs(hfft_out - signal))}")
+
+def test_fftfreq():
+    """Test FFT frequency generation"""
+    print("\n=== Test FFT Frequencies ===")
+    
+    # Odd length
+    n = 5
+    freq = np.fft.fftfreq(n)
+    print(f"fftfreq(n={n}): {freq}")
+    print_array(f"fftfreq_{n}", freq)
+    
+    # Even length with custom spacing
+    n = 4
+    d = 0.5
+    freq = np.fft.fftfreq(n, d=d)
+    print(f"fftfreq(n={n}, d={d}): {freq}")
+    print_array(f"fftfreq_{n}_d", freq)
+
+def test_rfftfreq():
+    """Test real FFT frequency generation"""
+    print("\n=== Test RFFT Frequencies ===")
+    
+    # Even length
+    n = 8
+    freq = np.fft.rfftfreq(n)
+    print(f"rfftfreq(n={n}): {freq}")
+    print_array(f"rfftfreq_{n}", freq)
+    
+    # Odd length with custom spacing
+    n = 9
+    d = 2.0
+    freq = np.fft.rfftfreq(n, d=d)
+    print(f"rfftfreq(n={n}, d={d}): {freq}")
+    print_array(f"rfftfreq_{n}_d", freq)
+
+def test_fftshift():
+    """Test FFT shift operations"""
+    print("\n=== Test FFT Shift ===")
+    
+    # 1D case
+    x = np.array([0.0, 1.0, 2.0, 3.0])
+    shifted = np.fft.fftshift(x)
+    print(f"Original: {x}")
+    print(f"fftshift: {shifted}")
+    print_array("fftshift_1d", shifted)
+    
+    # 2D case
+    x2d = np.arange(9, dtype=float).reshape(3, 3)
+    print(f"\n2D input:\n{x2d}")
+    shifted2d = np.fft.fftshift(x2d, axes=(0, 1))
+    print(f"fftshift 2D:\n{shifted2d}")
+    print_array("fftshift_2d", shifted2d)
+    
+    # Test ifftshift
+    unshifted = np.fft.ifftshift(shifted)
+    print(f"\nifftshift of 1D: {unshifted}")
+    print(f"Matches original: {np.array_equal(unshifted, x)}")
+
+def test_rfft_sizes():
+    """Test RFFT output sizes"""
+    print("\n=== Test RFFT Sizes ===")
+    
+    # Test with different input sizes
+    for n in [8, 7, 4, 6]:
+        signal = np.arange(n, dtype=float)
+        rfft_out = np.fft.rfft(signal)
+        print(f"n={n}: rfft output shape = {rfft_out.shape[0]} (expected {n//2 + 1})")
+        
+        # Test round-trip
+        irfft_out = np.fft.irfft(rfft_out, n=n)
+        print(f"  Round-trip error: {np.max(np.abs(irfft_out - signal))}")
+
+def test_fft_edge_cases():
+    """Test edge cases for FFT"""
+    print("\n=== Test FFT Edge Cases ===")
+    
+    # Empty array - NumPy doesn't support FFT of empty arrays
+    print("Note: NumPy raises ValueError for FFT of empty array")
+    
+    # Size 1
+    single = np.array([5.0 - 3.0j])
+    fft_single = np.fft.fft(single)
+    print(f"FFT of single element: {fft_single}")
+    print(f"Should equal input: {np.array_equal(fft_single, single)}")
+
+def test_rfft_edge_cases():
+    """Test edge cases for RFFT"""
+    print("\n=== Test RFFT Edge Cases ===")
+    
+    # Empty array - NumPy doesn't support RFFT of empty arrays
+    print("Note: NumPy raises ValueError for RFFT of empty array")
+    
+    # Size 1
+    single = np.array([5.0])
+    rfft_single = np.fft.rfft(single)
+    print(f"RFFT of single element: {rfft_single}")
+    print(f"Shape: {rfft_single.shape}")
+
+def test_2d_rfft():
+    """Test 2D RFFT behavior"""
+    print("\n=== Test 2D RFFT ===")
+    
+    m, n = 4, 6
+    signal = np.arange(m * n, dtype=float).reshape(m, n)
+    
+    # rfft2 applies rfft to last axis
+    rfft2_out = np.fft.rfft2(signal)
+    print(f"Input shape: {signal.shape}")
+    print(f"rfft2 output shape: {rfft2_out.shape} (expected ({m}, {n//2 + 1}))")
+    
+    # Test round-trip
+    irfft2_out = np.fft.irfft2(rfft2_out, s=(m, n))
+    print(f"Round-trip error: {np.max(np.abs(irfft2_out - signal))}")
+
+def test_rfftn_axes():
+    """Test RFFTN with specific axes"""
+    print("\n=== Test RFFTN Axes ===")
+    
+    shape = (4, 6, 8)
+    signal = np.arange(np.prod(shape), dtype=float).reshape(shape)
+    
+    # Single axis
+    rfft_axis1 = np.fft.rfftn(signal, axes=[1])
+    print(f"rfftn axes=[1] shape: {rfft_axis1.shape} (expected (4, 4, 8))")
+    
+    # Multiple axes - last specified axis is halved
+    rfft_axes_01 = np.fft.rfftn(signal, axes=[0, 1])
+    print(f"rfftn axes=[0,1] shape: {rfft_axes_01.shape} (expected (4, 4, 8))")
+    
+    # Negative axis
+    rfft_neg1 = np.fft.rfftn(signal, axes=[-1])
+    print(f"rfftn axes=[-1] shape: {rfft_neg1.shape} (expected (4, 6, 5))")
+    
+    # Last axis transform for ND
+    shape_nd = (2, 3, 8)
+    signal_nd = np.arange(np.prod(shape_nd), dtype=float).reshape(shape_nd)
+    rfft_nd = np.fft.rfftn(signal_nd, axes=[2])
+    print(f"rfftn last axis shape: {rfft_nd.shape} (expected (2, 3, 5))")
+
+if __name__ == "__main__":
+    test_fft_axes()
+    test_hfft_ihfft()
+    test_fftfreq()
+    test_rfftfreq()
+    test_fftshift()
+    test_rfft_sizes()
+    test_fft_edge_cases()
+    test_rfft_edge_cases()
+    test_2d_rfft()
+    test_rfftn_axes()

--- a/nx/test/unit/test_nx_fft.ml
+++ b/nx/test/unit/test_nx_fft.ml
@@ -1,0 +1,397 @@
+module Make (Backend : Nx_core.Backend_intf.S) = struct
+  module MakeSupport = Test_nx_support.Make (Backend)
+  module Nx = MakeSupport.Nx
+
+  let check_t = MakeSupport.check_t
+  let eps = 1e-10
+  let pi = 4.0 *. atan 1.0
+  let two_pi = 2.0 *. pi
+
+  (* Test standard FFT/IFFT *)
+  let test_fft_ifft ctx () =
+    (* 1D even length *)
+    let shape = [| 8 |] in
+    let input_data =
+      [|
+        Complex.{ re = 1.0; im = 0.5 };
+        Complex.{ re = 2.0; im = -0.5 };
+        Complex.{ re = 3.0; im = 0.2 };
+        Complex.{ re = 4.0; im = -0.2 };
+        Complex.{ re = 0.0; im = 0.0 };
+        Complex.{ re = 0.0; im = 0.0 };
+        Complex.{ re = 0.0; im = 0.0 };
+        Complex.{ re = 0.0; im = 0.0 };
+      |]
+    in
+    let input = Nx.create ctx Nx.complex64 shape input_data in
+    let fft_out = Nx.fft input in
+    let ifft_out = Nx.ifft fft_out in
+    check_t "1D even fft/ifft" shape input_data ifft_out;
+
+    (* 1D odd length *)
+    let n_odd = 7 in
+    let shape_odd = [| n_odd |] in
+    let input_data_odd =
+      Array.init n_odd (fun (i : int) ->
+          { Complex.re = Float.of_int i; im = Float.of_int (i - 3) *. 0.1 })
+    in
+    let input_odd = Nx.create ctx Nx.complex64 shape_odd input_data_odd in
+    let fft_odd = Nx.fft input_odd in
+    let ifft_odd = Nx.ifft fft_odd in
+    check_t "1D odd fft/ifft" shape_odd input_data_odd ifft_odd;
+
+    (* 2D *)
+    let m, n = (4, 6) in
+    let shape_2d = [| m; n |] in
+    let input_data_2d =
+      Array.init (m * n) (fun i ->
+          {
+            Complex.re = Float.of_int (i mod 10);
+            im = Float.of_int (i mod 5) *. 0.1;
+          })
+    in
+    let input_2d = Nx.create ctx Nx.complex64 shape_2d input_data_2d in
+    let fft_2d = Nx.fft2 input_2d in
+    let ifft_2d = Nx.ifft2 fft_2d in
+    check_t "2D fft/ifft" shape_2d input_data_2d ifft_2d;
+
+    (* ND *)
+    let shape_nd = [| 2; 3; 4 |] in
+    let size_nd = 2 * 3 * 4 in
+    let input_data_nd =
+      Array.init size_nd (fun i -> { Complex.re = Float.of_int i; im = 0.0 })
+    in
+    let input_nd = Nx.create ctx Nx.complex64 shape_nd input_data_nd in
+    let fft_nd = Nx.fftn input_nd in
+    let ifft_nd = Nx.ifftn fft_nd in
+    check_t "ND fft/ifft" shape_nd input_data_nd ifft_nd
+
+  let test_fft_axes ctx () =
+    let shape = [| 4; 6 |] in
+    let size = 4 * 6 in
+    let input_data =
+      Array.init size (fun i ->
+          { Complex.re = Float.of_int i; im = Float.of_int (i mod 7) *. 0.1 })
+    in
+    let input = Nx.create ctx Nx.complex64 shape input_data in
+
+    (* Specific axes *)
+    let fft_axis0 = Nx.fft input ~axis:0 in
+    let ifft_axis0 = Nx.ifft fft_axis0 ~axis:0 in
+    check_t "fft axis 0" shape input_data ifft_axis0;
+
+    let fft_axis1 = Nx.fft input ~axis:1 in
+    let ifft_axis1 = Nx.ifft fft_axis1 ~axis:1 in
+    check_t "fft axis 1" shape input_data ifft_axis1;
+
+    (* Negative axes *)
+    let fft_neg_axis = Nx.fft input ~axis:(-2) in
+    let ifft_neg_axis = Nx.ifft fft_neg_axis ~axis:(-2) in
+    check_t "fft axis -2" shape input_data ifft_neg_axis
+
+  let test_fft_size ctx () =
+    let n = 8 in
+    let shape = [| n |] in
+    let input_data =
+      Array.init n (fun i ->
+          let angle = two_pi *. Float.of_int i /. Float.of_int n in
+          { Complex.re = sin angle; im = cos angle })
+    in
+    let input = Nx.create ctx Nx.complex64 shape input_data in
+
+    (* Pad to larger size *)
+    let pad_size = 16 in
+    let fft_padded = Nx.fft input ~n:pad_size in
+    Alcotest.(check (array int))
+      "fft padded shape" [| pad_size |] (Nx.shape fft_padded);
+    let ifft_padded = Nx.ifft fft_padded ~n in
+    check_t "fft pad reconstruct" shape input_data ifft_padded;
+
+    (* Truncate to smaller size *)
+    let trunc_size = 4 in
+    let fft_trunc = Nx.fft input ~n:trunc_size in
+    Alcotest.(check (array int))
+      "fft trunc shape" [| trunc_size |] (Nx.shape fft_trunc)
+
+  let test_fft_norm ctx () =
+    let n = 4 in
+    let shape = [| n |] in
+    let input_data =
+      [|
+        Complex.{ re = 1.0; im = -1.0 };
+        Complex.{ re = 2.0; im = -2.0 };
+        Complex.{ re = 3.0; im = 3.0 };
+        Complex.{ re = 4.0; im = 4.0 };
+      |]
+    in
+    let input = Nx.create ctx Nx.complex64 shape input_data in
+
+    (* Backward norm (default) *)
+    let fft_backward = Nx.fft input ~norm:`Backward in
+    let ifft_backward = Nx.ifft fft_backward ~norm:`Backward in
+    check_t "backward norm" shape input_data ifft_backward;
+
+    (* Forward norm *)
+    let fft_forward = Nx.fft input ~norm:`Forward in
+    let ifft_forward = Nx.ifft fft_forward ~norm:`Forward in
+    check_t "forward norm" shape input_data ifft_forward;
+
+    (* Ortho norm *)
+    let fft_ortho = Nx.fft input ~norm:`Ortho in
+    let ifft_ortho = Nx.ifft fft_ortho ~norm:`Ortho in
+    check_t "ortho norm" shape input_data ifft_ortho
+
+  let test_fft_edge_cases ctx () =
+    (* Empty tensor *)
+    let empty = Nx.empty ctx Nx.complex64 [| 0 |] in
+    let fft_empty = Nx.fft empty in
+    Alcotest.(check (array int)) "fft empty" [| 0 |] (Nx.shape fft_empty);
+
+    (* Size 1 *)
+    let shape = [| 1 |] in
+    let input_data = [| Complex.{ re = 5.0; im = -3.0 } |] in
+    let single = Nx.create ctx Nx.complex64 shape input_data in
+    let fft_single = Nx.fft single in
+    check_t "fft size 1" shape input_data fft_single;
+
+    (* Non-power of 2 *)
+    let n = 5 in
+    let shape_non_pow2 = [| n |] in
+    let input_data_non_pow2 =
+      Array.init n (fun i -> { Complex.re = Float.of_int i; im = 0.0 })
+    in
+    let input = Nx.create ctx Nx.complex64 shape_non_pow2 input_data_non_pow2 in
+    let fft_out = Nx.fft input in
+    let ifft_out = Nx.ifft fft_out in
+    check_t "non-pow2" shape_non_pow2 input_data_non_pow2 ifft_out
+
+  (* Test real FFT/IFFT *)
+  let test_rfft_irfft ctx () =
+    (* 1D even *)
+    let n_even = 8 in
+    let shape_even = [| n_even |] in
+    let signal_even =
+      Array.init n_even (fun i ->
+          sin (two_pi *. Float.of_int i /. Float.of_int n_even))
+    in
+    let input_even = Nx.create ctx Nx.float64 shape_even signal_even in
+    let rfft_even = Nx.rfft input_even in
+    Alcotest.(check (array int))
+      "rfft even shape"
+      [| (n_even / 2) + 1 |]
+      (Nx.shape rfft_even);
+    let irfft_even = Nx.irfft rfft_even ~n:n_even in
+    check_t "rfft even reconstruct" shape_even signal_even irfft_even;
+
+    (* 1D odd *)
+    let n_odd = 7 in
+    let shape_odd = [| n_odd |] in
+    let signal_odd = Array.init n_odd (fun i -> Float.of_int i) in
+    let input_odd = Nx.create ctx Nx.float64 shape_odd signal_odd in
+    let rfft_odd = Nx.rfft input_odd in
+    Alcotest.(check (array int))
+      "rfft odd shape"
+      [| (n_odd / 2) + 1 |]
+      (Nx.shape rfft_odd);
+    let irfft_odd = Nx.irfft rfft_odd ~n:n_odd in
+    check_t "rfft odd reconstruct" shape_odd signal_odd irfft_odd;
+
+    (* 2D *)
+    let m, n = (4, 6) in
+    let shape_2d = [| m; n |] in
+    let signal_2d = Array.init (m * n) Float.of_int in
+    let input_2d = Nx.create ctx Nx.float64 shape_2d signal_2d in
+    let rfft_2d = Nx.rfft2 input_2d in
+    Alcotest.(check (array int))
+      "rfft2 shape"
+      [| m; (n / 2) + 1 |]
+      (Nx.shape rfft_2d);
+    let irfft_2d = Nx.irfft2 rfft_2d ~s:[| m; n |] in
+    check_t "rfft2 reconstruct" shape_2d signal_2d irfft_2d;
+
+    (* ND last axis transform *)
+    let shape_nd = [| 2; 3; 8 |] in
+    let size_nd = 2 * 3 * 8 in
+    let signal_nd = Array.init size_nd (fun i -> Float.of_int i) in
+    let input_nd = Nx.create ctx Nx.float64 shape_nd signal_nd in
+    let rfft_nd = Nx.rfftn input_nd ~axes:[| 2 |] in
+    Alcotest.(check (array int))
+      "rfftn last axis shape" [| 2; 3; 5 |] (Nx.shape rfft_nd);
+    let irfft_nd = Nx.irfftn rfft_nd ~axes:[| 2 |] ~s:[| 8 |] in
+    check_t "rfftn last axis reconstruct" shape_nd signal_nd irfft_nd
+
+  let test_rfft_axes ctx () =
+    let shape = [| 4; 6; 8 |] in
+    let size = 4 * 6 * 8 in
+    let signal = Array.init size (fun i -> Float.of_int i) in
+    let input = Nx.create ctx Nx.float64 shape signal in
+
+    (* Specific axis *)
+    let rfft_axis1 = Nx.rfftn input ~axes:[| 1 |] in
+    Alcotest.(check (array int))
+      "rfft axis 1" [| 4; 4; 8 |] (Nx.shape rfft_axis1);
+
+    (* Multiple axes, last is halved *)
+    let rfft_axes_01 = Nx.rfftn input ~axes:[| 0; 1 |] in
+    Alcotest.(check (array int))
+      "rfft axes [0;1]" [| 4; 4; 8 |] (Nx.shape rfft_axes_01);
+
+    (* Negative axis *)
+    let rfft_neg1 = Nx.rfftn input ~axes:[| -1 |] in
+    Alcotest.(check (array int))
+      "rfft axis -1" [| 4; 6; 5 |] (Nx.shape rfft_neg1)
+
+  let test_rfft_size ctx () =
+    let n = 8 in
+    let shape = [| n |] in
+    let signal =
+      Array.init n (fun i -> sin (two_pi *. Float.of_int i /. Float.of_int n))
+    in
+    let input = Nx.create ctx Nx.float64 shape signal in
+
+    (* Pad last axis *)
+    let pad_size = 16 in
+    let rfft_padded = Nx.rfft input ~n:pad_size in
+    Alcotest.(check (array int))
+      "rfft padded"
+      [| (pad_size / 2) + 1 |]
+      (Nx.shape rfft_padded);
+    let irfft_padded = Nx.irfft rfft_padded ~n in
+    check_t "rfft pad reconstruct" shape signal irfft_padded;
+
+    (* Truncate *)
+    let trunc_size = 4 in
+    let rfft_trunc = Nx.rfft input ~n:trunc_size in
+    Alcotest.(check (array int))
+      "rfft trunc"
+      [| (trunc_size / 2) + 1 |]
+      (Nx.shape rfft_trunc)
+
+  let test_rfft_norm ctx () =
+    let n = 4 in
+    let shape = [| n |] in
+    let signal = [| 1.0; 2.0; 3.0; 4.0 |] in
+    let input = Nx.create ctx Nx.float64 shape signal in
+
+    (* Backward *)
+    let rfft_backward = Nx.rfft input ~norm:`Backward in
+    let irfft_backward = Nx.irfft rfft_backward ~n ~norm:`Backward in
+    check_t "rfft backward" shape signal irfft_backward;
+
+    (* Forward *)
+    let rfft_forward = Nx.rfft input ~norm:`Forward in
+    let irfft_forward = Nx.irfft rfft_forward ~n ~norm:`Forward in
+    check_t "rfft forward" shape signal irfft_forward;
+
+    (* Ortho *)
+    let rfft_ortho = Nx.rfft input ~norm:`Ortho in
+    let irfft_ortho = Nx.irfft rfft_ortho ~n ~norm:`Ortho in
+    check_t "rfft ortho" shape signal irfft_ortho
+
+  let test_rfft_edge_cases ctx () =
+    (* Empty *)
+    let empty = Nx.empty ctx Nx.float64 [| 0 |] in
+    let rfft_empty = Nx.rfft empty in
+    Alcotest.(check (array int)) "rfft empty" [| 1 |] (Nx.shape rfft_empty);
+
+    (* Size 1 *)
+    let shape = [| 1 |] in
+    let signal_data = [| 5.0 |] in
+    let single = Nx.create ctx Nx.float64 shape signal_data in
+    let rfft_single = Nx.rfft single in
+    Alcotest.(check (array int))
+      "rfft size 1 shape" [| 1 |] (Nx.shape rfft_single);
+    let irfft_single = Nx.irfft rfft_single ~n:1 in
+    check_t "rfft size 1 reconstruct" shape signal_data irfft_single
+
+  (* Test Hermitian FFT *)
+  let test_hfft_ihfft ctx () =
+    let n = 8 in
+    let shape = [| n |] in
+    let signal =
+      Array.init n (fun i -> sin (two_pi *. Float.of_int i /. Float.of_int n))
+    in
+    let input = Nx.create ctx Nx.float64 shape signal in
+    let ihfft_out = Nx.ihfft input ~n in
+    Alcotest.(check (array int))
+      "ihfft shape"
+      [| (n / 2) + 1 |]
+      (Nx.shape ihfft_out);
+    let hfft_out = Nx.hfft ihfft_out ~n in
+    check_t "hfft/ihfft" shape signal hfft_out
+
+  (* Test helper routines *)
+  let test_fftfreq ctx () =
+    let n = 5 in
+    let shape = [| n |] in
+    let freq = Nx.fftfreq ctx n in
+    let expected_data = [| 0.0; 0.2; 0.4; -0.4; -0.2 |] in
+    check_t "fftfreq odd" shape expected_data freq;
+
+    let n_even = 4 in
+    let shape_even = [| n_even |] in
+    let freq_even = Nx.fftfreq ctx n_even ~d:0.5 in
+    let expected_even_data = [| 0.0; 0.5; -1.0; -0.5 |] in
+    check_t "fftfreq even" shape_even expected_even_data freq_even
+
+  let test_rfftfreq ctx () =
+    let n = 8 in
+    let shape = [| (n / 2) + 1 |] in
+    let freq = Nx.rfftfreq ctx n in
+    let expected_data = [| 0.0; 0.125; 0.25; 0.375; 0.5 |] in
+    check_t "rfftfreq even" shape expected_data freq;
+
+    let n_odd = 9 in
+    let shape_odd = [| (n_odd / 2) + 1 |] in
+    let freq_odd = Nx.rfftfreq ctx n_odd ~d:2.0 in
+    let expected_odd_data =
+      [| 0.0; 0.055555555555; 0.111111111111; 0.166666666666; 0.222222222222 |]
+    in
+    check_t ~eps:1e-8 "rfftfreq odd" shape_odd expected_odd_data freq_odd
+
+  let test_fftshift ctx () =
+    let x_shape = [| 4 |] in
+    let x_data = [| 0.0; 1.0; 2.0; 3.0 |] in
+    let x = Nx.create ctx Nx.float64 x_shape x_data in
+    let shifted = Nx.fftshift x in
+    let expected_shifted_data = [| 2.0; 3.0; 0.0; 1.0 |] in
+    check_t "fftshift 1D" x_shape expected_shifted_data shifted;
+
+    let x2d_shape = [| 3; 3 |] in
+    let x2d_data = Array.init 9 Float.of_int in
+    let x2d = Nx.create ctx Nx.float64 x2d_shape x2d_data in
+    let shifted2d = Nx.fftshift x2d ~axes:[| 0; 1 |] in
+    let expected2d_data = [| 8.0; 6.0; 7.0; 2.0; 0.0; 1.0; 5.0; 3.0; 4.0 |] in
+    check_t "fftshift 2D" x2d_shape expected2d_data shifted2d;
+
+    let unshifted = Nx.ifftshift shifted in
+    check_t "ifftshift 1D" x_shape x_data unshifted
+
+  let tests ctx =
+    [
+      ( "FFT :: fft/ifft",
+        [
+          Alcotest.test_case "basic" `Quick (test_fft_ifft ctx);
+          Alcotest.test_case "axes" `Quick (test_fft_axes ctx);
+          Alcotest.test_case "size" `Quick (test_fft_size ctx);
+          Alcotest.test_case "norm" `Quick (test_fft_norm ctx);
+          Alcotest.test_case "edge_cases" `Quick (test_fft_edge_cases ctx);
+        ] );
+      ( "FFT :: rfft/irfft",
+        [
+          Alcotest.test_case "basic" `Quick (test_rfft_irfft ctx);
+          Alcotest.test_case "axes" `Quick (test_rfft_axes ctx);
+          Alcotest.test_case "size" `Quick (test_rfft_size ctx);
+          Alcotest.test_case "norm" `Quick (test_rfft_norm ctx);
+          Alcotest.test_case "edge_cases" `Quick (test_rfft_edge_cases ctx);
+        ] );
+      ( "FFT :: hfft/ihfft",
+        [ Alcotest.test_case "basic" `Quick (test_hfft_ihfft ctx) ] );
+      ( "FFT :: helpers",
+        [
+          Alcotest.test_case "fftfreq" `Quick (test_fftfreq ctx);
+          Alcotest.test_case "rfftfreq" `Quick (test_rfftfreq ctx);
+          Alcotest.test_case "shifts" `Quick (test_fftshift ctx);
+        ] );
+    ]
+end

--- a/nx/test/unit/test_nx_support.ml
+++ b/nx/test/unit/test_nx_support.ml
@@ -30,11 +30,13 @@ module Make (Backend : Nx_core.Backend_intf.S) = struct
     | Nx_core.Dtype.Complex32 ->
         Alcotest.testable
           (fun ppf v -> Format.fprintf ppf "(%f, %f)" v.Complex.re v.Complex.im)
-          (fun a b -> a.re = b.re && a.im = b.im)
+          (fun a b ->
+            Float.abs (a.re -. b.re) < eps && Float.abs (a.im -. b.im) < eps)
     | Nx_core.Dtype.Complex64 ->
         Alcotest.testable
           (fun ppf v -> Format.fprintf ppf "(%f, %f)" v.Complex.re v.Complex.im)
-          (fun a b -> a.re = b.re && a.im = b.im)
+          (fun a b ->
+            Float.abs (a.re -. b.re) < eps && Float.abs (a.im -. b.im) < eps)
 
   (* Check function to test a tensor against an array *)
   let check_data (type a b) ?eps msg (expected : a array) (actual : (a, b) Nx.t)

--- a/nx/test/unit/test_nx_unit.ml
+++ b/nx/test/unit/test_nx_unit.ml
@@ -7,6 +7,7 @@ module Make (Backend : Nx_core.Backend_intf.S) = struct
   module Ops_tests = Test_nx_ops.Make (Backend)
   module Sanity_tests = Test_nx_sanity.Make (Backend)
   module Sorting_tests = Test_nx_sorting.Make (Backend)
+  module Fft_tests = Test_nx_fft.Make (Backend)
 
   let run backend_name ctx =
     Printexc.record_backtrace true;
@@ -23,5 +24,6 @@ module Make (Backend : Nx_core.Backend_intf.S) = struct
            Ops_tests.suite backend_name ctx;
            Sanity_tests.suite backend_name ctx;
            Sorting_tests.suite backend_name ctx;
+           Fft_tests.tests ctx;
          ])
 end

--- a/rune/lib/jit.ml
+++ b/rune/lib/jit.ml
@@ -566,6 +566,26 @@ let make_jit_handler (state : jit_tracer_state) =
                       dtype = ir_dtype;
                     }));
             continue k (create_symbolic_tensor state out_var dt shape))
+    | E_fft { t = _; axes = _; s = _ } ->
+        Some
+          (fun _k ->
+            (* FFT operations are not supported in JIT yet *)
+            failwith "JIT: FFT operations not yet supported")
+    | E_ifft { t = _; axes = _; s = _ } ->
+        Some
+          (fun _k ->
+            (* IFFT operations are not supported in JIT yet *)
+            failwith "JIT: IFFT operations not yet supported")
+    | E_rfft { t = _; axes = _; s = _ } ->
+        Some
+          (fun _k ->
+            (* RFFT operations are not supported in JIT yet *)
+            failwith "JIT: RFFT operations not yet supported")
+    | E_irfft { t = _; axes = _; s = _ } ->
+        Some
+          (fun _k ->
+            (* IRFFT operations are not supported in JIT yet *)
+            failwith "JIT: IRFFT operations not yet supported")
     | _ -> None
   in
   { effc; retc = Fun.id; exnc = raise }

--- a/rune/lib/metal/rune_metal.missing.ml
+++ b/rune/lib/metal/rune_metal.missing.ml
@@ -52,6 +52,10 @@ let op_fold _t ~output_size:_ ~kernel_size:_ ~stride:_ ~dilation:_ ~padding:_ =
   not_available ()
 
 let op_matmul _a _b = not_available ()
+let op_fft _t ~axes:_ ~s:_ = not_available ()
+let op_ifft _t ~axes:_ ~s:_ = not_available ()
+let op_rfft _t ~axes:_ ~s:_ = not_available ()
+let op_irfft _t ~axes:_ ~s:_ = not_available ()
 let op_cat _t = not_available ()
 let op_cast _t = not_available ()
 let op_contiguous _t = not_available ()

--- a/rune/lib/nx_rune.ml
+++ b/rune/lib/nx_rune.ml
@@ -275,6 +275,30 @@ type _ Effect.t +=
     }
       -> ('a, 'b) t Effect.t
   | E_matmul : { a : ('a, 'b) t; b : ('a, 'b) t } -> ('a, 'b) t Effect.t
+  | E_fft : {
+      t : (Complex.t, 'b) t;
+      axes : int array;
+      s : int array option;
+    }
+      -> (Complex.t, 'b) t Effect.t
+  | E_ifft : {
+      t : (Complex.t, 'b) t;
+      axes : int array;
+      s : int array option;
+    }
+      -> (Complex.t, 'b) t Effect.t
+  | E_rfft : {
+      t : (float, 'b) t;
+      axes : int array;
+      s : int array option;
+    }
+      -> (Complex.t, Dtype.complex64_elt) t Effect.t
+  | E_irfft : {
+      t : (Complex.t, 'b) t;
+      axes : int array;
+      s : int array option;
+    }
+      -> (float, Dtype.float64_elt) t Effect.t
 
 (* Helper functions for different operation types *)
 
@@ -693,3 +717,40 @@ let op_matmul a b =
     | Symbolic_tensor _, _ | _, Symbolic_tensor _ ->
         failwith "todo: op_matmul for symbolic tensors"
     | _ -> assert false)
+
+(* FFT operations *)
+let op_fft t ~axes ~s =
+  try Effect.perform (E_fft { t; axes; s })
+  with Effect.Unhandled _ -> (
+    match t with
+    | Ocaml_tensor t -> Ocaml_tensor (Nx_native.op_fft t ~axes ~s)
+    | C_tensor t -> C_tensor (Nx_c.op_fft t ~axes ~s)
+    | Metal_tensor t -> Metal_tensor (Rune_metal.op_fft t ~axes ~s)
+    | Symbolic_tensor _ -> failwith "todo: op_fft for symbolic tensors")
+
+let op_ifft t ~axes ~s =
+  try Effect.perform (E_ifft { t; axes; s })
+  with Effect.Unhandled _ -> (
+    match t with
+    | Ocaml_tensor t -> Ocaml_tensor (Nx_native.op_ifft t ~axes ~s)
+    | C_tensor t -> C_tensor (Nx_c.op_ifft t ~axes ~s)
+    | Metal_tensor t -> Metal_tensor (Rune_metal.op_ifft t ~axes ~s)
+    | Symbolic_tensor _ -> failwith "todo: op_ifft for symbolic tensors")
+
+let op_rfft t ~axes ~s =
+  try Effect.perform (E_rfft { t; axes; s })
+  with Effect.Unhandled _ -> (
+    match t with
+    | Ocaml_tensor t -> Ocaml_tensor (Nx_native.op_rfft t ~axes ~s)
+    | C_tensor t -> C_tensor (Nx_c.op_rfft t ~axes ~s)
+    | Metal_tensor t -> Metal_tensor (Rune_metal.op_rfft t ~axes ~s)
+    | Symbolic_tensor _ -> failwith "todo: op_rfft for symbolic tensors")
+
+let op_irfft t ~axes ~s =
+  try Effect.perform (E_irfft { t; axes; s })
+  with Effect.Unhandled _ -> (
+    match t with
+    | Ocaml_tensor t -> Ocaml_tensor (Nx_native.op_irfft t ~axes ~s)
+    | C_tensor t -> C_tensor (Nx_c.op_irfft t ~axes ~s)
+    | Metal_tensor t -> Metal_tensor (Rune_metal.op_irfft t ~axes ~s)
+    | Symbolic_tensor _ -> failwith "todo: op_irfft for symbolic tensors")

--- a/rune/lib/rune.mli
+++ b/rune/lib/rune.mli
@@ -2032,6 +2032,212 @@ val matmul : ('a, 'b, 'dev) t -> ('a, 'b, 'dev) t -> ('a, 'b, 'dev) t
       - : int array = [|5; 3; 2|]
     ]} *)
 
+(** {2 Fourier Transform}
+
+    Fast Fourier Transform (FFT) and related signal processing functions. *)
+
+type fft_norm = [ `Backward | `Forward | `Ortho ]
+(** FFT normalization mode:
+    - [`Backward]: normalize by 1/n on inverse transform (default)
+    - [`Forward]: normalize by 1/n on forward transform
+    - [`Ortho]: normalize by 1/√n on both transforms *)
+
+val fft :
+  ?axis:int ->
+  ?n:int ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a, 'dev) t ->
+  (Complex.t, 'a, 'dev) t
+(** [fft x ?axis ?n ?norm] computes discrete Fourier transform over specified
+    axis.
+
+    Transforms the last axis if [axis] is [None]. Forward transform is unscaled,
+    inverse transform applies 1/N normalization.
+
+    Computing 1D FFT of a signal:
+    {@ocaml[
+      # let real = Nx.create Nx.float32 [|4|] [|0.; 1.; 2.; 3.|] in
+        let imag = Nx.zeros Nx.float32 [|4|] in
+        let x = Nx.complex ~real ~imag in
+        let result = Nx.fft x ~axes:(Some [|0|]) in
+        Nx.real result
+      - : (float, float32_elt) t = [6, -2, -2, -2]
+    ]} *)
+
+val ifft :
+  ?axis:int ->
+  ?n:int ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a, 'dev) t ->
+  (Complex.t, 'a, 'dev) t
+(** [ifft x ?axis ?n ?norm] computes inverse discrete Fourier transform.
+
+    Divides by product of sizes along transformed axes. *)
+
+val fft2 :
+  ?s:int array ->
+  ?axes:int array ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a, 'dev) t ->
+  (Complex.t, 'a, 'dev) t
+(** [fft2 ?s ?axes x] computes 2-dimensional FFT.
+
+    Transforms last two axes by default. Truncates or pads to shape [s] if
+    given.
+
+    @raise Invalid_argument if input has less than 2 dimensions
+
+    Computing 2D FFT of a 2x2 matrix:
+    {@ocaml[
+      # let real = Nx.create Nx.float32 [|2; 2|] [|1.; 2.; 3.; 4.|] in
+        let imag = Nx.zeros Nx.float32 [|2; 2|] in
+        let x = Nx.complex ~real ~imag in
+        Nx.shape (Nx.fft2 x)
+      - : int array = [|2; 2|]
+    ]} *)
+
+val ifft2 :
+  ?s:int array ->
+  ?axes:int array ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a, 'dev) t ->
+  (Complex.t, 'a, 'dev) t
+(** [ifft2 ?s ?axes x] computes 2-dimensional inverse FFT.
+
+    @raise Invalid_argument if input has less than 2 dimensions *)
+
+val fftn :
+  ?s:int array ->
+  ?axes:int array ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a, 'dev) t ->
+  (Complex.t, 'a, 'dev) t
+(** [fftn ?s ?axes x] computes N-dimensional FFT.
+
+    Transforms all axes by default. *)
+
+val ifftn :
+  ?s:int array ->
+  ?axes:int array ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a, 'dev) t ->
+  (Complex.t, 'a, 'dev) t
+(** [ifftn ?s ?axes x] computes N-dimensional inverse FFT. *)
+
+val rfft :
+  ?axis:int ->
+  ?n:int ->
+  ?norm:fft_norm ->
+  (float, 'a, 'dev) t ->
+  (Complex.t, complex64_elt, 'dev) t
+(** [rfft x ?axis ?n ?norm] computes FFT of real input.
+
+    Returns only non-redundant positive frequencies. Output size along last
+    transformed axis is n/2+1 where n is input size.
+
+    Computing real FFT:
+    {@ocaml[
+      # let x = Nx.create Nx.float32 [|4|] [|0.; 1.; 2.; 3.|] in
+        let result = Nx.rfft x ~axes:(Some [|0|]) in
+        Nx.shape result
+      - : int array = [|3|]
+    ]} *)
+
+val irfft :
+  ?axis:int ->
+  ?n:int ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a, 'dev) t ->
+  (float, float64_elt, 'dev) t
+(** [irfft x ?axis ?n ?norm] computes inverse FFT returning real output.
+
+    Assumes Hermitian symmetry. Shape [s] specifies output size along
+    transformed axes. *)
+
+val rfft2 :
+  ?s:int array ->
+  ?axes:int array ->
+  ?norm:fft_norm ->
+  (float, 'a, 'dev) t ->
+  (Complex.t, complex64_elt, 'dev) t
+(** [rfft2 ?s ?axes x] computes 2D FFT of real input.
+
+    @raise Invalid_argument if input has less than 2 dimensions *)
+
+val irfft2 :
+  ?axes:int array ->
+  ?s:int array ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a, 'dev) t ->
+  (float, float64_elt, 'dev) t
+(** [irfft2 ?s ?axes x] computes 2D inverse FFT returning real output.
+
+    @raise Invalid_argument
+      if input has less than 2 dimensions or if [s] not specified *)
+
+val rfftn :
+  ?s:int array ->
+  ?axes:int array ->
+  ?norm:fft_norm ->
+  (float, 'a, 'dev) t ->
+  (Complex.t, complex64_elt, 'dev) t
+(** [rfftn ?s ?axes x] computes N-dimensional FFT of real input. *)
+
+val irfftn :
+  ?axes:int array ->
+  ?s:int array ->
+  ?norm:fft_norm ->
+  (Complex.t, 'a, 'dev) t ->
+  (float, float64_elt, 'dev) t
+(** [irfftn ?s ?axes x] computes N-dimensional inverse FFT returning real
+    output.
+
+    @raise Invalid_argument if [s] not specified *)
+
+val hfft :
+  n:int -> axis:int -> (Complex.t, 'a, 'dev) t -> (float, float64_elt, 'dev) t
+(** [hfft x ~n ~axis] computes FFT of Hermitian signal.
+
+    Interprets input as positive frequencies of Hermitian signal. *)
+
+val ihfft :
+  n:int -> axis:int -> (float, 'a, 'dev) t -> (Complex.t, complex64_elt, 'dev) t
+(** [ihfft x ~n ~axis] computes inverse FFT for Hermitian output. *)
+
+val fftfreq : 'dev device -> ?d:float -> int -> (float, float64_elt, 'dev) t
+(** [fftfreq ctx device ?d n] returns DFT sample frequencies.
+
+    For window length [n] and sample spacing [d], returns frequencies
+    [0, 1, ..., n/2-1, -n/2, ..., -1] / (d*n) if n is even.
+
+    Getting frequencies for 4-point FFT:
+    {@ocaml[
+      # let ctx = Nx_native.create_context () in
+        Nx.fftfreq ctx 4 ()
+      - : (float, float64_elt) t = [0, 0.25, -0.5, -0.25]
+    ]} *)
+
+val rfftfreq : 'dev device -> ?d:float -> int -> (float, float64_elt, 'dev) t
+(** [rfftfreq ctx device n ?d ()] returns positive DFT frequencies.
+
+    Returns [0, 1, ..., n/2] / (d*n). *)
+
+val fftshift : ?axes:int array -> ('a, 'b, 'dev) t -> ('a, 'b, 'dev) t
+(** [fftshift x ?axes] shifts zero-frequency component to center.
+
+    Shifts all axes by default. For visualization of frequency spectra.
+
+    Centering frequency spectrum:
+    {@ocaml[
+      # let ctx = Nx_native.create_context () in
+        let freqs = Nx.fftfreq ctx 5 () in
+        Nx.fftshift freqs
+      - : (float, float64_elt) t = [-0.4, -0.2, 0, 0.2, 0.4]
+    ]} *)
+
+val ifftshift : ?axes:int array -> ('a, 'b, 'dev) t -> ('a, 'b, 'dev) t
+(** [ifftshift x ?axes] undoes fftshift. *)
+
 (** {2 Activation Functions}
 
     Neural network activation functions. *)

--- a/rune/lib/tensor_with_debug.ml
+++ b/rune/lib/tensor_with_debug.ml
@@ -92,6 +92,59 @@ let prod ?axes ?keepdims x =
 let matmul a b = Debug.with_context "matmul" (fun () -> T.matmul a b)
 let dot a b = Debug.with_context "dot" (fun () -> T.dot a b)
 
+(* FFT *)
+
+let fft ?axis ?n ?(norm = `Backward) x =
+  Debug.with_context "fft" (fun () -> T.fft ?axis ?n ~norm x)
+
+let ifft ?axis ?n ?(norm = `Backward) x =
+  Debug.with_context "ifft" (fun () -> T.ifft ?axis ?n ~norm x)
+
+let fft2 ?s ?axes ?(norm = `Backward) x =
+  Debug.with_context "fft2" (fun () -> T.fft2 ?s ?axes ~norm x)
+
+let ifft2 ?s ?axes ?(norm = `Backward) x =
+  Debug.with_context "ifft2" (fun () -> T.ifft2 ?s ?axes ~norm x)
+
+let fftn ?s ?axes ?(norm = `Backward) x =
+  Debug.with_context "fftn" (fun () -> T.fftn ?s ?axes ~norm x)
+
+let ifftn ?s ?axes ?(norm = `Backward) x =
+  Debug.with_context "ifftn" (fun () -> T.ifftn ?s ?axes ~norm x)
+
+let rfft ?axis ?n ?(norm = `Backward) x =
+  Debug.with_context "rfft" (fun () -> T.rfft ?axis ?n ~norm x)
+
+let irfft ?axis ?n ?(norm = `Backward) x =
+  Debug.with_context "irfft" (fun () -> T.irfft ?axis ?n ~norm x)
+
+let rfft2 ?s ?axes ?(norm = `Backward) x =
+  Debug.with_context "rfft2" (fun () -> T.rfft2 ?s ?axes ~norm x)
+
+let irfft2 ?axes ?s ?(norm = `Backward) x =
+  Debug.with_context "irfft2" (fun () -> T.irfft2 ?axes ?s ~norm x)
+
+let rfftn ?s ?axes ?(norm = `Backward) x =
+  Debug.with_context "rfftn" (fun () -> T.rfftn ?s ?axes ~norm x)
+
+let irfftn ?axes ?s ?(norm = `Backward) x =
+  Debug.with_context "irfftn" (fun () -> T.irfftn ?axes ?s ~norm x)
+
+let hfft ~n ~axis x = Debug.with_context "hfft" (fun () -> T.hfft ~n ~axis x)
+let ihfft ~n ~axis x = Debug.with_context "ihfft" (fun () -> T.ihfft ~n ~axis x)
+
+let fftfreq ctx ?d n =
+  Debug.with_context "fftfreq" (fun () -> T.fftfreq ctx ?d n)
+
+let rfftfreq ctx ?d n =
+  Debug.with_context "rfftfreq" (fun () -> T.rfftfreq ctx ?d n)
+
+let fftshift ?axes x =
+  Debug.with_context "fftshift" (fun () -> T.fftshift ?axes x)
+
+let ifftshift ?axes x =
+  Debug.with_context "ifftshift" (fun () -> T.ifftshift ?axes x)
+
 (* Other operations *)
 
 let cast dtype x = Debug.with_context "cast" (fun () -> T.cast dtype x)


### PR DESCRIPTION
This adds support for FFT operations to our 3 backends (native, c and metal).

To support this, we add 4 new backend operations: `op_fft`, `op_ifft`, `op_rfft`, `op_irfft`.

And we add the following frontend operations (available in both nx and rune): `fft` `ifft` `fft2` `ifft2` `fftn` `ifftn` `rfft` `irfft` `rfft2` `irfft2` `rfftn` `irfftn` `hfft` `ihfft` `fftfreq` `rfftfreq` `fftshift` `ifftshift`.

These follow the Numpy API closely: https://numpy.org/doc/stable/reference/routines.fft.html.

cc @gabyfle 

---

**Status**

The implementations are still incomplete. Basic FFT work, but not all tests pass. The implementation is inneficient and still hacky. We're tracking the progress here (a checkbox meaning the implementation is in shape for merge, and the tests are passing)

- [ ] Native backend
- [ ] C backend
- [ ] Metal backend
- [ ] Derivative in Rune