### PR TITLE
feat(talon): added mapHomo

### DIFF
--- a/dev/talon/lib/talon.ml
+++ b/dev/talon/lib/talon.ml
@@ -390,6 +390,11 @@ module Row = struct
   let map x ~f = { f = (fun df i -> f (x.f df i)) }
   let map2 x y ~f = { f = (fun df i -> f (x.f df i) (y.f df i)) }
   let map3 x y z ~f = { f = (fun df i -> f (x.f df i) (y.f df i) (z.f df i)) }
+  
+  let mapHomo xl ~f = { f = (fun df i ->
+    List.map (fun x -> x.f df i) xl
+    |> f) }
+
   let both x y = { f = (fun df i -> (x.f df i, y.f df i)) }
 
   let float32 name =

--- a/dev/talon/lib/talon.mli
+++ b/dev/talon/lib/talon.mli
@@ -316,6 +316,12 @@ module Row : sig
 
   val map3 : 'a t -> 'b t -> 'c t -> f:('a -> 'b -> 'c -> 'd) -> 'd t
   (** [map3 x y z ~f] combines three computations with a ternary function. *)
+  
+  val mapHomo : ('a t) list -> f:('a list -> 'b) -> 'b t
+  (** [mapHomo [x] ~f] maps a function over a list of homogeneous computations. *)
+  
+  (* val mapHomo2 : ('a t) list -> ('b t) list -> f:('a list -> 'b list -> 'c) -> 'c t *)
+  (** [mapHomo2 [x] [y] ~f] maps a function over two lists of homogeneous computations. *)
 
   val both : 'a t -> 'b t -> ('a * 'b) t
   (** [both x y] pairs two computations. *)

--- a/dev/talon/test/test_talon.ml
+++ b/dev/talon/test/test_talon.ml
@@ -190,6 +190,21 @@ let test_row_map () =
   | Some arr -> check_bool "mapped values" true (arr = [|2l; 4l; 6l|])
   | None -> Alcotest.fail "doubled column should exist"
 
+let test_row_mapHomo () =
+  let df = create [
+    ("x", Col.int32_list [1l; 2l; 3l]);
+    ("y", Col.int32_list [4l; 5l; 6l]);
+    ("z", Col.int32_list [7l; 8l; 9l])
+  ] in
+  
+  (* Use map_column to create a new column *)
+  let df2 = map_column df "allMul" Nx.int32 
+    Row.(mapHomo [int32 "x"; int32 "y"; int32 "z"] ~f:(fun xl -> List.fold_left (Int32.mul) 1l xl)) in
+  
+  match to_int32_array df2 "allMul" with
+  | Some arr -> check_bool "mapped values" true (arr = [|28l; 80l; 162l|])
+  | None -> Alcotest.fail "allMul column should exist"
+
 (* Test sorting *)
 let test_sort () =
   let df = create [
@@ -379,6 +394,7 @@ let concat_tests = [
 let row_module_tests = [
   "accessors", `Quick, test_row_accessors;
   "map", `Quick, test_row_map;
+  "mapHomo", `Quick, test_row_mapHomo;
 ]
 
 let sort_group_tests = [


### PR DESCRIPTION
Previously, we had `map`, `map2` and `map3` in `Row` module. In hello-world tutorials, we may compute a new column based on 7 features. A basic requirement is mapping over any number of columns.

I added the function `mapHomo` which maps a list of homogeneous columns. See the example in the test cases.

We can also have `mapHomo2` to map two different lists of homogeneous columns, or even `mapHomoK` where `k` is the number of column types. For now, let's keep things simple, as in most cases we map over numerics.