### PR TITLE
fix(nx): do not drop standard cflags

### DIFF
--- a/packages/nx/lib/backend_c/dune
+++ b/packages/nx/lib/backend_c/dune
@@ -25,8 +25,10 @@
    nx_c_solve
    nx_c_svd)
   (flags
+   :standard
    (:include c_flags.sexp)))
  (c_library_flags
+  :standard
   (:include c_library_flags.sexp)))
 
 (rule


### PR DESCRIPTION
Previously the build completely replaced the default cflags from the compiler with its own.
This can result in linker errors like this due to a missing `-fPIC`:
```
/usr/lib64/gcc/x86_64-suse-linux/15/../../../../x86_64-suse-linux/bin/ld: duniverse/raven/nx/lib/backend_c/nx_c_window.o: relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/usr/lib64/gcc/x86_64-suse-linux/15/../../../../x86_64-suse-linux/bin/ld: failed to set dynamic section sizes: bad value
```

Append to the `:standard` CFLAGS instead.

(Also by completely replacing the CFLAGS it was also missing optimization flags)