### PR TITLE
feat(nx): add Nx.Complex accessors for complex tensors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -375,6 +375,10 @@ thread.
   `Nx.to_string`, and `Nx.print`. Remove `pp_data`, `data_to_string`,
   `print_data`, `format_to_string`, `print_with_formatter`, `dtype_to_string`,
   and `shape_to_string`; add `Nx.pp_shape` alongside `Nx.pp_dtype`.
+- Add `Nx.Complex` accessors for complex tensors: `real`, `imag`, `abs`
+  (magnitude), `angle`, `conj`, and `polar`, all running unboxed element-wise
+  kernels. The float-producing functions take the output dtype first, so a
+  `complex64` spectrum yields a `float32` magnitude without a boxed loop.
 - The default C backend and `nx.io` codecs now build cleanly with strict GCC
   warnings and single-pass ELF linkers. Empty DEFLATE streams also avoid
   allocating the encoder's match tables.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -363,6 +363,12 @@ thread.
 
 ### Nx
 
+- Add complex accessors `Nx.real`, `Nx.imag`, `Nx.magnitude`, `Nx.angle` and
+  the `Nx.complex ~re ~im` constructor, taking the result dtype first so a
+  `complex64` spectrum can yield a `float32` magnitude. `Nx.conjugate` now runs
+  the same element-wise kernels instead of reading every element back to the
+  host one at a time; it returns NaN components where the input has a
+  non-finite one, which the boxed version handled exactly.
 - Add `Nx.stft`, `Nx.istft`, and `Nx.hann` for short-time Fourier analysis.
   `stft` frames through a view rather than materializing, returns time-major
   `[frames; bins]`, and tapers with a periodic Hann by default; `istft`
@@ -375,10 +381,6 @@ thread.
   `Nx.to_string`, and `Nx.print`. Remove `pp_data`, `data_to_string`,
   `print_data`, `format_to_string`, `print_with_formatter`, `dtype_to_string`,
   and `shape_to_string`; add `Nx.pp_shape` alongside `Nx.pp_dtype`.
-- Add `Nx.Complex` accessors for complex tensors: `real`, `imag`, `abs`
-  (magnitude), `angle`, `conj`, and `polar`, all running unboxed element-wise
-  kernels. The float-producing functions take the output dtype first, so a
-  `complex64` spectrum yields a `float32` magnitude without a boxed loop.
 - The default C backend and `nx.io` codecs now build cleanly with strict GCC
   warnings and single-pass ELF linkers. Empty DEFLATE streams also avoid
   allocating the encoder's match tables.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -367,6 +367,10 @@ thread.
   `Nx.to_string`, and `Nx.print`. Remove `pp_data`, `data_to_string`,
   `print_data`, `format_to_string`, `print_with_formatter`, `dtype_to_string`,
   and `shape_to_string`; add `Nx.pp_shape` alongside `Nx.pp_dtype`.
+- Add `Nx.Complex` accessors for complex tensors: `real`, `imag`, `abs`
+  (magnitude), `angle`, `conj`, and `polar`, all running unboxed element-wise
+  kernels. The float-producing functions take the output dtype first, so a
+  `complex64` spectrum yields a `float32` magnitude without a boxed loop.
 - The default C backend and `nx.io` codecs now build cleanly with strict GCC
   warnings and single-pass ELF linkers. Empty DEFLATE streams also avoid
   allocating the encoder's match tables.

--- a/packages/nx/doc/03-linear-algebra.md
+++ b/packages/nx/doc/03-linear-algebra.md
@@ -208,6 +208,27 @@ let rfreqs = Nx.rfftfreq n        (* frequency bins for rfft *)
 let shifted = Nx.fftshift spectrum (* shift zero-frequency to center *)
 ```
 
+### Magnitude and phase
+
+A spectrum is complex. `magnitude` and `angle` extract its polar components as
+float tensors, and `complex` reassembles one. The first argument picks the
+result dtype, since leaving the complex domain has to name what to land in —
+this is why `magnitude` is not called `abs`, which preserves the dtype:
+
+<!-- $MDX skip -->
+```ocaml
+let mags = Nx.magnitude Nx.float64 spectrum  (* |z| per bin *)
+let phase = Nx.angle Nx.float64 spectrum     (* arg z, in [-π, π] *)
+
+(* rebuild a spectrum after reshaping its magnitude *)
+let rebuilt =
+  Nx.complex Nx.complex128
+    ~re:Nx.(mul mags (cos phase))
+    ~im:Nx.(mul mags (sin phase))
+```
+
+`real`, `imag`, and `conjugate` give the cartesian view of the same tensor.
+
 ## Next Steps
 
 - [Array Operations](/docs/nx/array-operations/) — reshaping, broadcasting, slicing

--- a/packages/nx/examples/08-signal-processing/main.ml
+++ b/packages/nx/examples/08-signal-processing/main.ml
@@ -35,18 +35,8 @@ let () =
   let spectrum = rfft signal in
   let freqs = rfftfreq ~d:dt n in
 
-  (* Magnitudes (scaled by 2/N for single-sided spectrum). Extract real and
-     imaginary parts to compute |z| = sqrt(re² + im²). *)
-  let spectrum_arr = to_array spectrum in
-  let re =
-    create float64 (shape spectrum)
-      (Array.map (fun c -> c.Complex.re) spectrum_arr)
-  in
-  let im =
-    create float64 (shape spectrum)
-      (Array.map (fun c -> c.Complex.im) spectrum_arr)
-  in
-  let magnitudes = sqrt ((re * re) + (im * im)) *$ (2.0 /. Float.of_int n) in
+  (* Magnitudes |z| (scaled by 2/N for single-sided spectrum). *)
+  let magnitudes = Complex.abs float64 spectrum *$ (2.0 /. Float.of_int n) in
 
   (* Find the dominant frequencies (magnitude > 0.3). *)
   Printf.printf "Dominant frequencies:\n";
@@ -64,7 +54,7 @@ let () =
   let filtered =
     Array.mapi
       (fun i c ->
-        if Stdlib.( < ) mag_arr.(i) threshold then Complex.zero else c)
+        if Stdlib.( < ) mag_arr.(i) threshold then Stdlib.Complex.zero else c)
       (to_array spectrum)
   in
   let clean_spectrum = create Complex128 (shape spectrum) filtered in

--- a/packages/nx/examples/08-signal-processing/main.ml
+++ b/packages/nx/examples/08-signal-processing/main.ml
@@ -36,7 +36,7 @@ let () =
   let freqs = rfftfreq ~d:dt n in
 
   (* Magnitudes |z| (scaled by 2/N for single-sided spectrum). *)
-  let magnitudes = Complex.abs float64 spectrum *$ (2.0 /. Float.of_int n) in
+  let magnitudes = magnitude float64 spectrum *$ (2.0 /. Float.of_int n) in
 
   (* Find the dominant frequencies (magnitude > 0.3). *)
   Printf.printf "Dominant frequencies:\n";
@@ -54,7 +54,7 @@ let () =
   let filtered =
     Array.mapi
       (fun i c ->
-        if Stdlib.( < ) mag_arr.(i) threshold then Stdlib.Complex.zero else c)
+        if Stdlib.( < ) mag_arr.(i) threshold then Complex.zero else c)
       (to_array spectrum)
   in
   let clean_spectrum = create Complex128 (shape spectrum) filtered in

--- a/packages/nx/lib/core/backend_intf.ml
+++ b/packages/nx/lib/core/backend_intf.ml
@@ -244,7 +244,13 @@ module type S = sig
   (** [recip x] is the element-wise reciprocal of [x]. *)
 
   val abs : ('a, 'b) t -> ('a, 'b) t
-  (** [abs x] is the element-wise absolute value of [x]. *)
+  (** [abs x] is the element-wise absolute value of [x].
+
+      {b Backend must:} for complex dtypes, return the modulus in the real
+      component and zero in the imaginary one, computed without intermediate
+      overflow — components large enough that [re² + im²] would saturate must
+      still give a finite modulus. The frontend's [magnitude] casts this
+      result down to a float tensor. *)
 
   val sqrt : ('a, 'b) t -> ('a, 'b) t
   (** [sqrt x] is the element-wise square root of [x]. *)
@@ -460,7 +466,13 @@ module type S = sig
   (** [cast ~dtype x] converts elements of [x] to [dtype].
 
       Float-to-int truncates toward zero. Int-to-float may lose precision for
-      large values. *)
+      large values.
+
+      {b Backend must:} drop the imaginary component when casting complex to a
+      real dtype, keeping the real one, and set a zero imaginary component when
+      casting a real dtype to complex. The frontend's complex accessors are
+      built on both directions, so a backend that instead cast complex through
+      its modulus would silently change their results. *)
 
   val contiguous : ('a, 'b) t -> ('a, 'b) t
   (** [contiguous t] returns a C-contiguous version of [t].

--- a/packages/nx/lib/core/frontend.ml
+++ b/packages/nx/lib/core/frontend.ml
@@ -2425,69 +2425,35 @@ module Make (B : Backend_intf.S) = struct
 
   (* ───── Complex ───── *)
 
-  let extract_complex_part (type a b) ~op ~field (x : (a, b) t) =
-    let extract (type c d e f) (x : (Complex.t, c) t) (out_dt : (d, e) Dtype.t)
-        (get : Complex.t -> d) : (f, _) t =
-      let s = shape x in
-      let size = array_prod s in
-      let data =
-        Array.init size (fun i ->
-            let idx = Shape.unravel_index i s |> Array.to_list in
-            get (unsafe_get idx x))
-      in
-      Obj.magic (create (B.context x) out_dt s data)
+  (* These compose element-wise operations rather than reading elements back to
+     the host, so effectful backends can trace them and no intermediate boxes a
+     [Complex.t]. Two cast rules carry the component work: complex-to-float
+     keeps the real part, float-to-complex sets a zero imaginary part.
+
+     Only [real] and [magnitude] read a lane directly. Reaching the imaginary
+     lane means rotating it into the real one, which is a complex multiply: it
+     is exact for finite components, but a non-finite component contaminates
+     the product through [inf * 0], so [imag], [angle], [complex], and
+     [conjugate] yield NaN there. Lifting a lane out without arithmetic would
+     need a component view of the storage, which the backend does not expose. *)
+
+  let real dt (z : (Complex.t, _) t) = cast dt z
+  let imag dt (z : (Complex.t, _) t) = cast dt (mul_s z Complex.{ re = 0.; im = -1. })
+  let magnitude dt (z : (Complex.t, _) t) = cast dt (abs z)
+  let angle dt (z : (Complex.t, _) t) = atan2 (imag dt z) (real dt z)
+  let complex dt ~re ~im = add (cast dt re) (mul_s (cast dt im) Complex.i)
+
+  let conjugate (type a b) (x : (a, b) t) : (a, b) t =
+    let negate_imag (type c) (z : (Complex.t, c) t) : (Complex.t, c) t =
+      (* [re - (z - re)] rather than [2·re - z]: the doubling would overflow for
+         components above half the dtype maximum. The float64 hop is exact for
+         both complex dtypes. *)
+      let re = cast (dtype z) (cast Dtype.float64 z) in
+      sub re (sub z re)
     in
     match dtype x with
-    | Complex64 ->
-        extract
-          (x : (Complex.t, complex32_elt) t)
-          Dtype.float32
-          (fun c -> field c)
-    | Complex128 ->
-        extract
-          (x : (Complex.t, complex64_elt) t)
-          Dtype.float64
-          (fun c -> field c)
-    | _ -> err op "dtype, input must be complex64 or complex128"
-
-  let complex (type a b) ~(real : (a, b) t) ~(imag : (a, b) t) =
-    let s = shape real in
-    if s <> shape imag then
-      err "complex" "cannot reshape %s to %s"
-        (Shape.to_string (shape imag))
-        (Shape.to_string s);
-    let size = array_prod s in
-    match dtype real with
-    | Float32 ->
-        let real = (real : (float, float32_elt) t) in
-        let imag = (imag : (float, float32_elt) t) in
-        let data =
-          Array.init size (fun i ->
-              let idx = Shape.unravel_index i s |> Array.to_list in
-              Complex.{ re = unsafe_get idx real; im = unsafe_get idx imag })
-        in
-        Obj.magic (create (B.context real) Dtype.complex64 s data)
-    | Float64 ->
-        let real = (real : (float, float64_elt) t) in
-        let imag = (imag : (float, float64_elt) t) in
-        let data =
-          Array.init size (fun i ->
-              let idx = Shape.unravel_index i s |> Array.to_list in
-              Complex.{ re = unsafe_get idx real; im = unsafe_get idx imag })
-        in
-        Obj.magic (create (B.context real) Dtype.complex128 s data)
-    | _ ->
-        invalid_arg "complex: dtype, real and imag must be float32 or float64"
-
-  let real (type a b) (x : (a, b) t) =
-    extract_complex_part ~op:"real" ~field:(fun c -> c.Complex.re) x
-
-  let imag (type a b) (x : (a, b) t) =
-    extract_complex_part ~op:"imag" ~field:(fun c -> c.Complex.im) x
-
-  let conjugate (type a b) (x : (a, b) t) =
-    match dtype x with
-    | Complex64 | Complex128 -> complex ~real:(real x) ~imag:(neg (imag x))
+    | Complex64 -> negate_imag x
+    | Complex128 -> negate_imag x
     | _ -> x
 
   (* ───── Dot Products and Tensor Contractions ───── *)
@@ -4696,39 +4662,6 @@ module Make (B : Backend_intf.S) = struct
       acc := f !acc (Nx_buffer.unsafe_get src i)
     done;
     !acc
-
-  (* ───── Complex Accessors ───── *)
-
-  (* Compositions of existing backend operations, so every backend (including
-     effectful ones) gets them without extending the backend interface. Each
-     runs a constant number of element-wise kernels and never boxes a
-     [Stdlib.Complex.t]. Component extraction leans on the normative cast
-     rules: complex-to-float takes the real part, float-to-complex sets a zero
-     imaginary part. *)
-  module Complex = struct
-    let real dt z = cast dt z
-
-    (* z * -i swaps the imaginary part into the real lane: for finite
-       components (re + i.im)(-i) has real part im exactly. *)
-    let imag dt z = cast dt (mul_s z Stdlib.Complex.{ re = 0.0; im = -1.0 })
-
-    (* The inner [abs] is the dtype-preserving frontend one; on complex it is
-       the fused magnitude kernel (im = 0), so the cast keeps |z|. *)
-    let abs dt z = cast dt (abs z)
-    let angle dt z = atan2 (imag dt z) (real dt z)
-
-    (* re_c - (z - re_c) = re - i.im without scaling, so finite components
-       (including values above half the dtype maximum) stay exact. The float64
-       hop through creal is exact for both complex dtypes. *)
-    let conj z =
-      let re_c = cast (dtype z) (cast Dtype.float64 z) in
-      sub re_c (sub z re_c)
-
-    let polar dt r theta =
-      let re = cast dt (mul r (cos theta)) in
-      let im = cast dt (mul r (sin theta)) in
-      add re (mul_s im Stdlib.Complex.i)
-  end
 
   (* ───── Infix Operators ───── *)
 

--- a/packages/nx/lib/core/frontend.ml
+++ b/packages/nx/lib/core/frontend.ml
@@ -4697,6 +4697,39 @@ module Make (B : Backend_intf.S) = struct
     done;
     !acc
 
+  (* ───── Complex Accessors ───── *)
+
+  (* Compositions of existing backend operations, so every backend (including
+     effectful ones) gets them without extending the backend interface. Each
+     runs a constant number of element-wise kernels and never boxes a
+     [Stdlib.Complex.t]. Component extraction leans on the normative cast
+     rules: complex-to-float takes the real part, float-to-complex sets a zero
+     imaginary part. *)
+  module Complex = struct
+    let real dt z = cast dt z
+
+    (* z * -i swaps the imaginary part into the real lane: for finite
+       components (re + i.im)(-i) has real part im exactly. *)
+    let imag dt z = cast dt (mul_s z Stdlib.Complex.{ re = 0.0; im = -1.0 })
+
+    (* The inner [abs] is the dtype-preserving frontend one; on complex it is
+       the fused magnitude kernel (im = 0), so the cast keeps |z|. *)
+    let abs dt z = cast dt (abs z)
+    let angle dt z = atan2 (imag dt z) (real dt z)
+
+    (* re_c - (z - re_c) = re - i.im without scaling, so finite components
+       (including values above half the dtype maximum) stay exact. The float64
+       hop through creal is exact for both complex dtypes. *)
+    let conj z =
+      let re_c = cast (dtype z) (cast Dtype.float64 z) in
+      sub re_c (sub z re_c)
+
+    let polar dt r theta =
+      let re = cast dt (mul r (cos theta)) in
+      let im = cast dt (mul r (sin theta)) in
+      add re (mul_s im Stdlib.Complex.i)
+  end
+
   (* ───── Infix Operators ───── *)
 
   module Infix = struct

--- a/packages/nx/lib/core/frontend.ml
+++ b/packages/nx/lib/core/frontend.ml
@@ -4568,6 +4568,39 @@ module Make (B : Backend_intf.S) = struct
     done;
     !acc
 
+  (* ───── Complex Accessors ───── *)
+
+  (* Compositions of existing backend operations, so every backend (including
+     effectful ones) gets them without extending the backend interface. Each
+     runs a constant number of element-wise kernels and never boxes a
+     [Stdlib.Complex.t]. Component extraction leans on the normative cast
+     rules: complex-to-float takes the real part, float-to-complex sets a zero
+     imaginary part. *)
+  module Complex = struct
+    let real dt z = cast dt z
+
+    (* z * -i swaps the imaginary part into the real lane: for finite
+       components (re + i.im)(-i) has real part im exactly. *)
+    let imag dt z = cast dt (mul_s z Stdlib.Complex.{ re = 0.0; im = -1.0 })
+
+    (* The inner [abs] is the dtype-preserving frontend one; on complex it is
+       the fused magnitude kernel (im = 0), so the cast keeps |z|. *)
+    let abs dt z = cast dt (abs z)
+    let angle dt z = atan2 (imag dt z) (real dt z)
+
+    (* re_c - (z - re_c) = re - i.im without scaling, so finite components
+       (including values above half the dtype maximum) stay exact. The float64
+       hop through creal is exact for both complex dtypes. *)
+    let conj z =
+      let re_c = cast (dtype z) (cast Dtype.float64 z) in
+      sub re_c (sub z re_c)
+
+    let polar dt r theta =
+      let re = cast dt (mul r (cos theta)) in
+      let im = cast dt (mul r (sin theta)) in
+      add re (mul_s im Stdlib.Complex.i)
+  end
+
   (* ───── Infix Operators ───── *)
 
   module Infix = struct

--- a/packages/nx/lib/nx.mli
+++ b/packages/nx/lib/nx.mli
@@ -1373,9 +1373,89 @@ val rmod_s : 'a -> ('a, 'b) t -> ('a, 'b) t
 val neg : ('a, 'b) t -> ('a, 'b) t
 (** [neg t] is the element-wise negation of [t]. *)
 
+(** {1:complex Complex numbers}
+
+    A complex tensor stores an interleaved real and imaginary component. These
+    functions move between such a tensor and the float tensors holding its
+    components. All are element-wise and return a fresh tensor, never a view.
+
+    The ones producing a float tensor take that dtype first. It selects the
+    result's storage precision independently of the input's, so the arithmetic
+    still happens at the input's precision: [magnitude float64] of a
+    [complex64] tensor widens a float32 result rather than recomputing it. The
+    matching pairs are [complex64] with [float32], and [complex128] with
+    [float64].
+
+    {2:complex_nonfinite Non-finite components}
+
+    Only {!real} and {!magnitude} read a component directly. The others reach
+    the imaginary component by rotating it into the real one, which multiplies
+    the two components together, so a non-finite component poisons the other:
+    {!imag}, {!angle}, {!val-complex}, and {!conjugate} produce NaN components
+    wherever an input component is infinite or NaN. Finite inputs are
+    unaffected, including components near the dtype maximum. *)
+
+val real : (float, 'b) dtype -> (Complex.t, 'a) t -> (float, 'b) t
+(** [real dt z] is the real component of each element of [z].
+
+    {@ocaml[
+      # create complex64 [| 2 |] [| Complex.{ re = 3.; im = 4. }; Complex.i |]
+        |> real float32
+      - : (float, float32_elt) t = [3, 0]
+    ]}
+
+    See also {!imag}, {!magnitude}. *)
+
+val imag : (float, 'b) dtype -> (Complex.t, 'a) t -> (float, 'b) t
+(** [imag dt z] is the imaginary component of each element of [z].
+
+    See also {!real}, {!val-complex}. *)
+
+val magnitude : (float, 'b) dtype -> (Complex.t, 'a) t -> (float, 'b) t
+(** [magnitude dt z] is the element-wise modulus of [z]. It is named apart from
+    {!abs}, which preserves the dtype and so cannot leave the complex domain.
+
+    Computed without intermediate overflow, so components large enough that
+    [re² + im²] would saturate still yield a finite magnitude.
+
+    {@ocaml[
+      # create complex64 [| 2 |] [| Complex.{ re = 3.; im = 4. }; Complex.i |]
+        |> magnitude float32
+      - : (float, float32_elt) t = [5, 1]
+    ]}
+
+    See also {!angle}, {!val-complex}. *)
+
+val angle : (float, 'b) dtype -> (Complex.t, 'a) t -> (float, 'b) t
+(** [angle dt z] is the element-wise argument of [z] in radians, in
+    \[[-π], [π]\].
+
+    The negative real axis is a branch cut and the sign of a zero imaginary
+    component picks the side: [-1. + 0.i] has argument [π], [-1. - 0.i] has
+    argument [-π]. Zero has argument zero.
+
+    See also {!magnitude}, {!val-complex}. *)
+
+val complex :
+  (Complex.t, 'c) dtype ->
+  re:(float, 'a) t ->
+  im:(float, 'a) t ->
+  (Complex.t, 'c) t
+(** [complex dt ~re ~im] assembles a complex tensor from its components, which
+    are broadcast together.
+
+    {@ocaml[
+      # complex complex64
+          ~re:(create float32 [| 2 |] [| 3.; 0. |])
+          ~im:(create float32 [| 2 |] [| 4.; 1. |])
+      - : (Complex.t, complex32_elt) t = [(3+4i), (0+1i)]
+    ]}
+
+    See also {!real}, {!imag}. *)
+
 val conjugate : ('a, 'b) t -> ('a, 'b) t
-(** [conjugate t] is the complex conjugate of [t]. For complex dtypes, negates
-    the imaginary part. For real dtypes, returns [t] unchanged. *)
+(** [conjugate t] negates the imaginary component of each element. Real dtypes
+    are returned unchanged. *)
 
 (** {1:math Mathematical functions} *)
 
@@ -2731,78 +2811,6 @@ val istft :
 
     See also {!stft}. *)
 
-(** {1:complex Complex accessors} *)
-
-module Complex : sig
-  (** Element-wise accessors for complex tensors: component extraction,
-      magnitude, phase, conjugation, and polar construction.
-
-      All functions run unboxed tensor kernels — no per-element
-      [Stdlib.Complex.t] round-trips — and return a fresh tensor (a copy, not
-      a {e view}). Functions producing float tensors take the output dtype
-      first; it selects the storage precision, independent of the input's. The
-      natural pairings are [complex64] with [float32] and [complex128] with
-      [float64].
-
-      This module is namespaced so that {!val-abs} — magnitude, complex in,
-      float out — does not clash with the dtype-preserving [Nx.abs]. *)
-
-  val real : (float, 'b) dtype -> (Stdlib.Complex.t, 'a) t -> (float, 'b) t
-  (** [real dt z] is the real part of each element of [z], as a float tensor
-      of dtype [dt].
-
-      {@ocaml[
-        # create complex64 [| 2 |]
-            [| Stdlib.Complex.{ re = 3.; im = 4. }; Stdlib.Complex.i |]
-          |> Complex.real float32
-        - : (float, float32_elt) t = [3, 0]
-      ]}
-
-      See also {!imag}, {!val-abs}. *)
-
-  val imag : (float, 'b) dtype -> (Stdlib.Complex.t, 'a) t -> (float, 'b) t
-  (** [imag dt z] is the imaginary part of each element of [z], as a float
-      tensor of dtype [dt].
-
-      See also {!real}. *)
-
-  val abs : (float, 'b) dtype -> (Stdlib.Complex.t, 'a) t -> (float, 'b) t
-  (** [abs dt z] is the element-wise magnitude (modulus) of [z], as a float
-      tensor of dtype [dt]. Computed without undue overflow (C [cabs]).
-
-      {@ocaml[
-        # create complex64 [| 2 |]
-            [| Stdlib.Complex.{ re = 3.; im = 4. }; Stdlib.Complex.i |]
-          |> Complex.abs float32
-        - : (float, float32_elt) t = [5, 1]
-      ]}
-
-      See also {!angle}, {!polar}. *)
-
-  val angle : (float, 'b) dtype -> (Stdlib.Complex.t, 'a) t -> (float, 'b) t
-  (** [angle dt z] is the element-wise argument (phase) of [z] in radians, in
-      \[[-π], [π]\], as a float tensor of dtype [dt]. Measured as
-      [atan2 im re], so negative real values map to π and zero maps to zero.
-
-      See also {!val-abs}, {!polar}. *)
-
-  val conj : (Stdlib.Complex.t, 'a) t -> (Stdlib.Complex.t, 'a) t
-  (** [conj z] is the element-wise complex conjugate of [z].
-
-      See also {!imag}. *)
-
-  val polar :
-    (Stdlib.Complex.t, 'c) dtype ->
-    (float, 'a) t ->
-    (float, 'a) t ->
-    (Stdlib.Complex.t, 'c) t
-  (** [polar dt r theta] is the complex tensor with magnitude [r] and phase
-      [theta]: [r·cos theta + i·r·sin theta], as a complex tensor of dtype
-      [dt]. [r] and [theta] are broadcast together. Inverse of the
-      ({!val-abs}, {!angle}) decomposition.
-
-      See also {!val-abs}, {!angle}. *)
-end
 
 (** {1:activation Activation functions} *)
 

--- a/packages/nx/lib/nx.mli
+++ b/packages/nx/lib/nx.mli
@@ -2731,6 +2731,79 @@ val istft :
 
     See also {!stft}. *)
 
+(** {1:complex Complex accessors} *)
+
+module Complex : sig
+  (** Element-wise accessors for complex tensors: component extraction,
+      magnitude, phase, conjugation, and polar construction.
+
+      All functions run unboxed tensor kernels — no per-element
+      [Stdlib.Complex.t] round-trips — and return a fresh tensor (a copy, not
+      a {e view}). Functions producing float tensors take the output dtype
+      first; it selects the storage precision, independent of the input's. The
+      natural pairings are [complex64] with [float32] and [complex128] with
+      [float64].
+
+      This module is namespaced so that {!val-abs} — magnitude, complex in,
+      float out — does not clash with the dtype-preserving [Nx.abs]. *)
+
+  val real : (float, 'b) dtype -> (Stdlib.Complex.t, 'a) t -> (float, 'b) t
+  (** [real dt z] is the real part of each element of [z], as a float tensor
+      of dtype [dt].
+
+      {@ocaml[
+        # create complex64 [| 2 |]
+            [| Stdlib.Complex.{ re = 3.; im = 4. }; Stdlib.Complex.i |]
+          |> Complex.real float32
+        - : (float, float32_elt) t = [3, 0]
+      ]}
+
+      See also {!imag}, {!val-abs}. *)
+
+  val imag : (float, 'b) dtype -> (Stdlib.Complex.t, 'a) t -> (float, 'b) t
+  (** [imag dt z] is the imaginary part of each element of [z], as a float
+      tensor of dtype [dt].
+
+      See also {!real}. *)
+
+  val abs : (float, 'b) dtype -> (Stdlib.Complex.t, 'a) t -> (float, 'b) t
+  (** [abs dt z] is the element-wise magnitude (modulus) of [z], as a float
+      tensor of dtype [dt]. Computed without undue overflow (C [cabs]).
+
+      {@ocaml[
+        # create complex64 [| 2 |]
+            [| Stdlib.Complex.{ re = 3.; im = 4. }; Stdlib.Complex.i |]
+          |> Complex.abs float32
+        - : (float, float32_elt) t = [5, 1]
+      ]}
+
+      See also {!angle}, {!polar}. *)
+
+  val angle : (float, 'b) dtype -> (Stdlib.Complex.t, 'a) t -> (float, 'b) t
+  (** [angle dt z] is the element-wise argument (phase) of [z] in radians, in
+      \[[-π], [π]\], as a float tensor of dtype [dt]. Measured as
+      [atan2 im re], so negative real values map to π and zero maps to zero.
+
+      See also {!val-abs}, {!polar}. *)
+
+  val conj : (Stdlib.Complex.t, 'a) t -> (Stdlib.Complex.t, 'a) t
+  (** [conj z] is the element-wise complex conjugate of [z].
+
+      See also {!imag}. *)
+
+  val polar :
+    (Stdlib.Complex.t, 'c) dtype ->
+    (float, 'a) t ->
+    (float, 'a) t ->
+    (Stdlib.Complex.t, 'c) t
+  (** [polar dt r theta] is the complex tensor with magnitude [r] and phase
+      [theta]: [r·cos theta + i·r·sin theta], as a complex tensor of dtype
+      [dt]. [r] and [theta] are broadcast together. Inverse of the
+      ({!val-abs}, {!angle}) decomposition.
+
+      See also {!val-abs}, {!angle}. *)
+end
+
 (** {1:activation Activation functions} *)
 
 val relu : ('a, 'b) t -> ('a, 'b) t

--- a/packages/nx/lib/nx.mli
+++ b/packages/nx/lib/nx.mli
@@ -2631,6 +2631,79 @@ val fftshift : ?axes:int list -> ('a, 'b) t -> ('a, 'b) t
 val ifftshift : ?axes:int list -> ('a, 'b) t -> ('a, 'b) t
 (** [ifftshift ?axes t] is the inverse of {!fftshift}. *)
 
+(** {1:complex Complex accessors} *)
+
+module Complex : sig
+  (** Element-wise accessors for complex tensors: component extraction,
+      magnitude, phase, conjugation, and polar construction.
+
+      All functions run unboxed tensor kernels — no per-element
+      [Stdlib.Complex.t] round-trips — and return a fresh tensor (a copy, not
+      a {e view}). Functions producing float tensors take the output dtype
+      first; it selects the storage precision, independent of the input's. The
+      natural pairings are [complex64] with [float32] and [complex128] with
+      [float64].
+
+      This module is namespaced so that {!val-abs} — magnitude, complex in,
+      float out — does not clash with the dtype-preserving [Nx.abs]. *)
+
+  val real : (float, 'b) dtype -> (Stdlib.Complex.t, 'a) t -> (float, 'b) t
+  (** [real dt z] is the real part of each element of [z], as a float tensor
+      of dtype [dt].
+
+      {@ocaml[
+        # create complex64 [| 2 |]
+            [| Stdlib.Complex.{ re = 3.; im = 4. }; Stdlib.Complex.i |]
+          |> Complex.real float32
+        - : (float, float32_elt) t = [3, 0]
+      ]}
+
+      See also {!imag}, {!val-abs}. *)
+
+  val imag : (float, 'b) dtype -> (Stdlib.Complex.t, 'a) t -> (float, 'b) t
+  (** [imag dt z] is the imaginary part of each element of [z], as a float
+      tensor of dtype [dt].
+
+      See also {!real}. *)
+
+  val abs : (float, 'b) dtype -> (Stdlib.Complex.t, 'a) t -> (float, 'b) t
+  (** [abs dt z] is the element-wise magnitude (modulus) of [z], as a float
+      tensor of dtype [dt]. Computed without undue overflow (C [cabs]).
+
+      {@ocaml[
+        # create complex64 [| 2 |]
+            [| Stdlib.Complex.{ re = 3.; im = 4. }; Stdlib.Complex.i |]
+          |> Complex.abs float32
+        - : (float, float32_elt) t = [5, 1]
+      ]}
+
+      See also {!angle}, {!polar}. *)
+
+  val angle : (float, 'b) dtype -> (Stdlib.Complex.t, 'a) t -> (float, 'b) t
+  (** [angle dt z] is the element-wise argument (phase) of [z] in radians, in
+      \[[-π], [π]\], as a float tensor of dtype [dt]. Measured as
+      [atan2 im re], so negative real values map to π and zero maps to zero.
+
+      See also {!val-abs}, {!polar}. *)
+
+  val conj : (Stdlib.Complex.t, 'a) t -> (Stdlib.Complex.t, 'a) t
+  (** [conj z] is the element-wise complex conjugate of [z].
+
+      See also {!imag}. *)
+
+  val polar :
+    (Stdlib.Complex.t, 'c) dtype ->
+    (float, 'a) t ->
+    (float, 'a) t ->
+    (Stdlib.Complex.t, 'c) t
+  (** [polar dt r theta] is the complex tensor with magnitude [r] and phase
+      [theta]: [r·cos theta + i·r·sin theta], as a complex tensor of dtype
+      [dt]. [r] and [theta] are broadcast together. Inverse of the
+      ({!val-abs}, {!angle}) decomposition.
+
+      See also {!val-abs}, {!angle}. *)
+end
+
 (** {1:activation Activation functions} *)
 
 val relu : ('a, 'b) t -> ('a, 'b) t

--- a/packages/nx/test/backend_contract.ml
+++ b/packages/nx/test/backend_contract.ml
@@ -1620,6 +1620,17 @@ struct
                 (array (ctest ~rel:0.0 ~abs:0.0))
                 [| z 1.5 0.0; z (-2.0) 0.0; z 3.0 0.0 |]
                 (F.to_array (B.cast ~dtype:F.complex128 t)));
+          case classify path "complex128->f64" (fun () ->
+              (* complex -> real keeps the real component and drops the
+                 imaginary one. The frontend's real/imag/angle/conjugate all
+                 rest on this direction. *)
+              let z re im = { Complex.re; im } in
+              let t =
+                F.create ctx F.complex128 [| 3 |]
+                  [| z 1.5 9.0; z (-2.0) (-9.0); z 0.0 3.0 |]
+              in
+              equal ~msg:"keeps re" exact [| 1.5; -2.0; 0.0 |]
+                (F.to_array (B.cast ~dtype:F.float64 t)));
           case classify path "int8<->int4-roundtrip" (fun () ->
               (* Int4 is storage-only, supported in cast (pack/unpack). In-range
                  values round-trip exactly. *)
@@ -2345,7 +2356,9 @@ struct
 
   (* ───── Complex ───── *)
 
-  type cdt = CDT : (Complex.t, 'b) Dtype.t * string * float -> cdt
+  (* The last field is a component big enough that [re² + im²] saturates the
+     dtype's float range, so a naive modulus would return infinity. *)
+  type cdt = CDT : (Complex.t, 'b) Dtype.t * string * float * float -> cdt
 
   let cpool =
     Array.init 18 (fun i ->
@@ -2355,13 +2368,16 @@ struct
         })
 
   let complex_dtypes =
-    [ CDT (F.complex64, "c32", 1e-5); CDT (F.complex128, "c64", 1e-11) ]
+    [
+      CDT (F.complex64, "c32", 1e-5, 1e20);
+      CDT (F.complex128, "c64", 1e-11, 1e200);
+    ]
 
   let complex_tests classify path =
     [
       group "complex"
         (List.map
-           (fun (CDT (dt, name, tol)) ->
+           (fun (CDT (dt, name, tol, big)) ->
              let ct = ctest ~rel:tol ~abs:tol in
              case classify path name (fun () ->
                  let a = F.create ctx dt [| 3; 4 |] (Array.sub cpool 0 12) in
@@ -2377,6 +2393,20 @@ struct
                  chk "div" B.fdiv Complex.div;
                  equal ~msg:"neg" (array ct) (Array.map Complex.neg sa)
                    (F.to_array (B.neg a));
+                 (* abs on complex is the modulus, delivered in the real
+                    component with a zero imaginary one; the frontend's
+                    magnitude casts that down to a float tensor. *)
+                 equal ~msg:"abs" (array ct)
+                   (Array.map
+                      (fun z -> { Complex.re = Complex.norm z; im = 0.0 })
+                      sa)
+                   (F.to_array (B.abs a));
+                 (* and it must not go through re² + im², which saturates *)
+                 let huge = F.create ctx dt [| 1 |] [| { Complex.re = big; im = big } |] in
+                 let hz = (F.to_array huge).(0) in
+                 equal ~msg:"abs no overflow" (array ct)
+                   [| { Complex.re = Complex.norm hz; im = 0.0 } |]
+                   (F.to_array (B.abs huge));
                  let bt_base =
                    F.create ctx dt [| 4; 3 |] (Array.sub cpool 4 12)
                  in

--- a/packages/nx/test/dune
+++ b/packages/nx/test/dune
@@ -14,6 +14,7 @@
   test_nx_manipulation
   test_nx_extended_dtypes
   test_nx_fft
+  test_nx_complex
   test_nx_ops
   test_nx_rng
   test_nx_stft)

--- a/packages/nx/test/dune
+++ b/packages/nx/test/dune
@@ -14,6 +14,7 @@
   test_nx_manipulation
   test_nx_extended_dtypes
   test_nx_fft
+  test_nx_complex
   test_nx_ops
   test_nx_rng)
  (package nx)

--- a/packages/nx/test/test_nx_complex.ml
+++ b/packages/nx/test/test_nx_complex.ml
@@ -32,123 +32,115 @@ let shape = [| Array.length samples |]
 let input64 () = Nx.create Nx.complex64 shape samples
 let input128 () = Nx.create Nx.complex128 shape samples
 
+let complex_testable =
+  Testable.make
+    ~pp:(fun ppf v -> Format.fprintf ppf "(%g, %g)" v.Complex.re v.Complex.im)
+    ~equal:(fun a b ->
+      a.Complex.re = b.Complex.re && a.Complex.im = b.Complex.im)
+    ()
+
 (* Oracle checks against per-element stdlib Complex loops *)
 
 let test_real_imag () =
   let expected_re = Array.map (fun z -> z.Complex.re) samples in
   let expected_im = Array.map (fun z -> z.Complex.im) samples in
-  check_t "real complex64" shape expected_re
-    (Nx.Complex.real Nx.float32 (input64 ()));
+  check_t "real complex64" shape expected_re (Nx.real Nx.float32 (input64 ()));
   check_t ~eps:1e-12 "real complex128" shape expected_re
-    (Nx.Complex.real Nx.float64 (input128 ()));
-  check_t "imag complex64" shape expected_im
-    (Nx.Complex.imag Nx.float32 (input64 ()));
+    (Nx.real Nx.float64 (input128 ()));
+  check_t "imag complex64" shape expected_im (Nx.imag Nx.float32 (input64 ()));
   check_t ~eps:1e-12 "imag complex128" shape expected_im
-    (Nx.Complex.imag Nx.float64 (input128 ()));
+    (Nx.imag Nx.float64 (input128 ()));
   (* the output dtype is independent of the input precision *)
   check_t ~eps:1e-12 "real complex64 to float64" shape expected_re
-    (Nx.Complex.real Nx.float64 (input64 ()))
+    (Nx.real Nx.float64 (input64 ()))
 
-let test_abs () =
+let test_magnitude () =
   let expected = Array.map Complex.norm samples in
-  check_t ~eps:1e-5 "abs complex64" shape expected
-    (Nx.Complex.abs Nx.float32 (input64 ()));
-  check_t ~eps:1e-12 "abs complex128" shape expected
-    (Nx.Complex.abs Nx.float64 (input128 ()));
-  check_t ~eps:1e-5 "abs complex64 to float64" shape expected
-    (Nx.Complex.abs Nx.float64 (input64 ()))
+  check_t ~eps:1e-5 "magnitude complex64" shape expected
+    (Nx.magnitude Nx.float32 (input64 ()));
+  check_t ~eps:1e-12 "magnitude complex128" shape expected
+    (Nx.magnitude Nx.float64 (input128 ()));
+  check_t ~eps:1e-5 "magnitude complex64 to float64" shape expected
+    (Nx.magnitude Nx.float64 (input64 ()))
 
 let test_angle () =
   let expected = Array.map Complex.arg samples in
   check_t ~eps:1e-5 "angle complex64" shape expected
-    (Nx.Complex.angle Nx.float32 (input64 ()));
+    (Nx.angle Nx.float32 (input64 ()));
   check_t ~eps:1e-12 "angle complex128" shape expected
-    (Nx.Complex.angle Nx.float64 (input128 ()))
+    (Nx.angle Nx.float64 (input128 ()))
 
-let test_conj () =
+let test_conjugate () =
   let expected = Array.map Complex.conj samples in
-  check_t "conj complex64" shape expected (Nx.Complex.conj (input64 ()));
-  check_t ~eps:1e-12 "conj complex128" shape expected
-    (Nx.Complex.conj (input128 ()))
+  check_t "conjugate complex64" shape expected (Nx.conjugate (input64 ()));
+  check_t ~eps:1e-12 "conjugate complex128" shape expected
+    (Nx.conjugate (input128 ()));
+  (* real dtypes pass through untouched *)
+  let r = Nx.create Nx.float64 [| 3 |] [| 1.5; -2.0; 0.0 |] in
+  check_t ~eps:1e-12 "conjugate float64" [| 3 |] [| 1.5; -2.0; 0.0 |]
+    (Nx.conjugate r)
 
-let test_polar () =
-  let r_data = [| 0.0; 0.5; 1.0; 2.0; 3.5; 5.0 |] in
-  let theta_data = [| 0.0; pi; -.pi; 1.5; -0.75; 2.5 |] in
-  let polar_shape = [| Array.length r_data |] in
-  let expected = Array.map2 Complex.polar r_data theta_data in
-  let r64 = Nx.create Nx.float64 polar_shape r_data in
-  let theta64 = Nx.create Nx.float64 polar_shape theta_data in
-  check_t ~eps:1e-12 "polar complex128" polar_shape expected
-    (Nx.Complex.polar Nx.complex128 r64 theta64);
-  let r32 = Nx.create Nx.float32 polar_shape r_data in
-  let theta32 = Nx.create Nx.float32 polar_shape theta_data in
-  check_t ~eps:1e-5 "polar complex64" polar_shape expected
-    (Nx.Complex.polar Nx.complex64 r32 theta32);
-  (* magnitude and phase broadcast together *)
-  let theta_scalar = Nx.scalar Nx.float64 (pi /. 2.0) in
-  let expected_bcast =
-    Array.map (fun r -> Complex.polar r (pi /. 2.0)) r_data
-  in
-  check_t ~eps:1e-12 "polar broadcast" polar_shape expected_bcast
-    (Nx.Complex.polar Nx.complex128 r64 theta_scalar)
+let test_complex_ctor () =
+  let re_data = Array.map (fun z -> z.Complex.re) samples in
+  let im_data = Array.map (fun z -> z.Complex.im) samples in
+  let re64 = Nx.create Nx.float64 shape re_data in
+  let im64 = Nx.create Nx.float64 shape im_data in
+  check_t ~eps:1e-12 "complex128" shape samples
+    (Nx.complex Nx.complex128 ~re:re64 ~im:im64);
+  let re32 = Nx.create Nx.float32 shape re_data in
+  let im32 = Nx.create Nx.float32 shape im_data in
+  check_t ~eps:1e-5 "complex64" shape samples
+    (Nx.complex Nx.complex64 ~re:re32 ~im:im32);
+  (* components broadcast together *)
+  let expected = Array.map (fun re -> Complex.{ re; im = 2.0 }) re_data in
+  check_t ~eps:1e-12 "complex broadcast" shape expected
+    (Nx.complex Nx.complex128 ~re:re64 ~im:(Nx.scalar Nx.float64 2.0))
 
 (* Round-trips *)
 
 let test_roundtrips () =
-  (* polar (abs z) (angle z) recovers z *)
   let z128 = input128 () in
-  let mag = Nx.Complex.abs Nx.float64 z128 in
-  let phase = Nx.Complex.angle Nx.float64 z128 in
-  check_t ~eps:1e-12 "polar/abs/angle complex128" shape samples
-    (Nx.Complex.polar Nx.complex128 mag phase);
-  let z64 = input64 () in
-  let mag32 = Nx.Complex.abs Nx.float32 z64 in
-  let phase32 = Nx.Complex.angle Nx.float32 z64 in
-  check_t ~eps:1e-5 "polar/abs/angle complex64" shape samples
-    (Nx.Complex.polar Nx.complex64 mag32 phase32);
-  (* conj is an involution *)
-  check_t ~eps:1e-12 "conj involution" shape samples
-    (Nx.Complex.conj (Nx.Complex.conj z128));
-  (* real/imag decompose z exactly *)
-  let re_arr = Nx.to_array (Nx.Complex.real Nx.float64 z128) in
-  let im_arr = Nx.to_array (Nx.Complex.imag Nx.float64 z128) in
-  let reassembled =
-    Array.init (Array.length samples) (fun i ->
-        { Complex.re = re_arr.(i); im = im_arr.(i) })
-  in
-  equal ~msg:"real/imag reassembly"
-    (array
-       (Testable.make
-          ~pp:(fun ppf v -> Format.fprintf ppf "(%f, %f)" v.Complex.re v.im)
-          ~equal:(fun a b -> a.Complex.re = b.Complex.re && a.im = b.im)
-          ()))
-    samples reassembled
+  (* real/imag decompose z and complex reassembles it, exactly *)
+  let re = Nx.real Nx.float64 z128 and im = Nx.imag Nx.float64 z128 in
+  equal ~msg:"decompose/reassemble" (array complex_testable) samples
+    (Nx.to_array (Nx.complex Nx.complex128 ~re ~im));
+  (* magnitude and angle recover z through the polar form *)
+  let mag = Nx.magnitude Nx.float64 z128 in
+  let phase = Nx.angle Nx.float64 z128 in
+  check_t ~eps:1e-12 "polar roundtrip" shape samples
+    (Nx.complex Nx.complex128
+       ~re:Nx.(mul mag (cos phase))
+       ~im:Nx.(mul mag (sin phase)));
+  (* conjugate is an involution *)
+  check_t ~eps:1e-12 "conjugate involution" shape samples
+    (Nx.conjugate (Nx.conjugate z128))
 
 (* Result dtypes *)
 
 let test_result_dtypes () =
   let dtype_name t = Nx_core.Dtype.to_string (Nx.dtype t) in
   let z64 = input64 () and z128 = input128 () in
-  equal ~msg:"abs complex64 dtype" string "float32"
-    (dtype_name (Nx.Complex.abs Nx.float32 z64));
-  equal ~msg:"abs complex128 dtype" string "float64"
-    (dtype_name (Nx.Complex.abs Nx.float64 z128));
+  equal ~msg:"magnitude complex64 dtype" string "float32"
+    (dtype_name (Nx.magnitude Nx.float32 z64));
+  equal ~msg:"magnitude complex128 dtype" string "float64"
+    (dtype_name (Nx.magnitude Nx.float64 z128));
   equal ~msg:"angle complex64 dtype" string "float32"
-    (dtype_name (Nx.Complex.angle Nx.float32 z64));
+    (dtype_name (Nx.angle Nx.float32 z64));
   equal ~msg:"real complex128 dtype" string "float64"
-    (dtype_name (Nx.Complex.real Nx.float64 z128));
+    (dtype_name (Nx.real Nx.float64 z128));
   equal ~msg:"imag cross dtype" string "float64"
-    (dtype_name (Nx.Complex.imag Nx.float64 z64));
-  equal ~msg:"conj complex64 dtype" string "complex64"
-    (dtype_name (Nx.Complex.conj z64));
-  equal ~msg:"conj complex128 dtype" string "complex128"
-    (dtype_name (Nx.Complex.conj z128));
-  equal ~msg:"polar complex64 dtype" string "complex64"
+    (dtype_name (Nx.imag Nx.float64 z64));
+  equal ~msg:"conjugate complex64 dtype" string "complex64"
+    (dtype_name (Nx.conjugate z64));
+  equal ~msg:"conjugate complex128 dtype" string "complex128"
+    (dtype_name (Nx.conjugate z128));
+  equal ~msg:"complex ctor dtype" string "complex64"
     (dtype_name
-       (Nx.Complex.polar Nx.complex64 (Nx.scalar Nx.float32 1.0)
-          (Nx.scalar Nx.float32 0.0)))
+       (Nx.complex Nx.complex64
+          ~re:(Nx.scalar Nx.float32 1.0)
+          ~im:(Nx.scalar Nx.float32 0.0)))
 
-(* Branch cuts and non-finite values, pinned to the kernel's behavior *)
+(* Branch cuts *)
 
 let test_branch_cuts () =
   let z =
@@ -160,46 +152,75 @@ let test_branch_cuts () =
         Complex.{ re = 0.0; im = 0.0 };
       |]
   in
-  (* atan2 semantics on the negative real axis: the sign of the zero imaginary
-     part selects the branch, matching C99 carg *)
+  (* the sign of the zero imaginary component selects the side of the cut *)
   check_t ~eps:1e-12 "angle negative reals" [| 4 |] [| pi; -.pi; pi; 0.0 |]
-    (Nx.Complex.angle Nx.float64 z)
+    (Nx.angle Nx.float64 z)
 
-let test_non_finite () =
+(* Non-finite components.
+
+   [real] and [magnitude] read a component directly and stay exact. The others
+   rotate the imaginary component into the real one through a multiply, so a
+   non-finite component poisons the other. The degraded cases below pin that
+   limitation so a future component-level extraction shows up here as a change.
+   They are not a claim that NaN is the wanted answer. *)
+
+let of_list l = Nx.create Nx.complex128 [| List.length l |] (Array.of_list l)
+
+let test_non_finite_exact () =
   let inf = Float.infinity in
   let z =
-    Nx.create Nx.complex128 [| 5 |]
-      [|
+    of_list
+      [
         Complex.{ re = inf; im = 1.0 };
         Complex.{ re = -.inf; im = 0.0 };
         Complex.{ re = inf; im = Float.nan };
         Complex.{ re = Float.nan; im = 1.0 };
         Complex.{ re = 1e300; im = 1e300 };
-      |]
+      ]
   in
-  (* real is exact componentwise, like C creal *)
-  let re = Nx.to_array (Nx.Complex.real Nx.float64 z) in
+  let re = Nx.to_array (Nx.real Nx.float64 z) in
   equal ~msg:"real inf" (float 0.0) inf re.(0);
   equal ~msg:"real -inf" (float 0.0) (-.inf) re.(1);
   is_true ~msg:"real nan" (Float.is_nan re.(3));
-  (* abs follows C99 cabs: infinite even when the other component is NaN, and no
-     overflow for large finite components *)
-  let mag = Nx.to_array (Nx.Complex.abs Nx.float64 z) in
-  equal ~msg:"abs inf" (float 0.0) inf mag.(0);
-  equal ~msg:"abs -inf" (float 0.0) inf mag.(1);
-  equal ~msg:"abs (inf, nan)" (float 0.0) inf mag.(2);
-  is_true ~msg:"abs (nan, finite)" (Float.is_nan mag.(3));
-  equal ~msg:"abs no overflow" (float 1e285) (1e300 *. sqrt 2.0) mag.(4);
-  (* imag routes through complex arithmetic, so a non-finite real part degrades
-     to NaN; a finite real part stays exact *)
-  let im = Nx.to_array (Nx.Complex.imag Nx.float64 z) in
-  is_true ~msg:"imag (inf, finite)" (Float.is_nan im.(0));
-  equal ~msg:"imag large" (float 0.0) 1e300 im.(4);
-  let finite_im =
-    Nx.Complex.imag Nx.float64
-      (Nx.create Nx.complex128 [| 1 |] [| Complex.{ re = 2.0; im = inf } |])
+  equal ~msg:"real large" (float 0.0) 1e300 re.(4);
+  (* the modulus is infinite even when the other component is NaN, and large
+     finite components do not saturate *)
+  let mag = Nx.to_array (Nx.magnitude Nx.float64 z) in
+  equal ~msg:"magnitude inf" (float 0.0) inf mag.(0);
+  equal ~msg:"magnitude -inf" (float 0.0) inf mag.(1);
+  equal ~msg:"magnitude (inf, nan)" (float 0.0) inf mag.(2);
+  is_true ~msg:"magnitude (nan, finite)" (Float.is_nan mag.(3));
+  equal ~msg:"magnitude no overflow" (float 1e285) (1e300 *. sqrt 2.0) mag.(4)
+
+let test_non_finite_degraded () =
+  let inf = Float.infinity in
+  (* a finite real component leaves the imaginary one intact, however large *)
+  let finite_re =
+    of_list
+      [ Complex.{ re = 2.0; im = inf }; Complex.{ re = 0.0; im = 1e300 } ]
   in
-  equal ~msg:"imag (finite, inf)" (float 0.0) inf (Nx.item [ 0 ] finite_im)
+  let im = Nx.to_array (Nx.imag Nx.float64 finite_re) in
+  equal ~msg:"imag (finite, inf)" (float 0.0) inf im.(0);
+  equal ~msg:"imag (finite, large)" (float 0.0) 1e300 im.(1);
+  (* a non-finite real component is the limitation: it contaminates the
+     imaginary one through the rotation *)
+  let bad_re =
+    of_list
+      [ Complex.{ re = inf; im = 1.0 }; Complex.{ re = Float.nan; im = 1.0 } ]
+  in
+  let im = Nx.to_array (Nx.imag Nx.float64 bad_re) in
+  is_true ~msg:"imag (inf, finite) degrades" (Float.is_nan im.(0));
+  is_true ~msg:"imag (nan, finite) degrades" (Float.is_nan im.(1));
+  let ang = Nx.to_array (Nx.angle Nx.float64 bad_re) in
+  is_true ~msg:"angle (inf, finite) degrades" (Float.is_nan ang.(0));
+  (* conjugate degrades the same way, and is exact everywhere else *)
+  let conj = Nx.to_array (Nx.conjugate bad_re) in
+  is_true ~msg:"conjugate (inf, finite) degrades"
+    (Float.is_nan conj.(0).Complex.re);
+  let big = of_list [ Complex.{ re = 1e308; im = 2.0 } ] in
+  let conj_big = (Nx.to_array (Nx.conjugate big)).(0) in
+  equal ~msg:"conjugate large re" (float 0.0) 1e308 conj_big.Complex.re;
+  equal ~msg:"conjugate large im" (float 0.0) (-2.0) conj_big.Complex.im
 
 (* Interaction with rfft: magnitude spectrum of a known signal *)
 
@@ -219,9 +240,9 @@ let test_rfft_magnitude () =
   check_t ~eps:1e-10 "cosine magnitude spectrum"
     [| (n / 2) + 1 |]
     expected
-    (Nx.Complex.abs Nx.float64 spectrum);
+    (Nx.magnitude Nx.float64 spectrum);
   (* the phase of the occupied bin is zero for a pure cosine *)
-  let phase = Nx.Complex.angle Nx.float64 spectrum in
+  let phase = Nx.angle Nx.float64 spectrum in
   equal ~msg:"cosine phase at bin" (float 1e-10) 0.0 (Nx.item [ k ] phase)
 
 let suite =
@@ -229,15 +250,19 @@ let suite =
     group "oracle"
       [
         test "real/imag" test_real_imag;
-        test "abs" test_abs;
+        test "magnitude" test_magnitude;
         test "angle" test_angle;
-        test "conj" test_conj;
-        test "polar" test_polar;
+        test "conjugate" test_conjugate;
+        test "complex" test_complex_ctor;
       ];
     group "roundtrips" [ test "roundtrips" test_roundtrips ];
     group "dtypes" [ test "results" test_result_dtypes ];
     group "edge values"
-      [ test "branch cuts" test_branch_cuts; test "non-finite" test_non_finite ];
+      [
+        test "branch cuts" test_branch_cuts;
+        test "non-finite, exact" test_non_finite_exact;
+        test "non-finite, degraded" test_non_finite_degraded;
+      ];
     group "fft" [ test "rfft magnitude" test_rfft_magnitude ];
   ]
 

--- a/packages/nx/test/test_nx_complex.ml
+++ b/packages/nx/test/test_nx_complex.ml
@@ -1,0 +1,244 @@
+(*---------------------------------------------------------------------------
+  Copyright (c) 2026 The Raven authors. All rights reserved.
+  SPDX-License-Identifier: ISC
+  ---------------------------------------------------------------------------*)
+
+open Windtrap
+open Test_nx_support
+
+let pi = 4.0 *. atan 1.0
+let two_pi = 2.0 *. pi
+
+(* Finite sample values covering all four quadrants, the axes, zeros, and
+   negative reals. Components are exactly representable in float32 so the same
+   array feeds both complex dtypes. *)
+let samples =
+  [|
+    Complex.{ re = 1.0; im = 0.5 };
+    Complex.{ re = -2.25; im = 0.75 };
+    Complex.{ re = -0.5; im = -1.5 };
+    Complex.{ re = 3.0; im = -4.0 };
+    Complex.{ re = 0.0; im = 0.0 };
+    Complex.{ re = -1.0; im = 0.0 };
+    Complex.{ re = 0.0; im = 2.0 };
+    Complex.{ re = 0.0; im = -3.5 };
+    Complex.{ re = 5.0; im = 0.0 };
+    Complex.{ re = -0.125; im = 0.25 };
+    Complex.{ re = 0.5; im = -0.5 };
+    Complex.{ re = -6.0; im = -8.0 };
+  |]
+
+let shape = [| Array.length samples |]
+let input64 () = Nx.create Nx.complex64 shape samples
+let input128 () = Nx.create Nx.complex128 shape samples
+
+(* Oracle checks against per-element stdlib Complex loops *)
+
+let test_real_imag () =
+  let expected_re = Array.map (fun z -> z.Complex.re) samples in
+  let expected_im = Array.map (fun z -> z.Complex.im) samples in
+  check_t "real complex64" shape expected_re
+    (Nx.Complex.real Nx.float32 (input64 ()));
+  check_t ~eps:1e-12 "real complex128" shape expected_re
+    (Nx.Complex.real Nx.float64 (input128 ()));
+  check_t "imag complex64" shape expected_im
+    (Nx.Complex.imag Nx.float32 (input64 ()));
+  check_t ~eps:1e-12 "imag complex128" shape expected_im
+    (Nx.Complex.imag Nx.float64 (input128 ()));
+  (* the output dtype is independent of the input precision *)
+  check_t ~eps:1e-12 "real complex64 to float64" shape expected_re
+    (Nx.Complex.real Nx.float64 (input64 ()))
+
+let test_abs () =
+  let expected = Array.map Complex.norm samples in
+  check_t ~eps:1e-5 "abs complex64" shape expected
+    (Nx.Complex.abs Nx.float32 (input64 ()));
+  check_t ~eps:1e-12 "abs complex128" shape expected
+    (Nx.Complex.abs Nx.float64 (input128 ()));
+  check_t ~eps:1e-5 "abs complex64 to float64" shape expected
+    (Nx.Complex.abs Nx.float64 (input64 ()))
+
+let test_angle () =
+  let expected = Array.map Complex.arg samples in
+  check_t ~eps:1e-5 "angle complex64" shape expected
+    (Nx.Complex.angle Nx.float32 (input64 ()));
+  check_t ~eps:1e-12 "angle complex128" shape expected
+    (Nx.Complex.angle Nx.float64 (input128 ()))
+
+let test_conj () =
+  let expected = Array.map Complex.conj samples in
+  check_t "conj complex64" shape expected (Nx.Complex.conj (input64 ()));
+  check_t ~eps:1e-12 "conj complex128" shape expected
+    (Nx.Complex.conj (input128 ()))
+
+let test_polar () =
+  let r_data = [| 0.0; 0.5; 1.0; 2.0; 3.5; 5.0 |] in
+  let theta_data = [| 0.0; pi; -.pi; 1.5; -0.75; 2.5 |] in
+  let polar_shape = [| Array.length r_data |] in
+  let expected = Array.map2 Complex.polar r_data theta_data in
+  let r64 = Nx.create Nx.float64 polar_shape r_data in
+  let theta64 = Nx.create Nx.float64 polar_shape theta_data in
+  check_t ~eps:1e-12 "polar complex128" polar_shape expected
+    (Nx.Complex.polar Nx.complex128 r64 theta64);
+  let r32 = Nx.create Nx.float32 polar_shape r_data in
+  let theta32 = Nx.create Nx.float32 polar_shape theta_data in
+  check_t ~eps:1e-5 "polar complex64" polar_shape expected
+    (Nx.Complex.polar Nx.complex64 r32 theta32);
+  (* magnitude and phase broadcast together *)
+  let theta_scalar = Nx.scalar Nx.float64 (pi /. 2.0) in
+  let expected_bcast =
+    Array.map (fun r -> Complex.polar r (pi /. 2.0)) r_data
+  in
+  check_t ~eps:1e-12 "polar broadcast" polar_shape expected_bcast
+    (Nx.Complex.polar Nx.complex128 r64 theta_scalar)
+
+(* Round-trips *)
+
+let test_roundtrips () =
+  (* polar (abs z) (angle z) recovers z *)
+  let z128 = input128 () in
+  let mag = Nx.Complex.abs Nx.float64 z128 in
+  let phase = Nx.Complex.angle Nx.float64 z128 in
+  check_t ~eps:1e-12 "polar/abs/angle complex128" shape samples
+    (Nx.Complex.polar Nx.complex128 mag phase);
+  let z64 = input64 () in
+  let mag32 = Nx.Complex.abs Nx.float32 z64 in
+  let phase32 = Nx.Complex.angle Nx.float32 z64 in
+  check_t ~eps:1e-5 "polar/abs/angle complex64" shape samples
+    (Nx.Complex.polar Nx.complex64 mag32 phase32);
+  (* conj is an involution *)
+  check_t ~eps:1e-12 "conj involution" shape samples
+    (Nx.Complex.conj (Nx.Complex.conj z128));
+  (* real/imag decompose z exactly *)
+  let re_arr = Nx.to_array (Nx.Complex.real Nx.float64 z128) in
+  let im_arr = Nx.to_array (Nx.Complex.imag Nx.float64 z128) in
+  let reassembled =
+    Array.init (Array.length samples) (fun i ->
+        { Complex.re = re_arr.(i); im = im_arr.(i) })
+  in
+  equal ~msg:"real/imag reassembly"
+    (array
+       (Testable.make
+          ~pp:(fun ppf v -> Format.fprintf ppf "(%f, %f)" v.Complex.re v.im)
+          ~equal:(fun a b -> a.Complex.re = b.Complex.re && a.im = b.im)
+          ()))
+    samples reassembled
+
+(* Result dtypes *)
+
+let test_result_dtypes () =
+  let dtype_name t = Nx_core.Dtype.to_string (Nx.dtype t) in
+  let z64 = input64 () and z128 = input128 () in
+  equal ~msg:"abs complex64 dtype" string "float32"
+    (dtype_name (Nx.Complex.abs Nx.float32 z64));
+  equal ~msg:"abs complex128 dtype" string "float64"
+    (dtype_name (Nx.Complex.abs Nx.float64 z128));
+  equal ~msg:"angle complex64 dtype" string "float32"
+    (dtype_name (Nx.Complex.angle Nx.float32 z64));
+  equal ~msg:"real complex128 dtype" string "float64"
+    (dtype_name (Nx.Complex.real Nx.float64 z128));
+  equal ~msg:"imag cross dtype" string "float64"
+    (dtype_name (Nx.Complex.imag Nx.float64 z64));
+  equal ~msg:"conj complex64 dtype" string "complex64"
+    (dtype_name (Nx.Complex.conj z64));
+  equal ~msg:"conj complex128 dtype" string "complex128"
+    (dtype_name (Nx.Complex.conj z128));
+  equal ~msg:"polar complex64 dtype" string "complex64"
+    (dtype_name
+       (Nx.Complex.polar Nx.complex64 (Nx.scalar Nx.float32 1.0)
+          (Nx.scalar Nx.float32 0.0)))
+
+(* Branch cuts and non-finite values, pinned to the kernel's behavior *)
+
+let test_branch_cuts () =
+  let z =
+    Nx.create Nx.complex128 [| 4 |]
+      [|
+        Complex.{ re = -1.0; im = 0.0 };
+        Complex.{ re = -1.0; im = -0.0 };
+        Complex.{ re = -0.0; im = 0.0 };
+        Complex.{ re = 0.0; im = 0.0 };
+      |]
+  in
+  (* atan2 semantics on the negative real axis: the sign of the zero imaginary
+     part selects the branch, matching C99 carg *)
+  check_t ~eps:1e-12 "angle negative reals" [| 4 |] [| pi; -.pi; pi; 0.0 |]
+    (Nx.Complex.angle Nx.float64 z)
+
+let test_non_finite () =
+  let inf = Float.infinity in
+  let z =
+    Nx.create Nx.complex128 [| 5 |]
+      [|
+        Complex.{ re = inf; im = 1.0 };
+        Complex.{ re = -.inf; im = 0.0 };
+        Complex.{ re = inf; im = Float.nan };
+        Complex.{ re = Float.nan; im = 1.0 };
+        Complex.{ re = 1e300; im = 1e300 };
+      |]
+  in
+  (* real is exact componentwise, like C creal *)
+  let re = Nx.to_array (Nx.Complex.real Nx.float64 z) in
+  equal ~msg:"real inf" (float 0.0) inf re.(0);
+  equal ~msg:"real -inf" (float 0.0) (-.inf) re.(1);
+  is_true ~msg:"real nan" (Float.is_nan re.(3));
+  (* abs follows C99 cabs: infinite even when the other component is NaN, and no
+     overflow for large finite components *)
+  let mag = Nx.to_array (Nx.Complex.abs Nx.float64 z) in
+  equal ~msg:"abs inf" (float 0.0) inf mag.(0);
+  equal ~msg:"abs -inf" (float 0.0) inf mag.(1);
+  equal ~msg:"abs (inf, nan)" (float 0.0) inf mag.(2);
+  is_true ~msg:"abs (nan, finite)" (Float.is_nan mag.(3));
+  equal ~msg:"abs no overflow" (float 1e285) (1e300 *. sqrt 2.0) mag.(4);
+  (* imag routes through complex arithmetic, so a non-finite real part degrades
+     to NaN; a finite real part stays exact *)
+  let im = Nx.to_array (Nx.Complex.imag Nx.float64 z) in
+  is_true ~msg:"imag (inf, finite)" (Float.is_nan im.(0));
+  equal ~msg:"imag large" (float 0.0) 1e300 im.(4);
+  let finite_im =
+    Nx.Complex.imag Nx.float64
+      (Nx.create Nx.complex128 [| 1 |] [| Complex.{ re = 2.0; im = inf } |])
+  in
+  equal ~msg:"imag (finite, inf)" (float 0.0) inf (Nx.item [ 0 ] finite_im)
+
+(* Interaction with rfft: magnitude spectrum of a known signal *)
+
+let test_rfft_magnitude () =
+  let n = 8 in
+  let k = 2 in
+  let signal =
+    Array.init n (fun i ->
+        cos (two_pi *. float_of_int k *. float_of_int i /. float_of_int n))
+  in
+  let spectrum = Nx.rfft (Nx.create Nx.float64 [| n |] signal) in
+  let expected =
+    Array.init
+      ((n / 2) + 1)
+      (fun i -> if i = k then float_of_int n /. 2.0 else 0.0)
+  in
+  check_t ~eps:1e-10 "cosine magnitude spectrum"
+    [| (n / 2) + 1 |]
+    expected
+    (Nx.Complex.abs Nx.float64 spectrum);
+  (* the phase of the occupied bin is zero for a pure cosine *)
+  let phase = Nx.Complex.angle Nx.float64 spectrum in
+  equal ~msg:"cosine phase at bin" (float 1e-10) 0.0 (Nx.item [ k ] phase)
+
+let suite =
+  [
+    group "oracle"
+      [
+        test "real/imag" test_real_imag;
+        test "abs" test_abs;
+        test "angle" test_angle;
+        test "conj" test_conj;
+        test "polar" test_polar;
+      ];
+    group "roundtrips" [ test "roundtrips" test_roundtrips ];
+    group "dtypes" [ test "results" test_result_dtypes ];
+    group "edge values"
+      [ test "branch cuts" test_branch_cuts; test "non-finite" test_non_finite ];
+    group "fft" [ test "rfft magnitude" test_rfft_magnitude ];
+  ]
+
+let () = run "Nx Complex" suite


### PR DESCRIPTION
The only public route from a complex tensor to its magnitude or phase is currently a boxed `Stdlib.Complex.t` loop: `Nx.abs` preserve the `dtype`, so it cannot perform conversion from complex to float. When you do spectral analysis in DSP, this loop sits on the hottest path of the compute, which is when we gather the magnitude of an FFT.

To solve this, this PR add an `Nx.Complex` module with `real`, `imag`, `abs` (which is the magnitude), `angle`, `conj`, and `polar`. 