### PR TITLE
Fix F16/BF16 loading in safetensors

### DIFF
--- a/nx/bigarray_ext/bigarray_ext_stubs.c
+++ b/nx/bigarray_ext/bigarray_ext_stubs.c
@@ -542,32 +542,3 @@ CAMLprim value caml_nx_ba_fill(value vb, value vinit) {
  
   CAMLreturn(Val_unit);
 }
-
-/* Conversion functions for 16-bit floats */
-CAMLprim value caml_half_to_float(value v) {
-  CAMLparam1(v);
-  uint16_t h = Int_val(v);
-  float f = half_to_float(h);
-  CAMLreturn(caml_copy_double(f));
-}
-
-CAMLprim value caml_bfloat16_to_float(value v) {
-  CAMLparam1(v);
-  uint16_t bf16 = Int_val(v);
-  float f = bfloat16_to_float(bf16);
-  CAMLreturn(caml_copy_double(f));
-}
-
-CAMLprim value caml_float_to_half(value v) {
-  CAMLparam1(v);
-  float f = Double_val(v);
-  uint16_t h = float_to_half(f);
-  CAMLreturn(Val_int(h));
-}
-
-CAMLprim value caml_float_to_bfloat16(value v) {
-  CAMLparam1(v);
-  float f = Double_val(v);
-  uint16_t bf16 = float_to_bfloat16(f);
-  CAMLreturn(Val_int(bf16));
-}

--- a/nx/bigarray_ext/bigarray_ext_stubs.c
+++ b/nx/bigarray_ext/bigarray_ext_stubs.c
@@ -542,3 +542,32 @@ CAMLprim value caml_nx_ba_fill(value vb, value vinit) {
  
   CAMLreturn(Val_unit);
 }
+
+/* Conversion functions for 16-bit floats */
+CAMLprim value caml_half_to_float(value v) {
+  CAMLparam1(v);
+  uint16_t h = Int_val(v);
+  float f = half_to_float(h);
+  CAMLreturn(caml_copy_double(f));
+}
+
+CAMLprim value caml_bfloat16_to_float(value v) {
+  CAMLparam1(v);
+  uint16_t bf16 = Int_val(v);
+  float f = bfloat16_to_float(bf16);
+  CAMLreturn(caml_copy_double(f));
+}
+
+CAMLprim value caml_float_to_half(value v) {
+  CAMLparam1(v);
+  float f = Double_val(v);
+  uint16_t h = float_to_half(f);
+  CAMLreturn(Val_int(h));
+}
+
+CAMLprim value caml_float_to_bfloat16(value v) {
+  CAMLparam1(v);
+  float f = Double_val(v);
+  uint16_t bf16 = float_to_bfloat16(f);
+  CAMLreturn(Val_int(bf16));
+}

--- a/nx/lib/io/nx_io.ml
+++ b/nx/lib/io/nx_io.ml
@@ -103,6 +103,7 @@ module Safe = struct
   (* Conversions from packed arrays *)
 
   let as_float16 = Packed_nx.as_float16
+  let as_bfloat16 = Packed_nx.as_bfloat16
   let as_float32 = Packed_nx.as_float32
   let as_float64 = Packed_nx.as_float64
   let as_int8 = Packed_nx.as_int8
@@ -128,6 +129,7 @@ let unwrap_result = function
   | Error err -> failwith (Error.to_string err)
 
 let as_float16 packed = Packed_nx.as_float16 packed |> unwrap_result
+let as_bfloat16 packed = Packed_nx.as_bfloat16 packed |> unwrap_result
 let as_float32 packed = Packed_nx.as_float32 packed |> unwrap_result
 let as_float64 packed = Packed_nx.as_float64 packed |> unwrap_result
 let as_int8 packed = Packed_nx.as_int8 packed |> unwrap_result

--- a/nx/lib/io/nx_io.mli
+++ b/nx/lib/io/nx_io.mli
@@ -22,6 +22,10 @@ val as_float16 : packed_nx -> Nx.float16_t
 (** [as_float16 packed] converts a packed Nx to a [Nx.float16_t], or [Error] if
     dtype mismatch. *)
 
+val as_bfloat16 : packed_nx -> Nx.bfloat16_t
+(** [as_bfloat16 packed] converts a packed Nx to a [Nx.bfloat16_t], or [Error] if
+    dtype mismatch. *)
+
 val as_float32 : packed_nx -> Nx.float32_t
 (** [as_float32 packed] converts a packed Nx to a [Nx.float32_t], or [Error] if
     dtype mismatch. *)
@@ -213,6 +217,9 @@ module Safe : sig
 
   val as_float16 : packed_nx -> (Nx.float16_t, error) result
   (** Safe alias for [as_float16] *)
+
+  val as_bfloat16 : packed_nx -> (Nx.bfloat16_t, error) result
+  (** Safe alias for [as_bfloat16] *)
 
   val as_float32 : packed_nx -> (Nx.float32_t, error) result
   (** Safe alias for [as_float32] *)

--- a/nx/lib/io/nx_io.mli
+++ b/nx/lib/io/nx_io.mli
@@ -23,8 +23,8 @@ val as_float16 : packed_nx -> Nx.float16_t
     dtype mismatch. *)
 
 val as_bfloat16 : packed_nx -> Nx.bfloat16_t
-(** [as_bfloat16 packed] converts a packed Nx to a [Nx.bfloat16_t], or [Error] if
-    dtype mismatch. *)
+(** [as_bfloat16 packed] converts a packed Nx to a [Nx.bfloat16_t], or [Error]
+    if dtype mismatch. *)
 
 val as_float32 : packed_nx -> Nx.float32_t
 (** [as_float32 packed] converts a packed Nx to a [Nx.float32_t], or [Error] if

--- a/nx/lib/io/packed_nx.ml
+++ b/nx/lib/io/packed_nx.ml
@@ -9,11 +9,26 @@ let convert_result_with_error : type a b.
       let source_dtype = Nx.dtype nx in
       let source_ba_kind = Nx_core.Dtype.to_bigarray_ext_kind source_dtype in
       let target_ba_kind = Nx_core.Dtype.to_bigarray_ext_kind target_dtype in
+      (* Try Npy.Eq.Kind first for standard types *)
       match Npy.Eq.Kind.( === ) source_ba_kind target_ba_kind with
       | Some Npy.Eq.W -> Ok nx
-      | None -> Error Unsupported_dtype)
+      | None -> (
+          (* Fallback: compare bigarray kinds directly for extended types *)
+          match (source_ba_kind, target_ba_kind) with
+          | (Bigarray_ext.Float16, Bigarray_ext.Float16) -> Ok nx
+          | (Bigarray_ext.Bfloat16, Bigarray_ext.Bfloat16) -> Ok nx
+          | (Bigarray_ext.Bool, Bigarray_ext.Bool) -> Ok nx
+          | (Bigarray_ext.Int4_signed, Bigarray_ext.Int4_signed) -> Ok nx
+          | (Bigarray_ext.Int4_unsigned, Bigarray_ext.Int4_unsigned) -> Ok nx
+          | (Bigarray_ext.Float8_e4m3, Bigarray_ext.Float8_e4m3) -> Ok nx
+          | (Bigarray_ext.Float8_e5m2, Bigarray_ext.Float8_e5m2) -> Ok nx
+          | (Bigarray_ext.Complex16, Bigarray_ext.Complex16) -> Ok nx
+          | (Bigarray_ext.Qint8, Bigarray_ext.Qint8) -> Ok nx
+          | (Bigarray_ext.Quint8, Bigarray_ext.Quint8) -> Ok nx
+          | _ -> Error Unsupported_dtype))
 
 let as_float16 packed = convert_result_with_error Nx.float16 packed
+let as_bfloat16 packed = convert_result_with_error Nx.bfloat16 packed
 let as_float32 packed = convert_result_with_error Nx.float32 packed
 let as_float64 packed = convert_result_with_error Nx.float64 packed
 let as_int8 packed = convert_result_with_error Nx.int8 packed

--- a/nx/lib/io/packed_nx.ml
+++ b/nx/lib/io/packed_nx.ml
@@ -13,19 +13,9 @@ let convert_result_with_error : type a b.
       match Npy.Eq.Kind.( === ) source_ba_kind target_ba_kind with
       | Some Npy.Eq.W -> Ok nx
       | None -> (
-          (* Fallback: compare bigarray kinds directly for extended types *)
-          match (source_ba_kind, target_ba_kind) with
-          | (Bigarray_ext.Float16, Bigarray_ext.Float16) -> Ok nx
-          | (Bigarray_ext.Bfloat16, Bigarray_ext.Bfloat16) -> Ok nx
-          | (Bigarray_ext.Bool, Bigarray_ext.Bool) -> Ok nx
-          | (Bigarray_ext.Int4_signed, Bigarray_ext.Int4_signed) -> Ok nx
-          | (Bigarray_ext.Int4_unsigned, Bigarray_ext.Int4_unsigned) -> Ok nx
-          | (Bigarray_ext.Float8_e4m3, Bigarray_ext.Float8_e4m3) -> Ok nx
-          | (Bigarray_ext.Float8_e5m2, Bigarray_ext.Float8_e5m2) -> Ok nx
-          | (Bigarray_ext.Complex16, Bigarray_ext.Complex16) -> Ok nx
-          | (Bigarray_ext.Qint8, Bigarray_ext.Qint8) -> Ok nx
-          | (Bigarray_ext.Quint8, Bigarray_ext.Quint8) -> Ok nx
-          | _ -> Error Unsupported_dtype))
+          match Nx_core.Dtype.equal_witness source_dtype target_dtype with
+          | Some Type.Equal -> Ok (nx : (a, b) Nx.t)
+          | None -> Error Unsupported_dtype))
 
 let as_float16 packed = convert_result_with_error Nx.float16 packed
 let as_bfloat16 packed = convert_result_with_error Nx.bfloat16 packed

--- a/nx/test/dune
+++ b/nx/test/dune
@@ -23,4 +23,4 @@
  (name test_nx_io)
  (package nx)
  (modules test_nx_io)
- (libraries nx nx_io alcotest))
+ (libraries nx nx_io safetensors alcotest))

--- a/nx/test/test_nx_io.ml
+++ b/nx/test/test_nx_io.ml
@@ -3,6 +3,11 @@ open Alcotest
 (* Helper functions *)
 let temp_file prefix suffix = Filename.temp_file prefix suffix
 
+let expect_safetensors_ok context = function
+  | Ok v -> v
+  | Error err ->
+      Alcotest.failf "%s: %s" context (Safetensors.string_of_error err)
+
 let array_approx_equal ?(eps = 1e-6) a b =
   try
     let a_flat = Nx.flatten a in
@@ -308,7 +313,7 @@ let test_safetensors_float16_roundtrip () =
   let path = temp_file "test_safetensors_f16_" ".safetensors" in
 
   (* Save the data *)
-  Nx_io.save_safetensor path [("test_f16", Nx_io.P test_data)];
+  Nx_io.save_safetensor path [ ("test_f16", Nx_io.P test_data) ];
 
   (* Load it back *)
   let archive = Nx_io.load_safetensor path in
@@ -321,12 +326,64 @@ let test_safetensors_float16_roundtrip () =
   (* Clean up *)
   Sys.remove path
 
+let u16_bytes values =
+  let len = List.length values in
+  let bytes = Bytes.create (len * 2) in
+  List.iteri
+    (fun i bits ->
+      Bytes.set bytes (i * 2) (Char.chr (bits land 0xFF));
+      Bytes.set bytes ((i * 2) + 1) (Char.chr ((bits lsr 8) land 0xFF)))
+    values;
+  bytes
+
+let write_raw_safetensor path name dtype shape bytes =
+  let view =
+    expect_safetensors_ok "tensor_view_new"
+    @@ Safetensors.tensor_view_new ~dtype ~shape
+         ~data:(Bytes.unsafe_to_string bytes)
+  in
+  expect_safetensors_ok "serialize_to_file"
+  @@ Safetensors.serialize_to_file [ (name, view) ] None path
+
+let read_tensor_payload path name =
+  let ic = open_in_bin path in
+  let len = in_channel_length ic in
+  let buffer = really_input_string ic len in
+  close_in ic;
+  let safetensors =
+    expect_safetensors_ok "deserialize" @@ Safetensors.deserialize buffer
+  in
+  let tensor =
+    Safetensors.tensors safetensors
+    |> List.find_opt (fun (n, _) -> String.equal n name)
+  in
+  match tensor with
+  | Some (_, view) -> String.sub view.data view.offset view.length
+  | None -> Alcotest.failf "Tensor '%s' not found in safetensors file" name
+
+let test_safetensors_float16_bit_exact () =
+  let path_in = temp_file "test_safetensors_f16_bits_in_" ".safetensors" in
+  let path_out = temp_file "test_safetensors_f16_bits_out_" ".safetensors" in
+  let values = [ 0x0000; 0x0001; 0x3C00; 0x7C00; 0x7E01 ] in
+  write_raw_safetensor path_in "half" Safetensors.F16 [ 5 ] (u16_bytes values);
+  let archive = Nx_io.load_safetensor path_in in
+  let original = Hashtbl.find archive "half" in
+  let original_values = original |> Nx_io.as_float16 |> Nx.to_array in
+  check bool "subnormal preserved" true (original_values.(1) <> 0.0);
+  check bool "nan preserved" true (Float.is_nan original_values.(4));
+  Nx_io.save_safetensor path_out [ ("half", original) ];
+  let payload_in = read_tensor_payload path_in "half" in
+  let payload_out = read_tensor_payload path_out "half" in
+  check string "float16 payload round-trip" payload_in payload_out;
+  Sys.remove path_in;
+  Sys.remove path_out
+
 let test_safetensors_bfloat16_roundtrip () =
   let test_data = Nx.full Nx.bfloat16 [| 2; 3 |] 1.5 in
   let path = temp_file "test_safetensors_bf16_" ".safetensors" in
 
   (* Save the data *)
-  Nx_io.save_safetensor path [("test_bf16", Nx_io.P test_data)];
+  Nx_io.save_safetensor path [ ("test_bf16", Nx_io.P test_data) ];
 
   (* Load it back *)
   let archive = Nx_io.load_safetensor path in
@@ -338,6 +395,23 @@ let test_safetensors_bfloat16_roundtrip () =
 
   (* Clean up *)
   Sys.remove path
+
+let test_safetensors_bfloat16_bit_exact () =
+  let path_in = temp_file "test_safetensors_bf16_bits_in_" ".safetensors" in
+  let path_out = temp_file "test_safetensors_bf16_bits_out_" ".safetensors" in
+  let values = [ 0x0000; 0x0001; 0x3F80; 0x7F80; 0x7FC1 ] in
+  write_raw_safetensor path_in "bf" Safetensors.BF16 [ 5 ] (u16_bytes values);
+  let archive = Nx_io.load_safetensor path_in in
+  let original = Hashtbl.find archive "bf" in
+  let original_values = original |> Nx_io.as_bfloat16 |> Nx.to_array in
+  check bool "bf16 subnormal preserved" true (original_values.(1) <> 0.0);
+  check bool "bf16 nan preserved" true (Float.is_nan original_values.(4));
+  Nx_io.save_safetensor path_out [ ("bf", original) ];
+  let payload_in = read_tensor_payload path_in "bf" in
+  let payload_out = read_tensor_payload path_out "bf" in
+  check string "bfloat16 payload round-trip" payload_in payload_out;
+  Sys.remove path_in;
+  Sys.remove path_out
 
 (* Test Safe module *)
 let test_safe_module_error_handling () =
@@ -381,8 +455,14 @@ let () =
         [
           test_case "Save/load tensors" `Quick test_safetensors_save_load;
           test_case "Different dtypes" `Quick test_safetensors_different_dtypes;
-          test_case "Float16 round-trip" `Quick test_safetensors_float16_roundtrip;
-          test_case "Bfloat16 round-trip" `Quick test_safetensors_bfloat16_roundtrip;
+          test_case "Float16 round-trip" `Quick
+            test_safetensors_float16_roundtrip;
+          test_case "Float16 bit exact" `Quick
+            test_safetensors_float16_bit_exact;
+          test_case "Bfloat16 round-trip" `Quick
+            test_safetensors_bfloat16_roundtrip;
+          test_case "Bfloat16 bit exact" `Quick
+            test_safetensors_bfloat16_bit_exact;
         ] );
       ( "dtype_conversions",
         [ test_case "Basic conversions" `Quick test_dtype_conversions ] );


### PR DESCRIPTION
- Replace placeholder code with real 16-bit to float conversions
- Add C stubs for half_to_float and bfloat16_to_float functions
- Fix dtype conversion logic to support extended bigarray types
- Add as_bfloat16 conversion function to Nx_io module
- Add unit tests for F16/BF16 round-trip functionality

Fixes issue where F16/BF16 tensors were loaded as zeros instead of preserving original values. Now supports proper half-precision checkpoint loading for ML models.