### PR TITLE
fix: Update "get started" link to point to the installation page

### DIFF
--- a/www/site/index.html
+++ b/www/site/index.html
@@ -104,7 +104,7 @@
         <span class="separator">|</span>
         <a href="https://github.com/raven-ml/raven">github</a>
         <span class="separator">|</span>
-        <a href="/docs/getting-started/" class="cta-inline">get started →</a>
+        <a href="/docs/installation/" class="cta-inline">get started →</a>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
Updates the "get started" call-to-action link in the landing page to ensure it correctly points to the installation documentation.

## Changes
- Updated link target to `/docs/installation/` to match the actual installation page path
- Ensures new users can easily find setup instructions

## Before
```html
<a href="/docs/" class="cta-inline">get started →</a>