### PR TITLE
add label support kau csv loader

### DIFF
--- a/kaun/lib/kaun/dataset/dataset.ml
+++ b/kaun/lib/kaun/dataset/dataset.ml
@@ -319,8 +319,6 @@ let from_jsonl ?field path =
 
 let from_csv ?(separator = ',') ?(text_column = 0) ?label_column
     ?(has_header = true) path =
-  let _ = label_column in
-  (* TODO: Handle label column *)
   let text_ds = from_text_file path in
   let skipped_header = ref (not has_header) in
 
@@ -329,26 +327,56 @@ let from_csv ?(separator = ',') ?(text_column = 0) ?label_column
     String.split_on_char separator line
   in
 
-  let next () =
-    if not !skipped_header then (
-      skipped_header := true;
-      ignore (text_ds.next ()));
+  match label_column with
+  | Some (Some lbl_col) ->
+      let next () =
+        if not !skipped_header then (
+          skipped_header := true;
+          ignore (text_ds.next ()));
 
-    match text_ds.next () with
-    | None -> None
-    | Some line ->
-        let fields = split_csv line in
-        if text_column < List.length fields then
-          Some (List.nth fields text_column)
-        else None
-  in
+        let rec read_next () =
+          match text_ds.next () with
+          | None -> None
+          | Some line ->
+              let fields = split_csv line in
+              let len = List.length fields in
+              if text_column < len && lbl_col < len then
+                let text = List.nth fields text_column in
+                let label = List.nth fields lbl_col in
+                Some (text, label)
+              else
+                read_next ()
+        in
+        read_next ()
+      in
 
-  {
-    next;
-    cardinality = text_ds.cardinality;
-    reset = text_ds.reset;
-    spec = (fun () -> Scalar "string");
-  }
+      {
+        next = (Obj.magic next : unit -> 'a option);
+        cardinality = text_ds.cardinality;
+        reset = text_ds.reset;
+        spec = (fun () -> Tuple [ Scalar "string"; Scalar "string" ]);
+      }
+  | _ ->
+      let next () =
+        if not !skipped_header then (
+          skipped_header := true;
+          ignore (text_ds.next ()));
+
+        match text_ds.next () with
+        | None -> None
+        | Some line ->
+            let fields = split_csv line in
+            if text_column < List.length fields then
+              Some (List.nth fields text_column)
+            else None
+      in
+
+      {
+        next = (Obj.magic next : unit -> 'a option);
+        cardinality = text_ds.cardinality;
+        reset = text_ds.reset;
+        spec = (fun () -> Scalar "string");
+      }
 
 let from_text ~tokenizer path =
   (* Read entire file as a single string *)

--- a/kaun/lib/kaun/dataset/dataset.mli
+++ b/kaun/lib/kaun/dataset/dataset.mli
@@ -128,13 +128,17 @@ val from_csv :
   ?label_column:int option ->
   ?has_header:bool ->
   string ->
-  string t
+  'a t
 (** [from_csv ?separator ?text_column ?label_column ?has_header path] reads CSV
     data.
     - [separator]: Field separator (default: ',')
     - [text_column]: Column index for text (default: 0)
     - [label_column]: Optional column index for labels
-    - [has_header]: Skip first row if true (default: true) *)
+    - [has_header]: Skip first row if true (default: true)
+
+    Element spec:
+    - Returns [Scalar "string"] when [label_column] is [None] or omitted, yielding just the text column.
+    - Returns [Tuple [ Scalar "string"; Scalar "string" ]] when [label_column = Some idx], yielding [(text, label)]. *)
 
 val from_text : tokenizer:tokenizer -> string -> int array t
 (** [from_text ~tokenizer path] reads a text file and returns a dataset of token

--- a/kaun/test/test_dataset.ml
+++ b/kaun/test/test_dataset.ml
@@ -135,6 +135,33 @@ let test_from_csv_no_header () =
       let collected = collect_dataset dataset in
       Alcotest.(check (list string)) "all rows" [ "a"; "d" ] collected)
 
+let test_from_csv_with_labels_headers () =
+  let content = "text,label\nhello,spam\nworld,ham\n" in
+  with_temp_csv content (fun path ->
+      let dataset = from_csv ~label_column:(Some 1) path in
+      let collected = collect_dataset dataset in
+      Alcotest.(check (list (pair string string)))
+        "text and labels with header"
+        [ ("hello", "spam"); ("world", "ham") ] collected)
+
+let test_from_csv_with_labels_no_header () =
+  let content = "foo,bar\nbaz,qux\n" in
+  with_temp_csv content (fun path ->
+      let dataset = from_csv ~label_column:(Some 1) ~has_header:false path in
+      let collected = collect_dataset dataset in
+      Alcotest.(check (list (pair string string)))
+        "text and labels without header"
+        [ ("foo", "bar"); ("baz", "qux") ] collected)
+
+let test_from_csv_with_labels_custom_sep () =
+  let content = "t1|l1\nt2|l2\n" in
+  with_temp_csv content (fun path ->
+      let dataset = from_csv ~separator:'|' ~label_column:(Some 1) ~has_header:false path in
+      let collected = collect_dataset dataset in
+      Alcotest.(check (list (pair string string)))
+        "text and labels with custom sep"
+        [ ("t1", "l1"); ("t2", "l2") ] collected)
+
 let test_from_file () =
   let content = "100\n200\n300\n" in
   with_temp_file content (fun path ->
@@ -573,6 +600,12 @@ let () =
           test_case "from_csv" `Quick test_from_csv;
           test_case "from_csv_custom_column" `Quick test_from_csv_custom_column;
           test_case "from_csv_no_header" `Quick test_from_csv_no_header;
+          test_case "from_csv_with_labels_headers" `Quick
+            test_from_csv_with_labels_headers;
+          test_case "from_csv_with_labels_no_header" `Quick
+            test_from_csv_with_labels_no_header;
+          test_case "from_csv_with_labels_custom_sep" `Quick
+            test_from_csv_with_labels_custom_sep;
           test_case "from_file" `Quick test_from_file;
         ] );
       ( "transformations",


### PR DESCRIPTION

This PR updates the `Kaun.Dataset.from_csv` function to properly handle labeled data. Previously, `from_csv` only returned the text column and ignored any labels.  

### Changes include:
- `from_csv` now returns `(text, label)` tuples when the optional `~label_column` argument is provided.
- Existing text-only behavior is preserved when `~label_column` is not specified.
- `spec` metadata is updated to reflect the new output format for labeled datasets.
- Added Alcotest tests for:
  - CSVs with headers  
  - CSVs without headers  
  - CSVs with custom separators

### Notes
- Bounds checking is implemented to safely handle rows where the label column is missing.
- Labels are kept as strings for now, following the original specification.

Fixes #94
