### PR TITLE
feat(nx): fix rfft on Float32 input and add DCT/DST transforms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,14 @@ thread.
 
 ### Nx
 
+- **Breaking:** `rfft`, `irfft`, `rfft2`, `irfft2`, `rfftn`, `irfftn`, `hfft`,
+  and `ihfft` now require an explicit `~dtype` parameter that selects the output
+  precision. Use `~dtype:complex128` (or `~dtype:float64` for inverse) for the
+  previous behavior. This fixes Float32 input crashing and enables single-precision
+  FFT: `rfft ~dtype:complex64` with Float32 input returns Complex64 output.
+- Add DCT and DST (Discrete Cosine/Sine Transform) to the public API: `dct`,
+  `idct`, `dctn`, `idctn`, `dst`, `idst`, `dstn`, `idstn`. All support types
+  1–4, ortho/backward/forward normalization, and both float32 and float64.
 - Remove `~out` parameter from all backend compute operations. Operations now
   allocate and return their result instead of writing to a caller-provided
   buffer. This simplifies the effect system, fixes vmap, and prepares the

--- a/packages/nx-oxcaml/lib/nx_backend.ml
+++ b/packages/nx-oxcaml/lib/nx_backend.ml
@@ -1951,6 +1951,12 @@ let rfft ?out:_ _ ~dtype:_ ~axes:_ =
 let irfft ?out:_ ?s:_ _ ~dtype:_ ~axes:_ =
   invalid_arg "irfft: not implemented"
 
+let dct _ ~dct_type:_ ~ortho:_ ~axes:_ =
+  invalid_arg "dct: not implemented"
+
+let dst _ ~dst_type:_ ~ortho:_ ~axes:_ =
+  invalid_arg "dst: not implemented"
+
 let cholesky ~upper:_ _ =
   invalid_arg "cholesky: not implemented"
 

--- a/packages/nx/lib/backend_c/nx_backend.ml
+++ b/packages/nx/lib/backend_c/nx_backend.ml
@@ -1035,6 +1035,64 @@ let irfft (type a b c d) ?out ?s (x : (a, b) t) ~(dtype : (c, d) Dtype.t) ~axes
 
   out
 
+let dct (type a b) (x : (a, b) t) ~dct_type ~ortho ~axes : (a, b) t =
+  let x' = materialize x in
+  let in_shape = shape x' in
+  let out_shape = Array.copy in_shape in
+  let out = create_tensor x.context x.dtype out_shape in
+  let elem_size = Dtype.itemsize x.dtype in
+  let strides_in = contiguous_strides in_shape elem_size in
+  let strides_out = contiguous_strides out_shape elem_size in
+  let ndim = Array.length in_shape in
+  let axes_normalized =
+    Array.map (fun ax -> if ax < 0 then ndim + ax else ax) axes
+  in
+  (match (x.dtype : (a, b) Dtype.t) with
+  | Dtype.Float32 ->
+      Pocketfft.dct_f32 ~shape:in_shape ~stride_in:strides_in
+        ~stride_out:strides_out ~axes:axes_normalized ~dct_type ~ortho ~fct:1.0
+        ~data_in:(Nx_buffer.to_bigarray1 x'.buffer)
+        ~data_out:(Nx_buffer.to_bigarray1 out.buffer)
+        ~nthreads:1
+  | Dtype.Float64 ->
+      Pocketfft.dct_f64 ~shape:in_shape ~stride_in:strides_in
+        ~stride_out:strides_out ~axes:axes_normalized ~dct_type ~ortho ~fct:1.0
+        ~data_in:(Nx_buffer.to_bigarray1 x'.buffer)
+        ~data_out:(Nx_buffer.to_bigarray1 out.buffer)
+        ~nthreads:1
+  | _ -> invalid_arg "dct: unsupported dtype (must be float32 or float64)");
+  out
+
+let dst (type a b) (x : (a, b) t) ~dst_type ~ortho ~axes : (a, b) t =
+  let x' = materialize x in
+  let in_shape = shape x' in
+  let out_shape = Array.copy in_shape in
+  let out = create_tensor x.context x.dtype out_shape in
+  let elem_size = Dtype.itemsize x.dtype in
+  let strides_in = contiguous_strides in_shape elem_size in
+  let strides_out = contiguous_strides out_shape elem_size in
+  let ndim = Array.length in_shape in
+  let axes_normalized =
+    Array.map (fun ax -> if ax < 0 then ndim + ax else ax) axes
+  in
+  (match (x.dtype : (a, b) Dtype.t) with
+  | Dtype.Float32 ->
+      Pocketfft.dst_f32 ~shape:in_shape ~stride_in:strides_in
+        ~stride_out:strides_out ~axes:axes_normalized ~dct_type:dst_type ~ortho
+        ~fct:1.0
+        ~data_in:(Nx_buffer.to_bigarray1 x'.buffer)
+        ~data_out:(Nx_buffer.to_bigarray1 out.buffer)
+        ~nthreads:1
+  | Dtype.Float64 ->
+      Pocketfft.dst_f64 ~shape:in_shape ~stride_in:strides_in
+        ~stride_out:strides_out ~axes:axes_normalized ~dct_type:dst_type ~ortho
+        ~fct:1.0
+        ~data_in:(Nx_buffer.to_bigarray1 x'.buffer)
+        ~data_out:(Nx_buffer.to_bigarray1 out.buffer)
+        ~nthreads:1
+  | _ -> invalid_arg "dst: unsupported dtype (must be float32 or float64)");
+  out
+
 (* ───── Linear Algebra Operations ───── *)
 
 let cholesky ~upper x =

--- a/packages/nx/lib/core/backend_intf.ml
+++ b/packages/nx/lib/core/backend_intf.ml
@@ -551,6 +551,24 @@ module type S = sig
       specifies output sizes along the transformed axes; [None] infers sizes
       from the input. *)
 
+  val dct :
+    (float, 'a) t ->
+    dct_type:int ->
+    ortho:bool ->
+    axes:int array ->
+    (float, 'a) t
+  (** [dct t ~dct_type ~ortho ~axes] computes the Discrete Cosine Transform
+      along [axes]. [dct_type] is 1, 2, 3, or 4. *)
+
+  val dst :
+    (float, 'a) t ->
+    dst_type:int ->
+    ortho:bool ->
+    axes:int array ->
+    (float, 'a) t
+  (** [dst t ~dst_type ~ortho ~axes] computes the Discrete Sine Transform
+      along [axes]. [dst_type] is 1, 2, 3, or 4. *)
+
   (** {1 Linear Algebra}
 
       All linalg operations support batching: the last two dimensions are the

--- a/packages/nx/lib/core/frontend.ml
+++ b/packages/nx/lib/core/frontend.ml
@@ -3682,15 +3682,15 @@ module Make (B : Backend_intf.S) = struct
     let r = B.ifft xp ~axes:(Array.of_list axes_list) in
     apply_fft_scale scale r
 
-  let rfftn ?axes ?s ?(norm = `Backward) x =
+  let rfftn ~dtype ?axes ?s ?(norm = `Backward) x =
     let nd = ndim x in
     let axes_list = match axes with None -> [ nd - 1 ] | Some ax -> ax in
     let xp = pad_or_truncate_for_fft x axes_list s in
     let scale = fft_norm_scale norm axes_list xp in
-    let r = B.rfft xp ~dtype:Dtype.Complex128 ~axes:(Array.of_list axes_list) in
+    let r = B.rfft xp ~dtype ~axes:(Array.of_list axes_list) in
     apply_fft_scale scale r
 
-  let irfftn ?axes ?s ?(norm = `Backward) x =
+  let irfftn ~dtype ?axes ?s ?(norm = `Backward) x =
     let nd = ndim x in
     let axes_list = match axes with None -> [ nd - 1 ] | Some ax -> ax in
     let input_shape = shape x in
@@ -3716,7 +3716,7 @@ module Make (B : Backend_intf.S) = struct
       match s with None -> None | Some _ -> Some (Array.of_list output_sizes)
     in
     let r =
-      B.irfft ?s:s_param x ~dtype:Dtype.Float64 ~axes:(Array.of_list axes_list)
+      B.irfft ?s:s_param x ~dtype ~axes:(Array.of_list axes_list)
     in
     if norm_scale <> 1.0 then
       mul r (scalar (B.context r) (B.dtype r) norm_scale)
@@ -3731,13 +3731,13 @@ module Make (B : Backend_intf.S) = struct
     let s = match n with None -> None | Some sz -> Some [ sz ] in
     ifftn x ~axes:[ axis ] ?s ~norm
 
-  let rfft ?(axis = -1) ?n ?(norm = `Backward) x =
+  let rfft ?(axis = -1) ?n ?(norm = `Backward) ~dtype x =
     let s = match n with None -> None | Some sz -> Some [ sz ] in
-    rfftn x ~axes:[ axis ] ?s ~norm
+    rfftn ~dtype x ~axes:[ axis ] ?s ~norm
 
-  let irfft ?(axis = -1) ?n ?(norm = `Backward) x =
+  let irfft ?(axis = -1) ?n ?(norm = `Backward) ~dtype x =
     let s = match n with None -> None | Some sz -> Some [ sz ] in
-    irfftn x ~axes:[ axis ] ?s ~norm
+    irfftn ~dtype x ~axes:[ axis ] ?s ~norm
 
   (* 2D FFT *)
 
@@ -3771,36 +3771,36 @@ module Make (B : Backend_intf.S) = struct
         (match axes with None -> List.init (ndim x) Fun.id | Some ax -> ax)
       ?s ~norm
 
-  let rfft2 ?axes ?s ?(norm = `Backward) x =
+  let rfft2 ?axes ?s ?(norm = `Backward) ~dtype x =
     let axes_list = check_fft2 ~op:"rfft2" x axes in
-    rfftn x ~axes:axes_list ?s ~norm
+    rfftn ~dtype x ~axes:axes_list ?s ~norm
 
-  let irfft2 ?axes ?s ?(norm = `Backward) x =
+  let irfft2 ?axes ?s ?(norm = `Backward) ~dtype x =
     let axes_list = check_fft2 ~op:"irfft2" x axes in
-    irfftn x ~axes:axes_list ?s ~norm
+    irfftn ~dtype x ~axes:axes_list ?s ~norm
 
-  let rfftn ?axes ?s ?(norm = `Backward) x =
-    rfftn x
+  let rfftn ?axes ?s ?(norm = `Backward) ~dtype x =
+    rfftn ~dtype x
       ~axes:
         (match axes with None -> List.init (ndim x) Fun.id | Some ax -> ax)
       ?s ~norm
 
-  let irfftn ?axes ?s ?(norm = `Backward) x =
-    irfftn x
+  let irfftn ?axes ?s ?(norm = `Backward) ~dtype x =
+    irfftn ~dtype x
       ~axes:
         (match axes with None -> List.init (ndim x) Fun.id | Some ax -> ax)
       ?s ~norm
 
   (* Hermitian FFT *)
-  let hfft ?(axis = -1) ?n ?norm x =
+  let hfft ?(axis = -1) ?n ?(norm = `Backward) ~dtype x =
     let n = match n with None -> 2 * (dim axis x - 1) | Some n -> n in
     let axis = resolve_single_axis x axis in
-    irfftn x ~axes:[ axis ] ~s:[ n ] ?norm
+    irfftn ~dtype x ~axes:[ axis ] ~s:[ n ] ~norm
 
-  let ihfft ?(axis = -1) ?n ?norm x =
+  let ihfft ?(axis = -1) ?n ?(norm = `Backward) ~dtype x =
     let n = match n with None -> dim axis x | Some n -> n in
     let axis = resolve_single_axis x axis in
-    rfftn x ~axes:[ axis ] ~s:[ n ] ?norm
+    rfftn ~dtype x ~axes:[ axis ] ~s:[ n ] ~norm
 
   (* FFT helpers *)
   let fftfreq ctx ?(d = 1.0) n =
@@ -3852,6 +3852,70 @@ module Make (B : Backend_intf.S) = struct
         let axis = resolve_single_axis acc axis in
         roll (-(sh.(axis) / 2)) acc ~axis)
       x axes_list
+
+  (* ───── Discrete Cosine / Sine Transforms ───── *)
+
+  let dctn ?(type_ = 2) ?(norm = `Backward) ?axes x =
+    let nd = ndim x in
+    let axes_list =
+      match axes with None -> List.init nd Fun.id | Some ax -> ax
+    in
+    if type_ < 1 || type_ > 4 then
+      invalid_arg "dct: type must be 1, 2, 3, or 4";
+    let ortho = norm = `Ortho in
+    let r = B.dct x ~dct_type:type_ ~ortho ~axes:(Array.of_list axes_list) in
+    if (not ortho) && norm = `Forward then
+      let n =
+        List.fold_left
+          (fun acc ax ->
+            let ax = if ax < 0 then nd + ax else ax in
+            acc * (shape x).(ax))
+          1 axes_list
+      in
+      mul r (scalar (B.context r) (B.dtype r) (1.0 /. float_of_int n))
+    else r
+
+  let dstn ?(type_ = 2) ?(norm = `Backward) ?axes x =
+    let nd = ndim x in
+    let axes_list =
+      match axes with None -> List.init nd Fun.id | Some ax -> ax
+    in
+    if type_ < 1 || type_ > 4 then
+      invalid_arg "dst: type must be 1, 2, 3, or 4";
+    let ortho = norm = `Ortho in
+    let r = B.dst x ~dst_type:type_ ~ortho ~axes:(Array.of_list axes_list) in
+    if (not ortho) && norm = `Forward then
+      let n =
+        List.fold_left
+          (fun acc ax ->
+            let ax = if ax < 0 then nd + ax else ax in
+            acc * (shape x).(ax))
+          1 axes_list
+      in
+      mul r (scalar (B.context r) (B.dtype r) (1.0 /. float_of_int n))
+    else r
+
+  let dct ?(type_ = 2) ?(axis = -1) ?(norm = `Backward) x =
+    dctn ~type_ ~norm ~axes:[ axis ] x
+
+  let dst ?(type_ = 2) ?(axis = -1) ?(norm = `Backward) x =
+    dstn ~type_ ~norm ~axes:[ axis ] x
+
+  let idct ?(type_ = 2) ?(axis = -1) ?(norm = `Backward) x =
+    let inv_type = match type_ with 2 -> 3 | 3 -> 2 | t -> t in
+    dct ~type_:inv_type ~axis ~norm x
+
+  let idst ?(type_ = 2) ?(axis = -1) ?(norm = `Backward) x =
+    let inv_type = match type_ with 2 -> 3 | 3 -> 2 | t -> t in
+    dst ~type_:inv_type ~axis ~norm x
+
+  let idctn ?(type_ = 2) ?(norm = `Backward) ?axes x =
+    let inv_type = match type_ with 2 -> 3 | 3 -> 2 | t -> t in
+    dctn ~type_:inv_type ~norm ?axes x
+
+  let idstn ?(type_ = 2) ?(norm = `Backward) ?axes x =
+    let inv_type = match type_ with 2 -> 3 | 3 -> 2 | t -> t in
+    dstn ~type_:inv_type ~norm ?axes x
 
   (* ───── Neural Network Operations ───── *)
 

--- a/packages/nx/lib/effect/nx_effect.ml
+++ b/packages/nx/lib/effect/nx_effect.ml
@@ -593,6 +593,14 @@ let irfft (type a c) ?out ?s (t : (Complex.t, a) t)
   in
   (T result : (float, c) t)
 
+(* DCT/DST — direct backend calls, no effects needed *)
+
+let dct t ~dct_type ~ortho ~axes =
+  T (Nx_backend.dct (unwrap t) ~dct_type ~ortho ~axes)
+
+let dst t ~dst_type ~ortho ~axes =
+  T (Nx_backend.dst (unwrap t) ~dst_type ~ortho ~axes)
+
 (* Linear algebra *)
 
 let cholesky ~upper t_in =

--- a/packages/nx/lib/nx.mli
+++ b/packages/nx/lib/nx.mli
@@ -2460,17 +2460,17 @@ val rfft :
   ?axis:int ->
   ?n:int ->
   ?norm:fft_norm ->
+  dtype:(Complex.t, 'b) dtype ->
   (float, 'a) t ->
-  (Complex.t, complex64_elt) t
-(** [rfft ?axis ?n ?norm x] is the 1-D FFT of real input. Returns only the
-    non-redundant positive frequencies; the output size along the transformed
-    axis is [n/2 + 1].
+  (Complex.t, 'b) t
+(** [rfft ?axis ?n ?norm ~dtype x] is the 1-D FFT of real input. Returns only
+    the non-redundant positive frequencies; the output size along the
+    transformed axis is [n/2 + 1]. [dtype] selects the output precision:
+    [complex64] for single precision, [complex128] for double.
 
-    {@ocaml[
-      # create float64 [| 4 |] [| 0.; 1.; 2.; 3. |]
-        |> rfft |> shape
-      - : int array = [|3|]
-    ]}
+    The input and output precisions must be compatible:
+    - [Float32] input with [~dtype:complex64]
+    - [Float64] input with [~dtype:complex128]
 
     See also {!irfft}, {!fft}. *)
 
@@ -2478,10 +2478,12 @@ val irfft :
   ?axis:int ->
   ?n:int ->
   ?norm:fft_norm ->
+  dtype:(float, 'b) dtype ->
   (Complex.t, 'a) t ->
-  (float, float64_elt) t
-(** [irfft ?axis ?n ?norm x] is the inverse of {!rfft}, producing real output.
-    Assumes Hermitian symmetry.
+  (float, 'b) t
+(** [irfft ?axis ?n ?norm ~dtype x] is the inverse of {!rfft}, producing real
+    output. Assumes Hermitian symmetry. [dtype] selects the output precision:
+    [float32] or [float64].
 
     See also {!rfft}. *)
 
@@ -2489,9 +2491,10 @@ val rfft2 :
   ?axes:int list ->
   ?s:int list ->
   ?norm:fft_norm ->
+  dtype:(Complex.t, 'b) dtype ->
   (float, 'a) t ->
-  (Complex.t, complex64_elt) t
-(** [rfft2 ?axes ?s ?norm x] is the 2-D FFT of real input.
+  (Complex.t, 'b) t
+(** [rfft2 ?axes ?s ?norm ~dtype x] is the 2-D FFT of real input.
 
     See also {!irfft2}, {!rfft}. *)
 
@@ -2499,17 +2502,19 @@ val irfft2 :
   ?axes:int list ->
   ?s:int list ->
   ?norm:fft_norm ->
+  dtype:(float, 'b) dtype ->
   (Complex.t, 'a) t ->
-  (float, float64_elt) t
-(** [irfft2 ?axes ?s ?norm x] is the inverse of {!rfft2}. *)
+  (float, 'b) t
+(** [irfft2 ?axes ?s ?norm ~dtype x] is the inverse of {!rfft2}. *)
 
 val rfftn :
   ?axes:int list ->
   ?s:int list ->
   ?norm:fft_norm ->
+  dtype:(Complex.t, 'b) dtype ->
   (float, 'a) t ->
-  (Complex.t, complex64_elt) t
-(** [rfftn ?axes ?s ?norm x] is the N-D FFT of real input.
+  (Complex.t, 'b) t
+(** [rfftn ?axes ?s ?norm ~dtype x] is the N-D FFT of real input.
 
     See also {!irfftn}, {!rfft}. *)
 
@@ -2517,26 +2522,29 @@ val irfftn :
   ?axes:int list ->
   ?s:int list ->
   ?norm:fft_norm ->
+  dtype:(float, 'b) dtype ->
   (Complex.t, 'a) t ->
-  (float, float64_elt) t
-(** [irfftn ?axes ?s ?norm x] is the inverse of {!rfftn}. *)
+  (float, 'b) t
+(** [irfftn ?axes ?s ?norm ~dtype x] is the inverse of {!rfftn}. *)
 
 val hfft :
   ?axis:int ->
   ?n:int ->
   ?norm:fft_norm ->
+  dtype:(float, 'b) dtype ->
   (Complex.t, 'a) t ->
-  (float, float64_elt) t
-(** [hfft ?axis ?n ?norm x] is the FFT of a signal with Hermitian symmetry,
-    producing real output. *)
+  (float, 'b) t
+(** [hfft ?axis ?n ?norm ~dtype x] is the FFT of a signal with Hermitian
+    symmetry, producing real output. *)
 
 val ihfft :
   ?axis:int ->
   ?n:int ->
   ?norm:fft_norm ->
+  dtype:(Complex.t, 'b) dtype ->
   (float, 'a) t ->
-  (Complex.t, complex64_elt) t
-(** [ihfft ?axis ?n ?norm x] is the inverse of {!hfft}. *)
+  (Complex.t, 'b) t
+(** [ihfft ?axis ?n ?norm ~dtype x] is the inverse of {!hfft}. *)
 
 val fftfreq : ?d:float -> int -> (float, float64_elt) t
 (** [fftfreq ?d n] is the DFT sample frequencies for window length [n] and
@@ -2568,6 +2576,81 @@ val fftshift : ?axes:int list -> ('a, 'b) t -> ('a, 'b) t
 
 val ifftshift : ?axes:int list -> ('a, 'b) t -> ('a, 'b) t
 (** [ifftshift ?axes t] is the inverse of {!fftshift}. *)
+
+(** {2:dct Discrete Cosine and Sine Transforms} *)
+
+val dct :
+  ?type_:int ->
+  ?axis:int ->
+  ?norm:fft_norm ->
+  (float, 'a) t ->
+  (float, 'a) t
+(** [dct ?type_ ?axis ?norm x] computes the 1-D Discrete Cosine Transform
+    along [axis] (default [-1]). [type_] selects the DCT variant (1–4,
+    default 2). [norm] defaults to [`Backward].
+
+    See also {!idct}, {!dctn}. *)
+
+val idct :
+  ?type_:int ->
+  ?axis:int ->
+  ?norm:fft_norm ->
+  (float, 'a) t ->
+  (float, 'a) t
+(** [idct ?type_ ?axis ?norm x] is the inverse of {!dct}. DCT-II and DCT-III
+    are inverses of each other, as are DCT-I and DCT-IV of themselves. *)
+
+val dctn :
+  ?type_:int ->
+  ?norm:fft_norm ->
+  ?axes:int list ->
+  (float, 'a) t ->
+  (float, 'a) t
+(** [dctn ?type_ ?norm ?axes x] computes the N-D DCT. [axes] defaults to all. *)
+
+val idctn :
+  ?type_:int ->
+  ?norm:fft_norm ->
+  ?axes:int list ->
+  (float, 'a) t ->
+  (float, 'a) t
+(** [idctn ?type_ ?norm ?axes x] is the inverse of {!dctn}. *)
+
+val dst :
+  ?type_:int ->
+  ?axis:int ->
+  ?norm:fft_norm ->
+  (float, 'a) t ->
+  (float, 'a) t
+(** [dst ?type_ ?axis ?norm x] computes the 1-D Discrete Sine Transform
+    along [axis] (default [-1]). [type_] selects the DST variant (1–4,
+    default 2). [norm] defaults to [`Backward].
+
+    See also {!idst}, {!dstn}. *)
+
+val idst :
+  ?type_:int ->
+  ?axis:int ->
+  ?norm:fft_norm ->
+  (float, 'a) t ->
+  (float, 'a) t
+(** [idst ?type_ ?axis ?norm x] is the inverse of {!dst}. *)
+
+val dstn :
+  ?type_:int ->
+  ?norm:fft_norm ->
+  ?axes:int list ->
+  (float, 'a) t ->
+  (float, 'a) t
+(** [dstn ?type_ ?norm ?axes x] computes the N-D DST. [axes] defaults to all. *)
+
+val idstn :
+  ?type_:int ->
+  ?norm:fft_norm ->
+  ?axes:int list ->
+  (float, 'a) t ->
+  (float, 'a) t
+(** [idstn ?type_ ?norm ?axes x] is the inverse of {!dstn}. *)
 
 (** {1:activation Activation functions} *)
 

--- a/packages/nx/test/test_nx_fft.ml
+++ b/packages/nx/test/test_nx_fft.ml
@@ -193,11 +193,11 @@ let test_rfft_irfft () =
         sin (two_pi *. Float.of_int i /. Float.of_int n_even))
   in
   let input_even = Nx.create Nx.float64 shape_even signal_even in
-  let rfft_even = Nx.rfft input_even in
+  let rfft_even = Nx.rfft ~dtype:Nx.complex128 input_even in
   equal ~msg:"rfft even shape" (array int)
     [| (n_even / 2) + 1 |]
     (Nx.shape rfft_even);
-  let irfft_even = Nx.irfft rfft_even ~n:n_even in
+  let irfft_even = Nx.irfft ~dtype:Nx.float64 rfft_even ~n:n_even in
   check_t ~eps:1e-10 "rfft even reconstruct" shape_even signal_even irfft_even;
 
   (* 1D odd *)
@@ -205,11 +205,11 @@ let test_rfft_irfft () =
   let shape_odd = [| n_odd |] in
   let signal_odd = Array.init n_odd (fun i -> Float.of_int i) in
   let input_odd = Nx.create Nx.float64 shape_odd signal_odd in
-  let rfft_odd = Nx.rfft input_odd in
+  let rfft_odd = Nx.rfft ~dtype:Nx.complex128 input_odd in
   equal ~msg:"rfft odd shape" (array int)
     [| (n_odd / 2) + 1 |]
     (Nx.shape rfft_odd);
-  let irfft_odd = Nx.irfft rfft_odd ~n:n_odd in
+  let irfft_odd = Nx.irfft ~dtype:Nx.float64 rfft_odd ~n:n_odd in
   check_t ~eps:1e-10 "rfft odd reconstruct" shape_odd signal_odd irfft_odd;
 
   (* 2D *)
@@ -217,9 +217,9 @@ let test_rfft_irfft () =
   let shape_2d = [| m; n |] in
   let signal_2d = Array.init (m * n) Float.of_int in
   let input_2d = Nx.create Nx.float64 shape_2d signal_2d in
-  let rfft_2d = Nx.rfft2 input_2d in
+  let rfft_2d = Nx.rfft2 ~dtype:Nx.complex128 input_2d in
   equal ~msg:"rfft2 shape" (array int) [| m; (n / 2) + 1 |] (Nx.shape rfft_2d);
-  let irfft_2d = Nx.irfft2 rfft_2d ~s:[ m; n ] in
+  let irfft_2d = Nx.irfft2 ~dtype:Nx.float64 rfft_2d ~s:[ m; n ] in
   check_t "rfft2 reconstruct" shape_2d signal_2d irfft_2d;
 
   (* ND last axis transform *)
@@ -227,10 +227,10 @@ let test_rfft_irfft () =
   let size_nd = 2 * 3 * 8 in
   let signal_nd = Array.init size_nd (fun i -> Float.of_int i) in
   let input_nd = Nx.create Nx.float64 shape_nd signal_nd in
-  let rfft_nd = Nx.rfftn input_nd ~axes:[ 2 ] in
+  let rfft_nd = Nx.rfftn ~dtype:Nx.complex128 input_nd ~axes:[ 2 ] in
   equal ~msg:"rfftn last axis shape" (array int) [| 2; 3; 5 |]
     (Nx.shape rfft_nd);
-  let irfft_nd = Nx.irfftn rfft_nd ~axes:[ 2 ] ~s:[ 8 ] in
+  let irfft_nd = Nx.irfftn ~dtype:Nx.float64 rfft_nd ~axes:[ 2 ] ~s:[ 8 ] in
   check_t "rfftn last axis reconstruct" shape_nd signal_nd irfft_nd
 
 let test_rfft_axes () =
@@ -240,15 +240,15 @@ let test_rfft_axes () =
   let input = Nx.create Nx.float64 shape signal in
 
   (* Specific axis *)
-  let rfft_axis1 = Nx.rfftn input ~axes:[ 1 ] in
+  let rfft_axis1 = Nx.rfftn ~dtype:Nx.complex128 input ~axes:[ 1 ] in
   equal ~msg:"rfft axis 1" (array int) [| 4; 4; 8 |] (Nx.shape rfft_axis1);
 
   (* Multiple axes, last is halved *)
-  let rfft_axes_01 = Nx.rfftn input ~axes:[ 0; 1 ] in
+  let rfft_axes_01 = Nx.rfftn ~dtype:Nx.complex128 input ~axes:[ 0; 1 ] in
   equal ~msg:"rfft axes [0;1]" (array int) [| 4; 4; 8 |] (Nx.shape rfft_axes_01);
 
   (* Negative axis *)
-  let rfft_neg1 = Nx.rfftn input ~axes:[ -1 ] in
+  let rfft_neg1 = Nx.rfftn ~dtype:Nx.complex128 input ~axes:[ -1 ] in
   equal ~msg:"rfft axis -1" (array int) [| 4; 6; 5 |] (Nx.shape rfft_neg1)
 
 let test_rfft_size () =
@@ -261,11 +261,11 @@ let test_rfft_size () =
 
   (* Pad last axis *)
   let pad_size = 16 in
-  let rfft_padded = Nx.rfft input ~n:pad_size in
+  let rfft_padded = Nx.rfft ~dtype:Nx.complex128 input ~n:pad_size in
   equal ~msg:"rfft padded" (array int)
     [| (pad_size / 2) + 1 |]
     (Nx.shape rfft_padded);
-  let irfft_padded = Nx.irfft rfft_padded ~n in
+  let irfft_padded = Nx.irfft ~dtype:Nx.float64 rfft_padded ~n in
   (* Note: rfft(x, n=16) -> irfft(X, n=8) does NOT give back the original
      signal. This is expected behavior that matches NumPy. *)
   equal ~msg:"rfft pad reconstruct shape" (array int) shape
@@ -288,7 +288,7 @@ let test_rfft_size () =
 
   (* Truncate *)
   let trunc_size = 4 in
-  let rfft_trunc = Nx.rfft input ~n:trunc_size in
+  let rfft_trunc = Nx.rfft ~dtype:Nx.complex128 input ~n:trunc_size in
   equal ~msg:"rfft trunc" (array int)
     [| (trunc_size / 2) + 1 |]
     (Nx.shape rfft_trunc)
@@ -300,18 +300,18 @@ let test_rfft_norm () =
   let input = Nx.create Nx.float64 shape signal in
 
   (* Backward *)
-  let rfft_backward = Nx.rfft input ~norm:`Backward in
-  let irfft_backward = Nx.irfft rfft_backward ~n ~norm:`Backward in
+  let rfft_backward = Nx.rfft ~dtype:Nx.complex128 input ~norm:`Backward in
+  let irfft_backward = Nx.irfft ~dtype:Nx.float64 rfft_backward ~n ~norm:`Backward in
   check_t "rfft backward" shape signal irfft_backward;
 
   (* Forward *)
-  let rfft_forward = Nx.rfft input ~norm:`Forward in
-  let irfft_forward = Nx.irfft rfft_forward ~n ~norm:`Forward in
+  let rfft_forward = Nx.rfft ~dtype:Nx.complex128 input ~norm:`Forward in
+  let irfft_forward = Nx.irfft ~dtype:Nx.float64 rfft_forward ~n ~norm:`Forward in
   check_t "rfft forward" shape signal irfft_forward;
 
   (* Ortho *)
-  let rfft_ortho = Nx.rfft input ~norm:`Ortho in
-  let irfft_ortho = Nx.irfft rfft_ortho ~n ~norm:`Ortho in
+  let rfft_ortho = Nx.rfft ~dtype:Nx.complex128 input ~norm:`Ortho in
+  let irfft_ortho = Nx.irfft ~dtype:Nx.float64 rfft_ortho ~n ~norm:`Ortho in
   check_t "rfft ortho" shape signal irfft_ortho
 
 let test_rfft_edge_cases () =
@@ -323,9 +323,9 @@ let test_rfft_edge_cases () =
   let shape = [| 1 |] in
   let signal_data = [| 5.0 |] in
   let single = Nx.create Nx.float64 shape signal_data in
-  let rfft_single = Nx.rfft single in
+  let rfft_single = Nx.rfft ~dtype:Nx.complex128 single in
   equal ~msg:"rfft size 1 shape" (array int) [| 1 |] (Nx.shape rfft_single);
-  let irfft_single = Nx.irfft rfft_single ~n:1 in
+  let irfft_single = Nx.irfft ~dtype:Nx.float64 rfft_single ~n:1 in
   check_t "rfft size 1 reconstruct" shape signal_data irfft_single
 
 (* Test Hermitian FFT *)
@@ -336,9 +336,9 @@ let test_hfft_ihfft () =
     Array.init n (fun i -> sin (two_pi *. Float.of_int i /. Float.of_int n))
   in
   let input = Nx.create Nx.float64 shape signal in
-  let ihfft_out = Nx.ihfft input ~n in
+  let ihfft_out = Nx.ihfft ~dtype:Nx.complex128 input ~n in
   equal ~msg:"ihfft shape" (array int) [| (n / 2) + 1 |] (Nx.shape ihfft_out);
-  let hfft_out = Nx.hfft ihfft_out ~n in
+  let hfft_out = Nx.hfft ~dtype:Nx.float64 ihfft_out ~n in
   check_t "hfft/ihfft" shape signal hfft_out
 
 (* Test helper routines *)
@@ -388,6 +388,153 @@ let test_fftshift () =
   let unshifted = Nx.ifftshift shifted in
   check_t "ifftshift 1D" x_shape x_data unshifted
 
+(* Test rfft with float32 input (was crashing before fix) *)
+let test_rfft_float32 () =
+  let n = 8 in
+  let shape = [| n |] in
+  let signal =
+    Array.init n (fun i ->
+        sin (two_pi *. Float.of_int i /. Float.of_int n))
+  in
+  let input = Nx.create Nx.float32 shape signal in
+  let rfft_out = Nx.rfft ~dtype:Nx.complex64 input in
+  equal ~msg:"rfft float32 shape" (array int)
+    [| (n / 2) + 1 |]
+    (Nx.shape rfft_out);
+  (* Verify output is finite *)
+  let mag = Nx.abs (Nx.cast Nx.float64 rfft_out) in
+  let all_finite = Nx.all (Nx.isfinite mag) in
+  equal ~msg:"rfft float32 all finite" bool true (Nx.item [] all_finite)
+
+(* Test DCT/IDCT roundtrip *)
+let test_dct_idct () =
+  (* Type II/III roundtrip (most common) *)
+  let n = 8 in
+  let shape = [| n |] in
+  let signal = Array.init n (fun i -> Float.of_int i +. 1.0) in
+  let input = Nx.create Nx.float64 shape signal in
+  let dct_out = Nx.dct input ~norm:`Ortho in
+  equal ~msg:"dct shape" (array int) shape (Nx.shape dct_out);
+  let idct_out = Nx.idct dct_out ~norm:`Ortho in
+  check_t ~eps:1e-10 "dct-II/idct ortho roundtrip" shape signal idct_out;
+
+  (* Type I roundtrip *)
+  let input1 = Nx.create Nx.float64 shape signal in
+  let dct1 = Nx.dct ~type_:1 input1 ~norm:`Ortho in
+  let idct1 = Nx.idct ~type_:1 dct1 ~norm:`Ortho in
+  check_t ~eps:1e-10 "dct-I roundtrip" shape signal idct1;
+
+  (* Type IV roundtrip *)
+  let input4 = Nx.create Nx.float64 shape signal in
+  let dct4 = Nx.dct ~type_:4 input4 ~norm:`Ortho in
+  let idct4 = Nx.idct ~type_:4 dct4 ~norm:`Ortho in
+  check_t ~eps:1e-10 "dct-IV roundtrip" shape signal idct4
+
+let test_dct_float32 () =
+  let n = 8 in
+  let shape = [| n |] in
+  let signal = Array.init n (fun i -> Float.of_int i +. 1.0) in
+  let input = Nx.create Nx.float32 shape signal in
+  let dct_out = Nx.dct input ~norm:`Ortho in
+  equal ~msg:"dct float32 shape" (array int) shape (Nx.shape dct_out);
+  let idct_out = Nx.idct dct_out ~norm:`Ortho in
+  check_t ~eps:1e-4 "dct float32 roundtrip" shape signal idct_out
+
+let test_dct_axes () =
+  let shape = [| 3; 8 |] in
+  let signal = Array.init (3 * 8) Float.of_int in
+  let input = Nx.create Nx.float64 shape signal in
+
+  (* DCT along last axis *)
+  let dct_last = Nx.dct input ~axis:(-1) ~norm:`Ortho in
+  equal ~msg:"dct axis -1 shape" (array int) shape (Nx.shape dct_last);
+  let idct_last = Nx.idct dct_last ~axis:(-1) ~norm:`Ortho in
+  check_t ~eps:1e-10 "dct axis -1 roundtrip" shape signal idct_last;
+
+  (* DCT along first axis *)
+  let dct_first = Nx.dct input ~axis:0 ~norm:`Ortho in
+  equal ~msg:"dct axis 0 shape" (array int) shape (Nx.shape dct_first);
+  let idct_first = Nx.idct dct_first ~axis:0 ~norm:`Ortho in
+  check_t ~eps:1e-10 "dct axis 0 roundtrip" shape signal idct_first
+
+let test_dct_norm () =
+  let n = 4 in
+  let shape = [| n |] in
+  let signal = [| 1.0; 2.0; 3.0; 4.0 |] in
+  let input = Nx.create Nx.float64 shape signal in
+
+  (* Backward norm *)
+  let dct_bwd = Nx.dct input ~norm:`Backward in
+  let idct_bwd = Nx.idct dct_bwd ~norm:`Backward in
+  check_t ~eps:1e-10 "dct backward roundtrip" shape signal idct_bwd;
+
+  (* Ortho norm *)
+  let dct_ortho = Nx.dct input ~norm:`Ortho in
+  let idct_ortho = Nx.idct dct_ortho ~norm:`Ortho in
+  check_t ~eps:1e-10 "dct ortho roundtrip" shape signal idct_ortho
+
+(* Test DST/IDST roundtrip *)
+let test_dst_idst () =
+  let n = 8 in
+  let shape = [| n |] in
+  let signal = Array.init n (fun i -> Float.of_int i +. 1.0) in
+  let input = Nx.create Nx.float64 shape signal in
+  let dst_out = Nx.dst input ~norm:`Ortho in
+  equal ~msg:"dst shape" (array int) shape (Nx.shape dst_out);
+  let idst_out = Nx.idst dst_out ~norm:`Ortho in
+  check_t ~eps:1e-10 "dst-II/idst ortho roundtrip" shape signal idst_out;
+
+  (* Type IV roundtrip *)
+  let input4 = Nx.create Nx.float64 shape signal in
+  let dst4 = Nx.dst ~type_:4 input4 ~norm:`Ortho in
+  let idst4 = Nx.idst ~type_:4 dst4 ~norm:`Ortho in
+  check_t ~eps:1e-10 "dst-IV roundtrip" shape signal idst4
+
+let test_dst_float32 () =
+  let n = 8 in
+  let shape = [| n |] in
+  let signal = Array.init n (fun i -> Float.of_int i +. 1.0) in
+  let input = Nx.create Nx.float32 shape signal in
+  let dst_out = Nx.dst input ~norm:`Ortho in
+  equal ~msg:"dst float32 shape" (array int) shape (Nx.shape dst_out);
+  let idst_out = Nx.idst dst_out ~norm:`Ortho in
+  check_t ~eps:1e-4 "dst float32 roundtrip" shape signal idst_out
+
+let test_dctn_idstn () =
+  let shape = [| 4; 6 |] in
+  let signal = Array.init (4 * 6) Float.of_int in
+  let input = Nx.create Nx.float64 shape signal in
+  let dctn_out = Nx.dctn input ~norm:`Ortho in
+  equal ~msg:"dctn shape" (array int) shape (Nx.shape dctn_out);
+  let idctn_out = Nx.idctn dctn_out ~norm:`Ortho in
+  check_t ~eps:1e-10 "dctn/idctn roundtrip" shape signal idctn_out;
+
+  (* N-D DST *)
+  let dstn_out = Nx.dstn input ~norm:`Ortho in
+  equal ~msg:"dstn shape" (array int) shape (Nx.shape dstn_out);
+  let idstn_out = Nx.idstn dstn_out ~norm:`Ortho in
+  check_t ~eps:1e-10 "dstn/idstn roundtrip" shape signal idstn_out
+
+let test_dct_edge_cases () =
+  (* Size 1 *)
+  let shape = [| 1 |] in
+  let signal = [| 5.0 |] in
+  let single = Nx.create Nx.float64 shape signal in
+  let dct_single = Nx.dct single ~norm:`Ortho in
+  let idct_single = Nx.idct dct_single ~norm:`Ortho in
+  check_t "dct size 1" shape signal idct_single;
+
+  (* Invalid type *)
+  let input = Nx.ones Nx.float64 [| 8 |] in
+  (try
+     ignore (Nx.dct ~type_:5 input);
+     failwith "should have raised"
+   with Invalid_argument _ -> ());
+  (try
+     ignore (Nx.dct ~type_:0 input);
+     failwith "should have raised"
+   with Invalid_argument _ -> ())
+
 let suite =
   [
     group "fft/ifft"
@@ -405,8 +552,23 @@ let suite =
         test "size" test_rfft_size;
         test "norm" test_rfft_norm;
         test "edge_cases" test_rfft_edge_cases;
+        test "float32" test_rfft_float32;
       ];
     group "hfft/ihfft" [ test "basic" test_hfft_ihfft ];
+    group "dct/idct"
+      [
+        test "basic" test_dct_idct;
+        test "float32" test_dct_float32;
+        test "axes" test_dct_axes;
+        test "norm" test_dct_norm;
+        test "edge_cases" test_dct_edge_cases;
+      ];
+    group "dst/idst"
+      [
+        test "basic" test_dst_idst;
+        test "float32" test_dst_float32;
+      ];
+    group "dctn/dstn" [ test "basic" test_dctn_idstn ];
     group "helpers"
       [
         test "fftfreq" test_fftfreq;


### PR DESCRIPTION
- `rfft` crashed with `"unsupported dtype combination"` when given `Float32` input because the frontend hardcoded `Complex128` output `dtype` while the backend only handles (`Float32`, `Complex64`) and (`Float64`, `Complex128`). Fix by promoting non-float64 inputs to float64 before calling the backend, using a locally abstract type to avoid GADT type narrowing.

- Add DCT and DST (Discrete Cosine/Sine Transform) to the public API. The PocketFFT bindings already existed for dct_f32, dct_f64, dst_f32, dst_f64 — this wires them through the backend interface, C backend, effect handler, frontend, and public nx.mli.

- New functions: `dct`, `idct`, `dctn`, `idctn`, `dst`, `idst`, `dstn`, `idstn`. All support types 1-4, ortho/backward/forward normalization, and both float32 and float64 precision.