### PR TITLE
fix(rune): allow plain `llvm-config` in discovery

### DIFF
--- a/rune/vendor/llvm/config/discover.ml
+++ b/rune/vendor/llvm/config/discover.ml
@@ -2,7 +2,7 @@ module C = Configurator.V1
 
 let get_llvm_config c =
   (* Try different llvm-config names in order of preference *)
-  let possible_names = [ "llvm-config-21"; "llvm-config-20"; "llvm-config-19" ] in
+  let possible_names = [ "llvm-config-21"; "llvm-config-20"; "llvm-config-19"; "llvm-config" ] in
 
   let rec find_llvm_config = function
     | [] -> None


### PR DESCRIPTION
thanks for making raven!

i'm trying to package raven into the nixpkgs ecosystem in https://github.com/NixOS/nixpkgs/pull/445206, but hit an issue with llvm-config discovery with raven

`llvmPackages_21.libllvm` ... `llvmPackages_19.libllvm`'s `llvm-config` are all without version suffix

though i can patch the source like [this](https://github.com/NixOS/nixpkgs/pull/445206/files#diff-63fc9983ea49baa8b818efc1c1689f7112f7523ed9f42ac494f325f681ed0d47R23-R28), i think the one without version suffix should also be acceptable