### PR TITLE
fix: make conjugate publicly available

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Nx
 
 - Move neural-network operations (softmax, log_softmax, relu, gelu, silu, sigmoid, tanh) from Kaun to Nx (@tmattio)
+- Add public `conjugate` function for complex number conjugation (#123, @Arsalaan-Alam)
 - Fix complex vdot to conjugate first tensor before multiplication, ensuring correct mathematical behavior (#123, @Arsalaan-Alam)
 - Update comparison and conditional operations to use boolean tensors (#54, @nirnayroy)
 - Add support for rcond parameter and underdetermined systems to `lstsq` (#102, @nirnayroy)

--- a/nx/lib/nx.mli
+++ b/nx/lib/nx.mli
@@ -1512,6 +1512,20 @@ val imod_s : ('a, 'b) t -> 'a -> ('a, 'b) t
 val neg : ('a, 'b) t -> ('a, 'b) t
 (** [neg t] negates all elements. *)
 
+val conjugate : ('a, 'b) t -> ('a, 'b) t
+(** [conjugate x] computes the complex conjugate.
+    
+    For complex tensors, negates the imaginary part of each element.
+    For real tensors, returns the input unchanged.
+    
+    {@ocaml[
+      # let x = create complex32 [| 2 |] 
+          [|Complex.{re=1.; im=2.}; Complex.{re=3.; im=4.}|] in
+        conjugate x |> to_array
+      - : Complex.t array =
+      [|{Complex.re = 1.; im = -2.}; {Complex.re = 3.; im = -4.}|]
+    ]} *)
+
 (** {2 Mathematical Functions}
 
     Unary mathematical operations and special functions. *)

--- a/nx/test/test_nx_linalg.ml
+++ b/nx/test/test_nx_linalg.ml
@@ -584,6 +584,22 @@ let test_vdot_complex () =
   check (float 1e-6) "vdot complex real part" expected.re actual.re;
   check (float 1e-6) "vdot complex imag part" expected.im actual.im
 
+let test_conjugate () =
+  (* Test complex conjugate *)
+  let x = Nx.create Nx.complex32 [| 2 |]
+    [| Complex.{ re = 1.; im = 2. }; Complex.{ re = 3.; im = 4. } |] in
+  let conj_x = Nx.conjugate x in
+  let expected = [| Complex.{ re = 1.; im = -2. }; Complex.{ re = 3.; im = -4. } |] in
+  let actual = Nx.to_array conj_x in
+  check (float 1e-6) "conjugate[0] real" expected.(0).re actual.(0).re;
+  check (float 1e-6) "conjugate[0] imag" expected.(0).im actual.(0).im;
+  check (float 1e-6) "conjugate[1] real" expected.(1).re actual.(1).re;
+  check (float 1e-6) "conjugate[1] imag" expected.(1).im actual.(1).im;
+  (* Test that real tensors are unchanged *)
+  let real_x = Nx.create Nx.float32 [| 2 |] [| 1.; 2. |] in
+  let conj_real = Nx.conjugate real_x in
+  check_nx "conjugate real unchanged" real_x conj_real
+
 let test_vdot_mismatch () =
   let a = Nx.create Nx.float32 [| 3 |] [| 1.; 2.; 3. |] in
   let b = Nx.create Nx.float32 [| 4 |] [| 4.; 5.; 6.; 7. |] in
@@ -1132,6 +1148,7 @@ let product_tests =
   [
     ("vdot", `Quick, test_vdot);
     ("vdot complex", `Quick, test_vdot_complex);
+    ("conjugate", `Quick, test_conjugate);
     ("vdot mismatch", `Quick, test_vdot_mismatch);
     ("vecdot", `Quick, test_vecdot);
     ("inner", `Quick, test_inner);

--- a/rune/lib/tensor_with_debug.ml
+++ b/rune/lib/tensor_with_debug.ml
@@ -47,6 +47,7 @@ let minimum a b = Debug.with_context "minimum" (fun () -> T.minimum a b)
 (* Unary operations *)
 
 let neg x = Debug.with_context "neg" (fun () -> T.neg x)
+let conjugate x = Debug.with_context "conjugate" (fun () -> T.conjugate x)
 let abs x = Debug.with_context "abs" (fun () -> T.abs x)
 let sign x = Debug.with_context "sign" (fun () -> T.sign x)
 let square x = Debug.with_context "square" (fun () -> T.square x)


### PR DESCRIPTION
- Added conjugate function to public API in `nx.mli`
- Added regression test for conjugate function in `test_nx_linalg.ml`
- Added conjugate wrapper to `tensor_with_debug.ml` for debugging support