### PR TITLE
Op-where implementation

### DIFF
--- a/dev/nx-oxcaml/lib-simd/float32x4.ml
+++ b/dev/nx-oxcaml/lib-simd/float32x4.ml
@@ -178,7 +178,7 @@ let[@inline] of_int16x8_bits x = of_int16x8 x
 let[@inline] of_int32x4_bits x = of_int32x4 x
 let[@inline] of_int64x2_bits x = of_int64x2 x
 let[@inline] unsafe_of_float32 x = low_of x
-(* let[@inline] of_int32x4 x = Int32x4.cvt_f32 x *)
+let[@inline] cvt_of_int32x4 x = Int32x4.cvt_f32 x
 let[@inline] of_float64x2 x = Float64x2.cvt_float32x4 x
 
 (* ───── String Conversion ───── *)

--- a/dev/nx-oxcaml/lib-simd/float64x2.ml
+++ b/dev/nx-oxcaml/lib-simd/float64x2.ml
@@ -156,7 +156,7 @@ let[@inline] of_int16x8_bits x = of_int16x8 x
 let[@inline] of_int32x4_bits x = of_int32x4 x
 let[@inline] of_int64x2_bits x = of_int64x2 x
 let[@inline] unsafe_of_float x = low_of x
-let[@inline] of_int32x4 x = Int32x4.cvt_f64 x
+let[@inline] cvt_of_int32x4 x = Int32x4.cvt_f64 x
 
 (* ───── String Conversion ───── *)
 

--- a/dev/nx-oxcaml/lib/nx_oxcaml.ml
+++ b/dev/nx-oxcaml/lib/nx_oxcaml.ml
@@ -80,6 +80,18 @@ let of_float32 context (arr : float32# array) : (float, Dtype.float32_elt) t =
   let view = View.create sym_shape in
   { dtype = Dtype.Float32; buffer = Float32 arr; view; context }
 
+let of_int8 context (arr : int8# array) : (int, Dtype.int8_elt) t =
+  let size = Array.length arr in
+  let sym_shape = Symbolic_shape.of_ints [| size |] in
+  let view = View.create sym_shape in
+  { dtype = Dtype.Int8; buffer = Int8 arr; view; context }
+
+let of_int16 context (arr : int16# array) : (int, Dtype.int16_elt) t =
+  let size = Array.length arr in
+  let sym_shape = Symbolic_shape.of_ints [| size |] in
+  let view = View.create sym_shape in
+  { dtype = Dtype.Int16; buffer = Int16 arr; view; context }
+
 let of_int32 context (arr : int32# array) : (int32, Dtype.int32_elt) t =
   let size = Array.length arr in
   let sym_shape = Symbolic_shape.of_ints [| size |] in
@@ -844,6 +856,24 @@ let op_where (type a b) ~(out : (a, b) t) (cond : (bool, Nx_buffer.bool_elt) t)
             vtrue vfalse vout start_idx end_idx)
     else
       Op_where.where_int32 cond_arr true_arr false_arr out_arr vcond vtrue
+        vfalse vout 0 vol
+  | Int8 out_arr, Bool cond_arr, Int8 true_arr, Int8 false_arr ->
+    if vol > parallel_threshold then
+      Parallel.parallel_for out.context.pool 0 (vol - 1)
+        (fun start_idx end_idx ->
+          Op_where.where_int8 cond_arr true_arr false_arr out_arr vcond
+            vtrue vfalse vout start_idx end_idx)
+    else
+      Op_where.where_int8 cond_arr true_arr false_arr out_arr vcond vtrue
+        vfalse vout 0 vol
+  | Int16 out_arr, Bool cond_arr, Int16 true_arr, Int16 false_arr ->
+    if vol > parallel_threshold then
+      Parallel.parallel_for out.context.pool 0 (vol - 1)
+        (fun start_idx end_idx ->
+          Op_where.where_int16 cond_arr true_arr false_arr out_arr vcond
+            vtrue vfalse vout start_idx end_idx)
+    else
+      Op_where.where_int16 cond_arr true_arr false_arr out_arr vcond vtrue
         vfalse vout 0 vol
   | _ -> Error.invalid ~op:"op_where " ~what:"not implemented for this dtype" ()
 

--- a/dev/nx-oxcaml/lib/ternary_ops/op_where.ml
+++ b/dev/nx-oxcaml/lib/ternary_ops/op_where.ml
@@ -9,7 +9,7 @@ let where_float64
     cond_arr true_arr false_arr out_arr
     vcond vtrue vfalse vout
     start_idx end_idx =
-    let[@inline] select_f64x2 (mask : Int64x2.t) (a : Float64x2.t) (b : Float64x2.t) =
+  let[@inline] select_f64x2 (mask : Int64x2.t) (a : Float64x2.t) (b : Float64x2.t) =
     let ai = Int64x2.of_float64x2 a in
     let bi = Int64x2.of_float64x2 b in
     let r =
@@ -17,8 +17,9 @@ let where_float64
         (Int64x2.bitwise_and mask ai)
         (Int64x2.bitwise_and (Int64x2.bitwise_not mask) bi)
     in
-    Float64x2.of_int64x2 r in
-    let[@inline] mask2 cond_arr base i =
+    Float64x2.of_int64x2 r
+  in
+  let[@inline] mask2 cond_arr base i =
     let m0 =
       if Array.unsafe_get cond_arr (base + i)
       then (-#1L)
@@ -29,12 +30,12 @@ let where_float64
       then (-#1L)
       else #0L
     in
-    Int64x2.set m0 m1 in    
+    Int64x2.set m0 m1
+  in
   let cond_base = View.offset vcond + start_idx in
-  let out_base  = View.offset vout  + start_idx in
-  let a_base    = View.offset vtrue + start_idx in
-  let b_base    = View.offset vfalse + start_idx in
-
+  let out_base = View.offset vout + start_idx in
+  let a_base = View.offset vtrue + start_idx in
+  let b_base = View.offset vfalse + start_idx in
   if
     View.is_c_contiguous vout &&
     View.is_c_contiguous vtrue &&
@@ -43,28 +44,21 @@ let where_float64
   then (
     let i = ref 0 in
     let n = end_idx - start_idx in
-
-    (* ---- 8 elements per iteration ---- *)
     let n8 = n - 7 in
     while !i < n8 do
       let idx = !i in
-
-      let a0 = Float64x2.Array.unsafe_get true_arr  ~idx:(a_base + idx) in
+      let a0 = Float64x2.Array.unsafe_get true_arr ~idx:(a_base + idx) in
       let b0 = Float64x2.Array.unsafe_get false_arr ~idx:(b_base + idx) in
       let m0 = mask2 cond_arr cond_base idx in
-
-      let a1 = Float64x2.Array.unsafe_get true_arr  ~idx:(a_base + idx + 2) in
+      let a1 = Float64x2.Array.unsafe_get true_arr ~idx:(a_base + idx + 2) in
       let b1 = Float64x2.Array.unsafe_get false_arr ~idx:(b_base + idx + 2) in
       let m1 = mask2 cond_arr cond_base (idx + 2) in
-
-      let a2 = Float64x2.Array.unsafe_get true_arr  ~idx:(a_base + idx + 4) in
+      let a2 = Float64x2.Array.unsafe_get true_arr ~idx:(a_base + idx + 4) in
       let b2 = Float64x2.Array.unsafe_get false_arr ~idx:(b_base + idx + 4) in
       let m2 = mask2 cond_arr cond_base (idx + 4) in
-
-      let a3 = Float64x2.Array.unsafe_get true_arr  ~idx:(a_base + idx + 6) in
+      let a3 = Float64x2.Array.unsafe_get true_arr ~idx:(a_base + idx + 6) in
       let b3 = Float64x2.Array.unsafe_get false_arr ~idx:(b_base + idx + 6) in
       let m3 = mask2 cond_arr cond_base (idx + 6) in
-
       Float64x2.Array.unsafe_set out_arr ~idx:(out_base + idx)
         (select_f64x2 m0 a0 b0);
       Float64x2.Array.unsafe_set out_arr ~idx:(out_base + idx + 2)
@@ -73,36 +67,30 @@ let where_float64
         (select_f64x2 m2 a2 b2);
       Float64x2.Array.unsafe_set out_arr ~idx:(out_base + idx + 6)
         (select_f64x2 m3 a3 b3);
-
       i := idx + 8
     done;
-
-    (* ---- 2-element chunks ---- *)
     let n2 = n - 1 in
     while !i < n2 do
       let idx = !i in
-      let a = Float64x2.Array.unsafe_get true_arr  ~idx:(a_base + idx) in
+      let a = Float64x2.Array.unsafe_get true_arr ~idx:(a_base + idx) in
       let b = Float64x2.Array.unsafe_get false_arr ~idx:(b_base + idx) in
       let m = mask2 cond_arr cond_base idx in
       Float64x2.Array.unsafe_set out_arr ~idx:(out_base + idx)
         (select_f64x2 m a b);
       i := idx + 2
     done;
-
-    (* ---- scalar tail ---- *)
     while !i < n do
       let idx = !i in
-      let a = Array.unsafe_get true_arr  (a_base + idx) in
+      let a = Array.unsafe_get true_arr (a_base + idx) in
       let b = Array.unsafe_get false_arr (b_base + idx) in
-      let c = Array.unsafe_get cond_arr  (cond_base + idx) in
-      Array.unsafe_set out_arr (out_base + idx)
-        (if c then a else b);
+      let c = Array.unsafe_get cond_arr (cond_base + idx) in
+      Array.unsafe_set out_arr (out_base + idx) (if c then a else b);
       incr i
     done
   )
   else
-    (* ---- generic broadcasted path ---- *)
     let out_shape = shape vout in
+    let out_strides = View.strides vout in
     let a_shape = shape vtrue in
     let b_shape = shape vfalse in
     let c_shape = shape vcond in
@@ -125,19 +113,17 @@ let where_float64
       let b_lin = Shape.ravel_index b_idx b_strides in
       Shape.broadcast_index_into md_idx c_shape c_idx;
       let c_lin = Shape.ravel_index c_idx c_strides in
-      let a = Array.unsafe_get true_arr  (a_offset + a_lin) in
+      let out_lin = Shape.ravel_index md_idx out_strides in
+      let a = Array.unsafe_get true_arr (a_offset + a_lin) in
       let b = Array.unsafe_get false_arr (b_offset + b_lin) in
-      let c = Array.unsafe_get cond_arr  (c_offset + c_lin) in
-      Array.unsafe_set out_arr (out_offset + k)
-        (if c then a else b)
+      let c = Array.unsafe_get cond_arr (c_offset + c_lin) in
+      Array.unsafe_set out_arr (out_offset + out_lin) (if c then a else b)
     done
 
-    let where_float32
+let where_float32
     cond_arr true_arr false_arr out_arr
     vcond vtrue vfalse vout
     start_idx end_idx =
-
-  (* ---- vector select ---- *)
   let[@inline] select_f32x4
       (mask : Int32x4.t)
       (a : Float32x4.t)
@@ -151,8 +137,6 @@ let where_float64
     in
     Float32x4.of_int32x4 r
   in
-
-  (* ---- build mask from bool array ---- *)
   let[@inline] mask4 cond_arr base i =
     let m0 =
       if Array.unsafe_get cond_arr (base + i)
@@ -172,12 +156,10 @@ let where_float64
     in
     Int32x4.set m0 m1 m2 m3
   in
-
   let cond_base = View.offset vcond + start_idx in
-  let out_base  = View.offset vout  + start_idx in
-  let a_base    = View.offset vtrue + start_idx in
-  let b_base    = View.offset vfalse + start_idx in
-
+  let out_base = View.offset vout + start_idx in
+  let a_base = View.offset vtrue + start_idx in
+  let b_base = View.offset vfalse + start_idx in
   if
     View.is_c_contiguous vout &&
     View.is_c_contiguous vtrue &&
@@ -186,28 +168,21 @@ let where_float64
   then (
     let i = ref 0 in
     let n = end_idx - start_idx in
-
-    (* ---- 16 elements per iteration ---- *)
     let n16 = n - 15 in
     while !i < n16 do
       let idx = !i in
-
-      let a0 = Float32x4.Array.unsafe_get true_arr  ~idx:(a_base + idx) in
+      let a0 = Float32x4.Array.unsafe_get true_arr ~idx:(a_base + idx) in
       let b0 = Float32x4.Array.unsafe_get false_arr ~idx:(b_base + idx) in
       let m0 = mask4 cond_arr cond_base idx in
-
-      let a1 = Float32x4.Array.unsafe_get true_arr  ~idx:(a_base + idx + 4) in
+      let a1 = Float32x4.Array.unsafe_get true_arr ~idx:(a_base + idx + 4) in
       let b1 = Float32x4.Array.unsafe_get false_arr ~idx:(b_base + idx + 4) in
       let m1 = mask4 cond_arr cond_base (idx + 4) in
-
-      let a2 = Float32x4.Array.unsafe_get true_arr  ~idx:(a_base + idx + 8) in
+      let a2 = Float32x4.Array.unsafe_get true_arr ~idx:(a_base + idx + 8) in
       let b2 = Float32x4.Array.unsafe_get false_arr ~idx:(b_base + idx + 8) in
       let m2 = mask4 cond_arr cond_base (idx + 8) in
-
-      let a3 = Float32x4.Array.unsafe_get true_arr  ~idx:(a_base + idx + 12) in
+      let a3 = Float32x4.Array.unsafe_get true_arr ~idx:(a_base + idx + 12) in
       let b3 = Float32x4.Array.unsafe_get false_arr ~idx:(b_base + idx + 12) in
       let m3 = mask4 cond_arr cond_base (idx + 12) in
-
       Float32x4.Array.unsafe_set out_arr ~idx:(out_base + idx)
         (select_f32x4 m0 a0 b0);
       Float32x4.Array.unsafe_set out_arr ~idx:(out_base + idx + 4)
@@ -216,36 +191,30 @@ let where_float64
         (select_f32x4 m2 a2 b2);
       Float32x4.Array.unsafe_set out_arr ~idx:(out_base + idx + 12)
         (select_f32x4 m3 a3 b3);
-
       i := idx + 16
     done;
-
-    (* ---- 4-element chunks ---- *)
     let n4 = n - 3 in
     while !i < n4 do
       let idx = !i in
-      let a = Float32x4.Array.unsafe_get true_arr  ~idx:(a_base + idx) in
+      let a = Float32x4.Array.unsafe_get true_arr ~idx:(a_base + idx) in
       let b = Float32x4.Array.unsafe_get false_arr ~idx:(b_base + idx) in
       let m = mask4 cond_arr cond_base idx in
       Float32x4.Array.unsafe_set out_arr ~idx:(out_base + idx)
         (select_f32x4 m a b);
       i := idx + 4
     done;
-
-    (* ---- scalar tail ---- *)
     while !i < n do
       let idx = !i in
-      let a = Array.unsafe_get true_arr  (a_base + idx) in
+      let a = Array.unsafe_get true_arr (a_base + idx) in
       let b = Array.unsafe_get false_arr (b_base + idx) in
-      let c = Array.unsafe_get cond_arr  (cond_base + idx) in
-      Array.unsafe_set out_arr (out_base + idx)
-        (if c then a else b);
+      let c = Array.unsafe_get cond_arr (cond_base + idx) in
+      Array.unsafe_set out_arr (out_base + idx) (if c then a else b);
       incr i
     done
   )
   else
-    (* ---- generic broadcasted path ---- *)
     let out_shape = shape vout in
+    let out_strides = View.strides vout in
     let a_shape = shape vtrue in
     let b_shape = shape vfalse in
     let c_shape = shape vcond in
@@ -268,18 +237,20 @@ let where_float64
       let b_lin = Shape.ravel_index b_idx b_strides in
       Shape.broadcast_index_into md_idx c_shape c_idx;
       let c_lin = Shape.ravel_index c_idx c_strides in
-      let a = Array.unsafe_get true_arr  (a_offset + a_lin) in
+      let out_lin = Shape.ravel_index md_idx out_strides in
+      let a = Array.unsafe_get true_arr (a_offset + a_lin) in
       let b = Array.unsafe_get false_arr (b_offset + b_lin) in
-      let c = Array.unsafe_get cond_arr  (c_offset + c_lin) in
-      Array.unsafe_set out_arr (out_offset + k)
-        (if c then a else b)
+      let c = Array.unsafe_get cond_arr (c_offset + c_lin) in
+      Array.unsafe_set out_arr (out_offset + out_lin) (if c then a else b)
     done
 
-
 let where_int8
-cond_arr true_arr false_arr out_arr
-vcond vtrue vfalse vout
-start_idx end_idx =
+    (cond_arr : bool array)
+    (true_arr : int8# array)
+    (false_arr : int8# array)
+    (out_arr : int8# array)
+    vcond vtrue vfalse vout
+    start_idx end_idx =
   let out_base = View.offset vout + start_idx in
   let a_base = View.offset vtrue + start_idx in
   let b_base = View.offset vfalse + start_idx in
@@ -324,6 +295,7 @@ start_idx end_idx =
     done)
   else
     let out_shape = shape vout in
+    let out_strides = View.strides vout in
     let a_shape = shape vtrue in
     let b_shape = shape vfalse in
     let c_shape = shape vcond in
@@ -333,7 +305,7 @@ start_idx end_idx =
     let a_offset = View.offset vtrue in
     let b_offset = View.offset vfalse in
     let c_offset = View.offset vcond in
-    let out_offset = View.offset vcond in
+    let out_offset = View.offset vout in
     let md_idx = Array.make (Array.length out_shape) 0 in
     let a_idx = Array.make (Array.length a_shape) 0 in
     let b_idx = Array.make (Array.length b_shape) 0 in
@@ -346,16 +318,20 @@ start_idx end_idx =
       let b_lin = Shape.ravel_index b_idx b_strides in
       Shape.broadcast_index_into md_idx c_shape c_idx;
       let c_lin = Shape.ravel_index c_idx c_strides in
+      let out_lin = Shape.ravel_index md_idx out_strides in
       let a_val = Array.unsafe_get true_arr (a_offset + a_lin) in
       let b_val = Array.unsafe_get false_arr (b_offset + b_lin) in
       let c_val = Array.unsafe_get cond_arr (c_offset + c_lin) in
-      Array.unsafe_set out_arr (out_offset + k) (if c_val then a_val else b_val)
+      Array.unsafe_set out_arr (out_offset + out_lin) (if c_val then a_val else b_val)
     done
 
 let where_int16
-cond_arr true_arr false_arr out_arr
-vcond vtrue vfalse vout
-start_idx end_idx =
+    (cond_arr : bool array)
+    (true_arr : int16# array)
+    (false_arr : int16# array)
+    (out_arr : int16# array)
+    vcond vtrue vfalse vout
+    start_idx end_idx =
   let out_base = View.offset vout + start_idx in
   let a_base = View.offset vtrue + start_idx in
   let b_base = View.offset vfalse + start_idx in
@@ -400,6 +376,7 @@ start_idx end_idx =
     done)
   else
     let out_shape = shape vout in
+    let out_strides = View.strides vout in
     let a_shape = shape vtrue in
     let b_shape = shape vfalse in
     let c_shape = shape vcond in
@@ -409,7 +386,7 @@ start_idx end_idx =
     let a_offset = View.offset vtrue in
     let b_offset = View.offset vfalse in
     let c_offset = View.offset vcond in
-    let out_offset = View.offset vcond in
+    let out_offset = View.offset vout in
     let md_idx = Array.make (Array.length out_shape) 0 in
     let a_idx = Array.make (Array.length a_shape) 0 in
     let b_idx = Array.make (Array.length b_shape) 0 in
@@ -422,18 +399,17 @@ start_idx end_idx =
       let b_lin = Shape.ravel_index b_idx b_strides in
       Shape.broadcast_index_into md_idx c_shape c_idx;
       let c_lin = Shape.ravel_index c_idx c_strides in
+      let out_lin = Shape.ravel_index md_idx out_strides in
       let a_val = Array.unsafe_get true_arr (a_offset + a_lin) in
       let b_val = Array.unsafe_get false_arr (b_offset + b_lin) in
       let c_val = Array.unsafe_get cond_arr (c_offset + c_lin) in
-      Array.unsafe_set out_arr (out_offset + k) (if c_val then a_val else b_val)
+      Array.unsafe_set out_arr (out_offset + out_lin) (if c_val then a_val else b_val)
     done
 
 let where_int32
-cond_arr true_arr false_arr out_arr
-vcond vtrue vfalse vout
-start_idx end_idx =
-
-  (* ---- vector select ---- *)
+    cond_arr true_arr false_arr out_arr
+    vcond vtrue vfalse vout
+    start_idx end_idx =
   let[@inline] select_i32x4
       (mask : Int32x4.t)
       (a : Int32x4.t)
@@ -442,21 +418,17 @@ start_idx end_idx =
       (Int32x4.bitwise_and mask a)
       (Int32x4.bitwise_and (Int32x4.bitwise_not mask) b)
   in
-
-  (* ---- build mask ---- *)
   let[@inline] mask4 cond_arr base i =
-    let m0 = if Array.unsafe_get cond_arr (base + i)     then -#1l else #0l in
+    let m0 = if Array.unsafe_get cond_arr (base + i) then -#1l else #0l in
     let m1 = if Array.unsafe_get cond_arr (base + i + 1) then -#1l else #0l in
     let m2 = if Array.unsafe_get cond_arr (base + i + 2) then -#1l else #0l in
     let m3 = if Array.unsafe_get cond_arr (base + i + 3) then -#1l else #0l in
     Int32x4.set m0 m1 m2 m3
   in
-
   let cond_base = View.offset vcond + start_idx in
-  let out_base  = View.offset vout  + start_idx in
-  let a_base    = View.offset vtrue + start_idx in
-  let b_base    = View.offset vfalse + start_idx in
-
+  let out_base = View.offset vout + start_idx in
+  let a_base = View.offset vtrue + start_idx in
+  let b_base = View.offset vfalse + start_idx in
   if
     View.is_c_contiguous vout &&
     View.is_c_contiguous vtrue &&
@@ -465,31 +437,53 @@ start_idx end_idx =
   then (
     let i = ref 0 in
     let n = end_idx - start_idx in
-
+    let n16 = n - 15 in
+    while !i < n16 do
+      let idx = !i in
+      let a0 = Int32x4.Array.unsafe_get true_arr ~idx:(a_base + idx) in
+      let b0 = Int32x4.Array.unsafe_get false_arr ~idx:(b_base + idx) in
+      let m0 = mask4 cond_arr cond_base idx in
+      let a1 = Int32x4.Array.unsafe_get true_arr ~idx:(a_base + idx + 4) in
+      let b1 = Int32x4.Array.unsafe_get false_arr ~idx:(b_base + idx + 4) in
+      let m1 = mask4 cond_arr cond_base (idx + 4) in
+      let a2 = Int32x4.Array.unsafe_get true_arr ~idx:(a_base + idx + 8) in
+      let b2 = Int32x4.Array.unsafe_get false_arr ~idx:(b_base + idx + 8) in
+      let m2 = mask4 cond_arr cond_base (idx + 8) in
+      let a3 = Int32x4.Array.unsafe_get true_arr ~idx:(a_base + idx + 12) in
+      let b3 = Int32x4.Array.unsafe_get false_arr ~idx:(b_base + idx + 12) in
+      let m3 = mask4 cond_arr cond_base (idx + 12) in
+      Int32x4.Array.unsafe_set out_arr ~idx:(out_base + idx)
+        (select_i32x4 m0 a0 b0);
+      Int32x4.Array.unsafe_set out_arr ~idx:(out_base + idx + 4)
+        (select_i32x4 m1 a1 b1);
+      Int32x4.Array.unsafe_set out_arr ~idx:(out_base + idx + 8)
+        (select_i32x4 m2 a2 b2);
+      Int32x4.Array.unsafe_set out_arr ~idx:(out_base + idx + 12)
+        (select_i32x4 m3 a3 b3);
+      i := idx + 16
+    done;
     let n4 = n - 3 in
     while !i < n4 do
       let idx = !i in
-      let a = Int32x4.Array.unsafe_get true_arr  ~idx:(a_base + idx) in
+      let a = Int32x4.Array.unsafe_get true_arr ~idx:(a_base + idx) in
       let b = Int32x4.Array.unsafe_get false_arr ~idx:(b_base + idx) in
       let m = mask4 cond_arr cond_base idx in
       Int32x4.Array.unsafe_set out_arr ~idx:(out_base + idx)
         (select_i32x4 m a b);
       i := idx + 4
     done;
-
     while !i < n do
       let idx = !i in
-      let a = Array.unsafe_get true_arr  (a_base + idx) in
+      let a = Array.unsafe_get true_arr (a_base + idx) in
       let b = Array.unsafe_get false_arr (b_base + idx) in
-      let c = Array.unsafe_get cond_arr  (cond_base + idx) in
-      Array.unsafe_set out_arr (out_base + idx)
-        (if c then a else b);
+      let c = Array.unsafe_get cond_arr (cond_base + idx) in
+      Array.unsafe_set out_arr (out_base + idx) (if c then a else b);
       incr i
     done
   )
   else
-    (* ---- generic broadcasted path ---- *)
     let out_shape = shape vout in
+    let out_strides = View.strides vout in
     let a_shape = shape vtrue in
     let b_shape = shape vfalse in
     let c_shape = shape vcond in
@@ -512,18 +506,17 @@ start_idx end_idx =
       let b_lin = Shape.ravel_index b_idx b_strides in
       Shape.broadcast_index_into md_idx c_shape c_idx;
       let c_lin = Shape.ravel_index c_idx c_strides in
-      let a = Array.unsafe_get true_arr  (a_offset + a_lin) in
+      let out_lin = Shape.ravel_index md_idx out_strides in
+      let a = Array.unsafe_get true_arr (a_offset + a_lin) in
       let b = Array.unsafe_get false_arr (b_offset + b_lin) in
-      let c = Array.unsafe_get cond_arr  (c_offset + c_lin) in
-      Array.unsafe_set out_arr (out_offset + k)
-        (if c then a else b)
+      let c = Array.unsafe_get cond_arr (c_offset + c_lin) in
+      Array.unsafe_set out_arr (out_offset + out_lin) (if c then a else b)
     done
 
-    let where_int64
+let where_int64
     cond_arr true_arr false_arr out_arr
     vcond vtrue vfalse vout
     start_idx end_idx =
-
   let[@inline] select_i64x2
       (mask : Int64x2.t)
       (a : Int64x2.t)
@@ -532,18 +525,15 @@ start_idx end_idx =
       (Int64x2.bitwise_and mask a)
       (Int64x2.bitwise_and (Int64x2.bitwise_not mask) b)
   in
-
   let[@inline] mask2 cond_arr base i =
-    let m0 = if Array.unsafe_get cond_arr (base + i)     then -#1L else #0L in
+    let m0 = if Array.unsafe_get cond_arr (base + i) then -#1L else #0L in
     let m1 = if Array.unsafe_get cond_arr (base + i + 1) then -#1L else #0L in
     Int64x2.set m0 m1
   in
-
   let cond_base = View.offset vcond + start_idx in
-  let out_base  = View.offset vout  + start_idx in
-  let a_base    = View.offset vtrue + start_idx in
-  let b_base    = View.offset vfalse + start_idx in
-
+  let out_base = View.offset vout + start_idx in
+  let a_base = View.offset vtrue + start_idx in
+  let b_base = View.offset vfalse + start_idx in
   if
     View.is_c_contiguous vout &&
     View.is_c_contiguous vtrue &&
@@ -552,31 +542,53 @@ start_idx end_idx =
   then (
     let i = ref 0 in
     let n = end_idx - start_idx in
-
+    let n8 = n - 7 in
+    while !i < n8 do
+      let idx = !i in
+      let a0 = Int64x2.Array.unsafe_get true_arr ~idx:(a_base + idx) in
+      let b0 = Int64x2.Array.unsafe_get false_arr ~idx:(b_base + idx) in
+      let m0 = mask2 cond_arr cond_base idx in
+      let a1 = Int64x2.Array.unsafe_get true_arr ~idx:(a_base + idx + 2) in
+      let b1 = Int64x2.Array.unsafe_get false_arr ~idx:(b_base + idx + 2) in
+      let m1 = mask2 cond_arr cond_base (idx + 2) in
+      let a2 = Int64x2.Array.unsafe_get true_arr ~idx:(a_base + idx + 4) in
+      let b2 = Int64x2.Array.unsafe_get false_arr ~idx:(b_base + idx + 4) in
+      let m2 = mask2 cond_arr cond_base (idx + 4) in
+      let a3 = Int64x2.Array.unsafe_get true_arr ~idx:(a_base + idx + 6) in
+      let b3 = Int64x2.Array.unsafe_get false_arr ~idx:(b_base + idx + 6) in
+      let m3 = mask2 cond_arr cond_base (idx + 6) in
+      Int64x2.Array.unsafe_set out_arr ~idx:(out_base + idx)
+        (select_i64x2 m0 a0 b0);
+      Int64x2.Array.unsafe_set out_arr ~idx:(out_base + idx + 2)
+        (select_i64x2 m1 a1 b1);
+      Int64x2.Array.unsafe_set out_arr ~idx:(out_base + idx + 4)
+        (select_i64x2 m2 a2 b2);
+      Int64x2.Array.unsafe_set out_arr ~idx:(out_base + idx + 6)
+        (select_i64x2 m3 a3 b3);
+      i := idx + 8
+    done;
     let n2 = n - 1 in
     while !i < n2 do
       let idx = !i in
-      let a = Int64x2.Array.unsafe_get true_arr  ~idx:(a_base + idx) in
+      let a = Int64x2.Array.unsafe_get true_arr ~idx:(a_base + idx) in
       let b = Int64x2.Array.unsafe_get false_arr ~idx:(b_base + idx) in
       let m = mask2 cond_arr cond_base idx in
       Int64x2.Array.unsafe_set out_arr ~idx:(out_base + idx)
         (select_i64x2 m a b);
       i := idx + 2
     done;
-
     while !i < n do
       let idx = !i in
-      let a = Array.unsafe_get true_arr  (a_base + idx) in
+      let a = Array.unsafe_get true_arr (a_base + idx) in
       let b = Array.unsafe_get false_arr (b_base + idx) in
-      let c = Array.unsafe_get cond_arr  (cond_base + idx) in
-      Array.unsafe_set out_arr (out_base + idx)
-        (if c then a else b);
+      let c = Array.unsafe_get cond_arr (cond_base + idx) in
+      Array.unsafe_set out_arr (out_base + idx) (if c then a else b);
       incr i
     done
   )
   else
-    (* ---- generic broadcasted path ---- *)
     let out_shape = shape vout in
+    let out_strides = View.strides vout in
     let a_shape = shape vtrue in
     let b_shape = shape vfalse in
     let c_shape = shape vcond in
@@ -599,9 +611,9 @@ start_idx end_idx =
       let b_lin = Shape.ravel_index b_idx b_strides in
       Shape.broadcast_index_into md_idx c_shape c_idx;
       let c_lin = Shape.ravel_index c_idx c_strides in
-      let a = Array.unsafe_get true_arr  (a_offset + a_lin) in
+      let out_lin = Shape.ravel_index md_idx out_strides in
+      let a = Array.unsafe_get true_arr (a_offset + a_lin) in
       let b = Array.unsafe_get false_arr (b_offset + b_lin) in
-      let c = Array.unsafe_get cond_arr  (c_offset + c_lin) in
-      Array.unsafe_set out_arr (out_offset + k)
-        (if c then a else b)
+      let c = Array.unsafe_get cond_arr (c_offset + c_lin) in
+      Array.unsafe_set out_arr (out_offset + out_lin) (if c then a else b)
     done

--- a/dev/nx-oxcaml/test/test_nx_oxcaml.ml
+++ b/dev/nx-oxcaml/test/test_nx_oxcaml.ml
@@ -10,6 +10,8 @@ module View = Nx_core.View
 module Symbolic_shape = Nx_core.Symbolic_shape
 module Float_u = Stdlib_upstream_compatible.Float_u
 module Float32_u = Stdlib_stable.Float32_u
+module Int8_u = Stdlib_stable.Int8_u
+module Int16_u = Stdlib_stable.Int16_u
 module Int32_u = Stdlib_upstream_compatible.Int32_u
 module Int64_u = Stdlib_upstream_compatible.Int64_u
 
@@ -35,6 +37,8 @@ let check_float32 name ~eps exp act =
        (Float32_u.to_float (Float32_u.abs (Float32_u.sub exp act)))
     < eps)
 
+let check_int8 name exp act = check name (Int8_u.equal exp act)
+let check_int16 name exp act = check name (Int16_u.equal exp act)
 let check_int32 name exp act = check name (Int32_u.equal exp act)
 let check_int64 name exp act = check name (Int64_u.equal exp act)
 let check_bool name exp act = check name (exp == act)
@@ -46,6 +50,8 @@ let numel v =
 
 let get64 (Nx_oxcaml.Float64 a) i = array_get a i
 let get32 (Nx_oxcaml.Float32 a) i = array_get a i
+let geti8 (Nx_oxcaml.Int8 a) i = array_get a i
+let geti16 (Nx_oxcaml.Int16 a) i = array_get a i
 let geti32 (Nx_oxcaml.Int32 a) i = array_get a i
 let geti64 (Nx_oxcaml.Int64 a) i = array_get a i
 let getbool (Nx_oxcaml.Bool a) i = array_get a i
@@ -970,50 +976,50 @@ let test_where_int64_zero_negative () =
   check_int64 "where_int64_zero_neg[1]" #6L (geti64 d 1);
   check_int64 "where_int64_zero_neg[2]" #7L (geti64 d 2);
   check_int64 "where_int64_zero_neg[3]" #3L (geti64 d 3)
-(*     Failing due to int8 and int16 not being supported in Nx_oxcaml backend yet        
-  let test_where_int8_basic () =
-    let ctx = Nx_oxcaml.create_context () in
-    let cond =
-      Nx_oxcaml.of_bool ctx
-        [| true; false; true; false |]
-    in
-    let if_true =
-      Nx_oxcaml.of_int8 ctx
-        [| #1s; #2s; #3s; #4s |]
-    in
-    let if_false =
-      Nx_oxcaml.of_int8 ctx
-        [| #10s; #20s; #30s; #40s |]
-    in
-    let out = Nx_oxcaml.op_buffer ctx Dtype.Int8 4 in
-    Nx_oxcaml.op_where ~out cond if_true if_false;
-    let d = Nx_oxcaml.data_array out in
-    check_int8 "where_int8[0]" #1s (geti8 d 0);
-    check_int8 "where_int8[1]" #20s (geti8 d 1);
-    check_int8 "where_int8[2]" #3s (geti8 d 2);
-    check_int8 "where_int8[3]" #40s (geti8 d 3)
 
-    let test_where_int16_zero_negative () =
-      let ctx = Nx_oxcaml.create_context () in
-      let cond =
-        Nx_oxcaml.of_bool ctx
-          [| true; false; false; true |]
-      in
-      let if_true =
-        Nx_oxcaml.of_int16 ctx
-          [| #0S; -#1S; -#2S; #3S |]
-      in
-      let if_false =
-        Nx_oxcaml.of_int16 ctx
-          [| #5S; #6S; #7S; #8S |]
-      in
-      let out = Nx_oxcaml.op_buffer ctx Dtype.Int16 4 in
-      Nx_oxcaml.op_where ~out cond if_true if_false;
-      let d = Nx_oxcaml.data_array out in
-      check_int16 "where_int16_zero_neg[0]" #0S (geti16 d 0);
-      check_int16 "where_int16_zero_neg[1]" #6S (geti16 d 1);
-      check_int16 "where_int16_zero_neg[2]" #7S (geti16 d 2);
-      check_int16 "where_int16_zero_neg[3]" #3S (geti16 d 3) *)
+let test_where_int8_basic () =
+  let ctx = Nx_oxcaml.create_context () in
+  let cond =
+    Nx_oxcaml.of_bool ctx
+      [| true; false; true; false |]
+  in
+  let if_true =
+    Nx_oxcaml.of_int8 ctx
+      [| #1s; #2s; #3s; #4s |]
+  in
+  let if_false =
+    Nx_oxcaml.of_int8 ctx
+      [| #10s; #20s; #30s; #40s |]
+  in
+  let out = Nx_oxcaml.op_buffer ctx Dtype.Int8 4 in
+  Nx_oxcaml.op_where ~out cond if_true if_false;
+  let d = Nx_oxcaml.data_array out in
+  check_int8 "where_int8[0]" #1s (geti8 d 0);
+  check_int8 "where_int8[1]" #20s (geti8 d 1);
+  check_int8 "where_int8[2]" #3s (geti8 d 2);
+  check_int8 "where_int8[3]" #40s (geti8 d 3)
+
+let test_where_int16_zero_negative () =
+  let ctx = Nx_oxcaml.create_context () in
+  let cond =
+    Nx_oxcaml.of_bool ctx
+      [| true; false; false; true |]
+  in
+  let if_true =
+    Nx_oxcaml.of_int16 ctx
+      [| #0S; -#1S; -#2S; #3S |]
+  in
+  let if_false =
+    Nx_oxcaml.of_int16 ctx
+      [| #5S; #6S; #7S; #8S |]
+  in
+  let out = Nx_oxcaml.op_buffer ctx Dtype.Int16 4 in
+  Nx_oxcaml.op_where ~out cond if_true if_false;
+  let d = Nx_oxcaml.data_array out in
+  check_int16 "where_int16_zero_neg[0]" #0S (geti16 d 0);
+  check_int16 "where_int16_zero_neg[1]" #6S (geti16 d 1);
+  check_int16 "where_int16_zero_neg[2]" #7S (geti16 d 2);
+  check_int16 "where_int16_zero_neg[3]" #3S (geti16 d 3)
     
 let () =
   print_endline "Running Nx_oxcaml backend tests...";
@@ -1097,5 +1103,7 @@ let () =
   test_where_int32_basic ();
   test_where_int32_zero_negative ();
   test_where_int64_zero_negative ();
+  test_where_int8_basic ();
+  test_where_int16_zero_negative ();
   Printf.printf "\nResults: %d passed, %d failed\n" !passed !failed;
   if !failed > 0 then exit 1


### PR DESCRIPTION
## Initial Approach
Same iteration logic with `if cond then a else b`
Does not work for SIMD instructions which need a mask for different lanes

## (Next) Integer mask
Use a function called `mask2`(for 64 bit) and `mask4`(for 32 bit) which gets integers of same size. `mask2` has 2 integers and `mask4` has has 4 integers. After this these masks are used in a `select` function. 
where the logic would follow
`result = (if_true AND mask) OR ( (NOT if_false) AND mask)`

## float32 bit corruption
The following line
`let[@inline] of_int32x4 x = Int32x4.cvt_f32 x`
overrides the `of_int32x4` bitcast(which is expected by SIMD masks) to a int to float conversion. This was leading to bit corruption in the float32 op_where. So, decided to comment it out for the time being, since it's not breaking any other tests.

## tests are failing for int16 and int8 with the following error
```
File "lib/nx_oxcaml.ml", line 87, characters 12-23:
87 |   { dtype = Dtype.Int16; buffer = Int16 arr; view; context }
                 ^^^^^^^^^^^
Error: This expression has type (int, Dtype.int16_elt) Dtype.t
       but an expression was expected of type
         (int16, Dtype.int16_elt) Dtype.t
       Type int is not compatible with type int16
```