### PR TITLE
feat(nx): add with_view frontend operation

### DIFF
--- a/nx/lib/c/nx_c.ml
+++ b/nx/lib/c/nx_c.ml
@@ -444,6 +444,7 @@ let view t = t.view
 let dtype t = t.dtype
 let context t = t.context
 let data t = t.buffer
+let with_view t view = { t with view }
 let create ctx dtype buffer view = { context = ctx; dtype; buffer; view }
 
 let make_buffer (type a b) (dtype : (a, b) Dtype.t) size =

--- a/nx/lib/core/backend_intf.ml
+++ b/nx/lib/core/backend_intf.ml
@@ -31,6 +31,11 @@ module type S = sig
   val data : ('a, 'b) t -> ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
   (** Return the raw buffer of [t]. *)
 
+  val with_view : ('a, 'b) t -> View.t -> ('a, 'b) t
+  (** Create a new tensor with the same context, dtype, and data but with a
+      different view. This is a low-level operation that allows direct
+      manipulation of tensor view metadata. *)
+
   (* ops: mirrors tinygrad UOps *)
 
   val op_buffer :

--- a/nx/lib/core/frontend.ml
+++ b/nx/lib/core/frontend.ml
@@ -99,6 +99,10 @@ module Make (B : Backend_intf.S) = struct
   let offset x = View.offset (B.view x)
   let is_c_contiguous x = View.is_c_contiguous (B.view x)
 
+  (* ───── View Operations ───── *)
+
+  let with_view x new_view = B.with_view x new_view
+
   (* ───── Internal Utilities ───── *)
 
   (* Create a power of 2 for integer shift operations *)

--- a/nx/lib/metal/nx_metal.ml
+++ b/nx/lib/metal/nx_metal.ml
@@ -13,6 +13,7 @@ type ('a, 'b) t = ('a, 'b) Internal.t = {
 let view t = t.view
 let dtype t = t.dtype
 let context t = t.context
+let with_view t view = { t with view }
 
 let create_context () =
   let device = Metal.Device.create_system_default () in

--- a/nx/lib/nx.mli
+++ b/nx/lib/nx.mli
@@ -147,6 +147,17 @@ val offset : ('a, 'b) t -> int
 val is_c_contiguous : ('a, 'b) t -> bool
 (** [is_c_contiguous t] returns true if elements are contiguous in C order. *)
 
+val with_view : ('a, 'b) t -> Nx_core.View.t -> ('a, 'b) t
+(** [with_view t view] creates a new tensor with the same context, dtype, and
+    data but with a different view.
+
+    This is a low-level operation that allows direct manipulation of tensor view
+    metadata. Use with caution as it can create invalid tensor states if the
+    view is incompatible with the underlying data.
+
+    @raise Invalid_argument
+      if the view is incompatible with the tensor's buffer size *)
+
 val to_bigarray : ('a, 'b) t -> ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
 (** [to_bigarray t] converts to bigarray.
 


### PR DESCRIPTION
## Summary

Adds ``with_view`` function to enable zero-copy tensor operations with custom memory layouts. This function creates a new tensor sharing the same underlying buffer but with a different view specification. ``with_view`` was already available for the ``native`` backend. This PR make it available for all backends, adds it into the backend interface and adds a new frontend operation: ``with_view``

## Motivation

Currently, Nx lacks a way to create tensors with custom stride patterns while sharing existing data buffers. This limitation prevents implementing efficient zero-copy operations like:

• **Sliding window operations** (e.g., audio framing, convolution im2col)
• **Custom broadcasting patterns** beyond standard rules
• **Memory layout transformations** without copying data
• **Advanced indexing operations** that require stride manipulation

While ``Nx_core.View`` provides the low-level view manipulation capabilities, there's no frontend function to create tensors from these custom views.