### PR TITLE
library `rune.jit.llvm` requires `ctypes-foreign` so package `rune` should require it

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -125,11 +125,8 @@
    (= :version))
   (ctypes
    (>= 0.21.0))
-  ; rune.jit.metal
   (ctypes-foreign
-   (and
-    (>= 0.21.0)
-    (= :os macos)))
+   (>= 0.21.0))
   (alcotest :with-test)))
 
 (package

--- a/rune.opam
+++ b/rune.opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "3.19"}
   "nx" {= version}
   "ctypes" {>= "0.21.0"}
-  "ctypes-foreign" {>= "0.21.0" & os = "macos"}
+  "ctypes-foreign" {>= "0.21.0"}
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Fixes the following `dune build` compilation error I see on OCaml 5.3.0 x86-64 

```bash
$ dune build
File "rune/lib-jit/backends/llvm/dune", line 13, characters 2-16:
13 |   ctypes-foreign
       ^^^^^^^^^^^^^^
Error: Library "ctypes-foreign" not found.
-> required by library "rune.jit.llvm" in
   _build/default/rune/lib-jit/backends/llvm
-> required by _build/default/META.rune
-> required by alias all
-> required by alias default
```