### PR TITLE
feat(nx)!: make the real FFT family precision-preserving

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -363,10 +363,10 @@ thread.
 
 ### Nx
 
-- **Breaking:** `rfft`, `irfft`, `hfft`, `ihfft` and their 2-D/N-D variants now
-  take the output dtype first, like the constructors. Real FFTs preserve
-  precision: float32 input can produce a `complex64` spectrum instead of always
-  promoting to `complex128`.
+- **Breaking:** the real FFT family (`rfft`, `irfft`, `hfft`, `ihfft` and their
+  2-D/N-D variants) and `fftfreq`/`rfftfreq` now take the output dtype first,
+  like the constructors. It selects storage precision independent of the
+  input's, so a float32 signal can keep a `complex64` spectrum.
 - Add complex accessors `Nx.real`, `Nx.imag`, `Nx.magnitude`, `Nx.angle` and
   the `Nx.complex ~re ~im` constructor, taking the result dtype first so a
   `complex64` spectrum can yield a `float32` magnitude. `Nx.conjugate` now runs

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -363,6 +363,10 @@ thread.
 
 ### Nx
 
+- **Breaking:** `rfft`, `irfft`, `hfft`, `ihfft` and their 2-D/N-D variants now
+  take the output dtype first, like the constructors. Real FFTs preserve
+  precision: float32 input can produce a `complex64` spectrum instead of always
+  promoting to `complex128`.
 - Add complex accessors `Nx.real`, `Nx.imag`, `Nx.magnitude`, `Nx.angle` and
   the `Nx.complex ~re ~im` constructor, taking the result dtype first so a
   `complex64` spectrum can yield a `float32` magnitude. `Nx.conjugate` now runs

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -363,6 +363,10 @@ thread.
 
 ### Nx
 
+- **Breaking:** `rfft`, `irfft`, `hfft`, `ihfft` and their 2-D/N-D variants now
+  take the output dtype first, like the constructors. Real FFTs preserve
+  precision: float32 input can produce a `complex64` spectrum instead of always
+  promoting to `complex128`.
 - **Breaking:** consolidate tensor formatting around the compact `Nx.pp`,
   `Nx.to_string`, and `Nx.print`. Remove `pp_data`, `data_to_string`,
   `print_data`, `format_to_string`, `print_with_formatter`, `dtype_to_string`,

--- a/packages/nx/doc/03-linear-algebra.md
+++ b/packages/nx/doc/03-linear-algebra.md
@@ -192,11 +192,13 @@ For real-valued inputs, `rfft` is more efficient — it exploits conjugate symme
 
 <!-- $MDX skip -->
 ```ocaml
-let spectrum = Nx.rfft signal           (* n/2+1 complex outputs *)
-let signal_back = Nx.irfft spectrum     (* back to real *)
+(* The first argument picks the output dtype: float32 input can keep a
+   complex64 spectrum instead of promoting to complex128 *)
+let spectrum = Nx.rfft Nx.complex128 signal    (* n/2+1 complex outputs *)
+let signal_back = Nx.irfft Nx.float64 spectrum (* back to real *)
 
-let spectrum_2d = Nx.rfft2 image
-let spectrum_nd = Nx.rfftn ~axes:[0; 1] data
+let spectrum_2d = Nx.rfft2 Nx.complex128 image
+let spectrum_nd = Nx.rfftn Nx.complex128 ~axes:[0; 1] data
 ```
 
 ### Frequency axes

--- a/packages/nx/doc/03-linear-algebra.md
+++ b/packages/nx/doc/03-linear-algebra.md
@@ -192,22 +192,24 @@ For real-valued inputs, `rfft` is more efficient — it exploits conjugate symme
 
 <!-- $MDX skip -->
 ```ocaml
-(* The first argument picks the output dtype: float32 input can keep a
-   complex64 spectrum instead of promoting to complex128 *)
-let spectrum = Nx.rfft Nx.complex128 signal    (* n/2+1 complex outputs *)
-let signal_back = Nx.irfft Nx.float64 spectrum (* back to real *)
+(* The first argument picks the output dtype, independent of the input's.
+   Pair float32 with complex64 to keep a single-precision spectrum. *)
+let spectrum = Nx.rfft Nx.complex64 signal    (* n/2+1 complex outputs *)
+let signal_back = Nx.irfft Nx.float32 spectrum (* back to real *)
 
-let spectrum_2d = Nx.rfft2 Nx.complex128 image
-let spectrum_nd = Nx.rfftn Nx.complex128 ~axes:[0; 1] data
+let spectrum_2d = Nx.rfft2 Nx.complex64 image
+let spectrum_nd = Nx.rfftn Nx.complex64 ~axes:[0; 1] data
 ```
 
 ### Frequency axes
 
+Frequency axes are constructed, so they take their dtype first. Ask for the same precision you transformed at and the frequency bins line up with the spectrum without a cast:
+
 <!-- $MDX skip -->
 ```ocaml
-let freqs = Nx.fftfreq n          (* frequency bins for fft *)
-let rfreqs = Nx.rfftfreq n        (* frequency bins for rfft *)
-let shifted = Nx.fftshift spectrum (* shift zero-frequency to center *)
+let freqs = Nx.fftfreq Nx.float32 n    (* frequency bins for fft *)
+let rfreqs = Nx.rfftfreq Nx.float32 n  (* frequency bins for rfft *)
+let shifted = Nx.fftshift spectrum     (* shift zero-frequency to center *)
 ```
 
 ### Magnitude and phase

--- a/packages/nx/examples/08-signal-processing/README.md
+++ b/packages/nx/examples/08-signal-processing/README.md
@@ -16,6 +16,7 @@ dune exec nx/examples/08-signal-processing/main.exe
 - Identifying dominant frequency components by magnitude
 - Filtering noise by zeroing small-magnitude frequency bins
 - Reconstructing a clean signal with `irfft`
+- Keeping a whole spectral pipeline in single precision
 
 ## Key Functions
 
@@ -23,7 +24,8 @@ dune exec nx/examples/08-signal-processing/main.exe
 | ----------------------------- | ------------------------------------------------- |
 | `rfft dtype t`                | Real-valued FFT (time domain to frequency domain) |
 | `irfft dtype ~n t`            | Inverse real FFT (frequency domain back to time)  |
-| `rfftfreq ~d n`               | Frequency bin labels for `rfft` output            |
+| `rfftfreq dtype ~d n`         | Frequency bin labels for `rfft` output            |
+| `magnitude dtype z`           | Element-wise modulus of a complex spectrum        |
 | `linspace dtype start stop n` | Evenly spaced time samples                        |
 | `sin t`                       | Element-wise sine                                 |
 | `Rng.normal ~key dtype shape` | Gaussian noise                                    |
@@ -42,7 +44,10 @@ Components: 5 Hz (amplitude 1.0) + 20 Hz (amplitude 0.5) + noise
 
 ### Frequency analysis
 
-After `rfft`, compute magnitudes scaled by 2/N to get amplitudes:
+The signal is `float32`, so `rfft complex64` keeps the spectrum in single
+precision — half the bytes a `complex128` spectrum would take — and
+`rfftfreq float32` labels it without a cast. After `rfft`, compute magnitudes
+scaled by 2/N to get amplitudes:
 
 ```
 Dominant frequencies:

--- a/packages/nx/examples/08-signal-processing/README.md
+++ b/packages/nx/examples/08-signal-processing/README.md
@@ -21,8 +21,8 @@ dune exec nx/examples/08-signal-processing/main.exe
 
 | Function                      | Purpose                                           |
 | ----------------------------- | ------------------------------------------------- |
-| `rfft t`                      | Real-valued FFT (time domain to frequency domain) |
-| `irfft ~n t`                  | Inverse real FFT (frequency domain back to time)  |
+| `rfft dtype t`                | Real-valued FFT (time domain to frequency domain) |
+| `irfft dtype ~n t`            | Inverse real FFT (frequency domain back to time)  |
 | `rfftfreq ~d n`               | Frequency bin labels for `rfft` output            |
 | `linspace dtype start stop n` | Evenly spaced time samples                        |
 | `sin t`                       | Element-wise sine                                 |

--- a/packages/nx/examples/08-signal-processing/main.ml
+++ b/packages/nx/examples/08-signal-processing/main.ml
@@ -32,7 +32,7 @@ let () =
     (to_string (slice [ R (0, 8) ] signal));
 
   (* --- Real FFT: transform to frequency domain --- *)
-  let spectrum = rfft signal in
+  let spectrum = rfft complex128 signal in
   let freqs = rfftfreq ~d:dt n in
 
   (* Magnitudes |z| (scaled by 2/N for single-sided spectrum). *)
@@ -60,7 +60,7 @@ let () =
   let clean_spectrum = create Complex128 (shape spectrum) filtered in
 
   (* Inverse FFT back to time domain. *)
-  let clean_signal = irfft ~n clean_spectrum in
+  let clean_signal = irfft float64 ~n clean_spectrum in
 
   Printf.printf "After filtering (threshold=%.1f):\n" threshold;
   Printf.printf "  Original first 8:  %s\n"

--- a/packages/nx/examples/08-signal-processing/main.ml
+++ b/packages/nx/examples/08-signal-processing/main.ml
@@ -2,7 +2,10 @@
 
     Build a signal from two sine waves plus noise. Use the real FFT to identify
     component frequencies, then filter the noise and reconstruct a clean signal.
-*)
+
+    The pipeline stays in single precision throughout: [rfft complex64] keeps
+    the spectrum half the size of a [complex128] one, and [rfftfreq float32]
+    gives a frequency axis that combines with the magnitudes without a cast. *)
 
 open Nx
 open Nx.Infix
@@ -14,10 +17,10 @@ let () =
   let dt = 1.0 /. sample_rate in
 
   (* Time axis: n samples at the given rate. *)
-  let t = linspace float64 0.0 (Float.of_int n *. dt) n ~endpoint:false in
+  let t = linspace float32 0.0 (Float.of_int n *. dt) n ~endpoint:false in
 
   (* Build signal: 5 Hz sine + 20 Hz sine + noise. *)
-  let noise = randn Float64 [| n |] *$ 0.3 in
+  let noise = randn float32 [| n |] *$ 0.3 in
   let pi2 = 2.0 *. Float.pi in
   let signal_5hz = sin (t *$ (pi2 *. 5.0)) in
   let signal_20hz = sin (t *$ (pi2 *. 20.0)) *$ 0.5 in
@@ -32,11 +35,11 @@ let () =
     (to_string (slice [ R (0, 8) ] signal));
 
   (* --- Real FFT: transform to frequency domain --- *)
-  let spectrum = rfft complex128 signal in
-  let freqs = rfftfreq ~d:dt n in
+  let spectrum = rfft complex64 signal in
+  let freqs = rfftfreq float32 ~d:dt n in
 
   (* Magnitudes |z| (scaled by 2/N for single-sided spectrum). *)
-  let magnitudes = magnitude float64 spectrum *$ (2.0 /. Float.of_int n) in
+  let magnitudes = magnitude float32 spectrum *$ (2.0 /. Float.of_int n) in
 
   (* Find the dominant frequencies (magnitude > 0.3). *)
   Printf.printf "Dominant frequencies:\n";
@@ -57,10 +60,10 @@ let () =
         if Stdlib.( < ) mag_arr.(i) threshold then Complex.zero else c)
       (to_array spectrum)
   in
-  let clean_spectrum = create Complex128 (shape spectrum) filtered in
+  let clean_spectrum = create complex64 (shape spectrum) filtered in
 
   (* Inverse FFT back to time domain. *)
-  let clean_signal = irfft float64 ~n clean_spectrum in
+  let clean_signal = irfft float32 ~n clean_spectrum in
 
   Printf.printf "After filtering (threshold=%.1f):\n" threshold;
   Printf.printf "  Original first 8:  %s\n"

--- a/packages/nx/examples/08-signal-processing/main.ml
+++ b/packages/nx/examples/08-signal-processing/main.ml
@@ -32,7 +32,7 @@ let () =
     (to_string (slice [ R (0, 8) ] signal));
 
   (* --- Real FFT: transform to frequency domain --- *)
-  let spectrum = rfft signal in
+  let spectrum = rfft complex128 signal in
   let freqs = rfftfreq ~d:dt n in
 
   (* Magnitudes (scaled by 2/N for single-sided spectrum). Extract real and
@@ -70,7 +70,7 @@ let () =
   let clean_spectrum = create Complex128 (shape spectrum) filtered in
 
   (* Inverse FFT back to time domain. *)
-  let clean_signal = irfft ~n clean_spectrum in
+  let clean_signal = irfft float64 ~n clean_spectrum in
 
   Printf.printf "After filtering (threshold=%.1f):\n" threshold;
   Printf.printf "  Original first 8:  %s\n"

--- a/packages/nx/lib/core/frontend.ml
+++ b/packages/nx/lib/core/frontend.ml
@@ -3893,8 +3893,7 @@ module Make (B : Backend_intf.S) = struct
     rfftn dtype x ~axes:[ axis ] ~s:[ n ] ?norm
 
   (* FFT helpers *)
-  let fftfreq ctx ?(d = 1.0) n =
-    let dt = Dtype.float64 in
+  let fftfreq ctx dt ?(d = 1.0) n =
     let v = 1.0 /. (float_of_int n *. d) in
     let freqs =
       if n mod 2 = 0 then
@@ -3912,8 +3911,7 @@ module Make (B : Backend_intf.S) = struct
     in
     mul_s freqs v
 
-  let rfftfreq ctx ?(d = 1.0) n =
-    let dt = Dtype.float64 in
+  let rfftfreq ctx dt ?(d = 1.0) n =
     let v = 1.0 /. (float_of_int n *. d) in
     mul (cast dt (arange ctx Dtype.int32 0 ((n / 2) + 1) 1)) (scalar ctx dt v)
 

--- a/packages/nx/lib/core/frontend.ml
+++ b/packages/nx/lib/core/frontend.ml
@@ -3982,8 +3982,8 @@ module Make (B : Backend_intf.S) = struct
             window;
         w
 
-  let stft (type c) (cdt : (Complex.t, c) Dtype.t) ~window ?step ?win x :
-      (Complex.t, c) t =
+  let stft (cdt : (Complex.t, 'c) Dtype.t) ~window ?step ?win x :
+      (Complex.t, 'c) t =
     let step = stft_step ~window step in
     let r = ndim x in
     if r < 1 then err "stft" "input must have at least 1 dimension";
@@ -3994,15 +3994,10 @@ module Make (B : Backend_intf.S) = struct
       err "stft" "window %d exceeds the %d samples on the last axis" window n;
     let w = taper "stft" (B.context x) (B.dtype x) ~window win in
     let frames = B.sliding_window x ~axis:(r - 1) ~window ~step in
-    let spectrum = rfft Dtype.Complex128 (mul frames w) ~axis:(-1) in
-    (* [rfft] fixes its own output dtype, so honor [cdt] with a trailing
-       conversion — a no-op when they already agree. *)
-    match Dtype.equal_witness (dtype spectrum) cdt with
-    | Some Type.Equal -> spectrum
-    | None -> cast cdt spectrum
+    rfft cdt (mul frames w) ~axis:(-1)
 
-  let istft (type a) (dt : (float, a) Dtype.t) ~window ?step ?win ?length z :
-      (float, a) t =
+  let istft (dt : (float, 'a) Dtype.t) ~window ?step ?win ?length z :
+      (float, 'a) t =
     let step = stft_step ~window step in
     let r = ndim z in
     if r < 2 then err "istft" "input must have at least 2 dimensions";
@@ -4037,9 +4032,7 @@ module Make (B : Backend_intf.S) = struct
         ~dilation:[| 1 |]
         ~padding:[| (0, 0) |]
     in
-    let windowed =
-      mul (cast dt (irfft Dtype.Float64 z ~axis:(-1) ~n:window)) w
-    in
+    let windowed = mul (irfft dt z ~axis:(-1) ~n:window) w in
     let signal = overlap_add windowed in
     let envelope =
       overlap_add

--- a/packages/nx/lib/core/frontend.ml
+++ b/packages/nx/lib/core/frontend.ml
@@ -3765,7 +3765,7 @@ module Make (B : Backend_intf.S) = struct
     let r = B.ifft xp ~axes:(Array.of_list axes_list) in
     apply_fft_scale scale r
 
-  let rfftn ?axes ?s ?(norm = `Backward) x =
+  let rfftn dtype ?axes ?s ?(norm = `Backward) x =
     let nd = ndim x in
     let axes_list =
       match axes with
@@ -3775,10 +3775,10 @@ module Make (B : Backend_intf.S) = struct
     in
     let xp = pad_or_truncate_for_fft x axes_list s in
     let scale = fft_norm_scale norm axes_list xp in
-    let r = B.rfft xp ~dtype:Dtype.Complex128 ~axes:(Array.of_list axes_list) in
+    let r = B.rfft xp ~dtype ~axes:(Array.of_list axes_list) in
     apply_fft_scale scale r
 
-  let irfftn ?axes ?s ?(norm = `Backward) x =
+  let irfftn dtype ?axes ?s ?(norm = `Backward) x =
     let nd = ndim x in
     let axes_list =
       match axes with
@@ -3807,9 +3807,7 @@ module Make (B : Backend_intf.S) = struct
     let s_param =
       match s with None -> None | Some _ -> Some (Array.of_list output_sizes)
     in
-    let r =
-      B.irfft ?s:s_param x ~dtype:Dtype.Float64 ~axes:(Array.of_list axes_list)
-    in
+    let r = B.irfft ?s:s_param x ~dtype ~axes:(Array.of_list axes_list) in
     if norm_scale <> 1.0 then
       mul r (scalar (B.context r) (B.dtype r) norm_scale)
     else r
@@ -3823,13 +3821,13 @@ module Make (B : Backend_intf.S) = struct
     let s = match n with None -> None | Some sz -> Some [ sz ] in
     ifftn x ~axes:[ axis ] ?s ~norm
 
-  let rfft ?(axis = -1) ?n ?(norm = `Backward) x =
+  let rfft dtype ?(axis = -1) ?n ?(norm = `Backward) x =
     let s = match n with None -> None | Some sz -> Some [ sz ] in
-    rfftn x ~axes:[ axis ] ?s ~norm
+    rfftn dtype x ~axes:[ axis ] ?s ~norm
 
-  let irfft ?(axis = -1) ?n ?(norm = `Backward) x =
+  let irfft dtype ?(axis = -1) ?n ?(norm = `Backward) x =
     let s = match n with None -> None | Some sz -> Some [ sz ] in
-    irfftn x ~axes:[ axis ] ?s ~norm
+    irfftn dtype x ~axes:[ axis ] ?s ~norm
 
   (* 2D FFT *)
 
@@ -3863,36 +3861,36 @@ module Make (B : Backend_intf.S) = struct
         (match axes with None -> List.init (ndim x) Fun.id | Some ax -> ax)
       ?s ~norm
 
-  let rfft2 ?axes ?s ?(norm = `Backward) x =
+  let rfft2 dtype ?axes ?s ?(norm = `Backward) x =
     let axes_list = check_fft2 ~op:"rfft2" x axes in
-    rfftn x ~axes:axes_list ?s ~norm
+    rfftn dtype x ~axes:axes_list ?s ~norm
 
-  let irfft2 ?axes ?s ?(norm = `Backward) x =
+  let irfft2 dtype ?axes ?s ?(norm = `Backward) x =
     let axes_list = check_fft2 ~op:"irfft2" x axes in
-    irfftn x ~axes:axes_list ?s ~norm
+    irfftn dtype x ~axes:axes_list ?s ~norm
 
-  let rfftn ?axes ?s ?(norm = `Backward) x =
-    rfftn x
+  let rfftn dtype ?axes ?s ?(norm = `Backward) x =
+    rfftn dtype x
       ~axes:
         (match axes with None -> List.init (ndim x) Fun.id | Some ax -> ax)
       ?s ~norm
 
-  let irfftn ?axes ?s ?(norm = `Backward) x =
-    irfftn x
+  let irfftn dtype ?axes ?s ?(norm = `Backward) x =
+    irfftn dtype x
       ~axes:
         (match axes with None -> List.init (ndim x) Fun.id | Some ax -> ax)
       ?s ~norm
 
   (* Hermitian FFT *)
-  let hfft ?(axis = -1) ?n ?norm x =
+  let hfft dtype ?(axis = -1) ?n ?norm x =
     let n = match n with None -> 2 * (dim axis x - 1) | Some n -> n in
     let axis = resolve_single_axis x axis in
-    irfftn x ~axes:[ axis ] ~s:[ n ] ?norm
+    irfftn dtype x ~axes:[ axis ] ~s:[ n ] ?norm
 
-  let ihfft ?(axis = -1) ?n ?norm x =
+  let ihfft dtype ?(axis = -1) ?n ?norm x =
     let n = match n with None -> dim axis x | Some n -> n in
     let axis = resolve_single_axis x axis in
-    rfftn x ~axes:[ axis ] ~s:[ n ] ?norm
+    rfftn dtype x ~axes:[ axis ] ~s:[ n ] ?norm
 
   (* FFT helpers *)
   let fftfreq ctx ?(d = 1.0) n =
@@ -3998,7 +3996,7 @@ module Make (B : Backend_intf.S) = struct
       err "stft" "window %d exceeds the %d samples on the last axis" window n;
     let w = taper "stft" (B.context x) (B.dtype x) ~window win in
     let frames = B.sliding_window x ~axis:(r - 1) ~window ~step in
-    let spectrum = rfft (mul frames w) ~axis:(-1) in
+    let spectrum = rfft Dtype.Complex128 (mul frames w) ~axis:(-1) in
     (* [rfft] fixes its own output dtype, so honor [cdt] with a trailing
        conversion — a no-op when they already agree. *)
     match Dtype.equal_witness (dtype spectrum) cdt with
@@ -4041,7 +4039,9 @@ module Make (B : Backend_intf.S) = struct
         ~dilation:[| 1 |]
         ~padding:[| (0, 0) |]
     in
-    let windowed = mul (cast dt (irfft z ~axis:(-1) ~n:window)) w in
+    let windowed =
+      mul (cast dt (irfft Dtype.Float64 z ~axis:(-1) ~n:window)) w
+    in
     let signal = overlap_add windowed in
     let envelope =
       overlap_add

--- a/packages/nx/lib/core/frontend.ml
+++ b/packages/nx/lib/core/frontend.ml
@@ -3799,7 +3799,7 @@ module Make (B : Backend_intf.S) = struct
     let r = B.ifft xp ~axes:(Array.of_list axes_list) in
     apply_fft_scale scale r
 
-  let rfftn ?axes ?s ?(norm = `Backward) x =
+  let rfftn dtype ?axes ?s ?(norm = `Backward) x =
     let nd = ndim x in
     let axes_list =
       match axes with
@@ -3809,10 +3809,10 @@ module Make (B : Backend_intf.S) = struct
     in
     let xp = pad_or_truncate_for_fft x axes_list s in
     let scale = fft_norm_scale norm axes_list xp in
-    let r = B.rfft xp ~dtype:Dtype.Complex128 ~axes:(Array.of_list axes_list) in
+    let r = B.rfft xp ~dtype ~axes:(Array.of_list axes_list) in
     apply_fft_scale scale r
 
-  let irfftn ?axes ?s ?(norm = `Backward) x =
+  let irfftn dtype ?axes ?s ?(norm = `Backward) x =
     let nd = ndim x in
     let axes_list =
       match axes with
@@ -3841,9 +3841,7 @@ module Make (B : Backend_intf.S) = struct
     let s_param =
       match s with None -> None | Some _ -> Some (Array.of_list output_sizes)
     in
-    let r =
-      B.irfft ?s:s_param x ~dtype:Dtype.Float64 ~axes:(Array.of_list axes_list)
-    in
+    let r = B.irfft ?s:s_param x ~dtype ~axes:(Array.of_list axes_list) in
     if norm_scale <> 1.0 then
       mul r (scalar (B.context r) (B.dtype r) norm_scale)
     else r
@@ -3857,13 +3855,13 @@ module Make (B : Backend_intf.S) = struct
     let s = match n with None -> None | Some sz -> Some [ sz ] in
     ifftn x ~axes:[ axis ] ?s ~norm
 
-  let rfft ?(axis = -1) ?n ?(norm = `Backward) x =
+  let rfft dtype ?(axis = -1) ?n ?(norm = `Backward) x =
     let s = match n with None -> None | Some sz -> Some [ sz ] in
-    rfftn x ~axes:[ axis ] ?s ~norm
+    rfftn dtype x ~axes:[ axis ] ?s ~norm
 
-  let irfft ?(axis = -1) ?n ?(norm = `Backward) x =
+  let irfft dtype ?(axis = -1) ?n ?(norm = `Backward) x =
     let s = match n with None -> None | Some sz -> Some [ sz ] in
-    irfftn x ~axes:[ axis ] ?s ~norm
+    irfftn dtype x ~axes:[ axis ] ?s ~norm
 
   (* 2D FFT *)
 
@@ -3897,36 +3895,36 @@ module Make (B : Backend_intf.S) = struct
         (match axes with None -> List.init (ndim x) Fun.id | Some ax -> ax)
       ?s ~norm
 
-  let rfft2 ?axes ?s ?(norm = `Backward) x =
+  let rfft2 dtype ?axes ?s ?(norm = `Backward) x =
     let axes_list = check_fft2 ~op:"rfft2" x axes in
-    rfftn x ~axes:axes_list ?s ~norm
+    rfftn dtype x ~axes:axes_list ?s ~norm
 
-  let irfft2 ?axes ?s ?(norm = `Backward) x =
+  let irfft2 dtype ?axes ?s ?(norm = `Backward) x =
     let axes_list = check_fft2 ~op:"irfft2" x axes in
-    irfftn x ~axes:axes_list ?s ~norm
+    irfftn dtype x ~axes:axes_list ?s ~norm
 
-  let rfftn ?axes ?s ?(norm = `Backward) x =
-    rfftn x
+  let rfftn dtype ?axes ?s ?(norm = `Backward) x =
+    rfftn dtype x
       ~axes:
         (match axes with None -> List.init (ndim x) Fun.id | Some ax -> ax)
       ?s ~norm
 
-  let irfftn ?axes ?s ?(norm = `Backward) x =
-    irfftn x
+  let irfftn dtype ?axes ?s ?(norm = `Backward) x =
+    irfftn dtype x
       ~axes:
         (match axes with None -> List.init (ndim x) Fun.id | Some ax -> ax)
       ?s ~norm
 
   (* Hermitian FFT *)
-  let hfft ?(axis = -1) ?n ?norm x =
+  let hfft dtype ?(axis = -1) ?n ?norm x =
     let n = match n with None -> 2 * (dim axis x - 1) | Some n -> n in
     let axis = resolve_single_axis x axis in
-    irfftn x ~axes:[ axis ] ~s:[ n ] ?norm
+    irfftn dtype x ~axes:[ axis ] ~s:[ n ] ?norm
 
-  let ihfft ?(axis = -1) ?n ?norm x =
+  let ihfft dtype ?(axis = -1) ?n ?norm x =
     let n = match n with None -> dim axis x | Some n -> n in
     let axis = resolve_single_axis x axis in
-    rfftn x ~axes:[ axis ] ~s:[ n ] ?norm
+    rfftn dtype x ~axes:[ axis ] ~s:[ n ] ?norm
 
   (* FFT helpers *)
   let fftfreq ctx ?(d = 1.0) n =

--- a/packages/nx/lib/nx.ml
+++ b/packages/nx/lib/nx.ml
@@ -88,6 +88,6 @@ let truncated_normal dtype ~lower ~upper shape =
 
 (* ───── FFT ───── *)
 
-let fftfreq ?d n = F.fftfreq (Lazy.force context) ?d n
-let rfftfreq ?d n = F.rfftfreq (Lazy.force context) ?d n
+let fftfreq dtype ?d n = F.fftfreq (Lazy.force context) dtype ?d n
+let rfftfreq dtype ?d n = F.rfftfreq (Lazy.force context) dtype ?d n
 let hann dt n = F.hann (Lazy.force context) dt n

--- a/packages/nx/lib/nx.mli
+++ b/packages/nx/lib/nx.mli
@@ -2695,20 +2695,23 @@ val idstn :
   (float, 'a) t
 (** [idstn ?type_ ?axes ?norm x] is the inverse of {!dstn}. *)
 
-val fftfreq : ?d:float -> int -> (float, float64_elt) t
-(** [fftfreq ?d n] is the DFT sample frequencies for window length [n] and
-    sample spacing [d] (default [1.0]).
+val fftfreq : (float, 'a) dtype -> ?d:float -> int -> (float, 'a) t
+(** [fftfreq dtype ?d n] is the DFT sample frequencies for window length [n] and
+    sample spacing [d] (default [1.0]), as a tensor of dtype [dtype]. Pair it
+    with the dtype the spectrum was transformed at so the frequency axis and the
+    magnitudes combine without a {!cast}.
 
     {@ocaml[
-      # fftfreq 4
+      # fftfreq float64 4
       - : (float, float64_elt) t = [0, 0.25, -0.5, -0.25]
     ]}
 
     See also {!rfftfreq}. *)
 
-val rfftfreq : ?d:float -> int -> (float, float64_elt) t
-(** [rfftfreq ?d n] is the positive DFT sample frequencies:
-    [[0, 1, …, n/2] / (d * n)].
+val rfftfreq : (float, 'a) dtype -> ?d:float -> int -> (float, 'a) t
+(** [rfftfreq dtype ?d n] is the positive DFT sample frequencies:
+    [[0, 1, …, n/2] / (d * n)], as a tensor of dtype [dtype]. This is the
+    frequency axis matching {!rfft}'s output.
 
     See also {!fftfreq}. *)
 
@@ -2717,7 +2720,7 @@ val fftshift : ?axes:int list -> ('a, 'b) t -> ('a, 'b) t
     defaults to all.
 
     {@ocaml[
-      # fftfreq 5 |> fftshift
+      # fftfreq float64 5 |> fftshift
       - : (float, float64_elt) t = float64 [5] [-0.4, -0.2, ..., 0.2, 0.4]
     ]}
 

--- a/packages/nx/lib/nx.mli
+++ b/packages/nx/lib/nx.mli
@@ -2518,10 +2518,15 @@ val rfft :
     [dtype]. Returns only the non-redundant positive frequencies; the output
     size along the transformed axis is [n/2 + 1].
 
-    [dtype] selects the storage precision of the result independently of the
-    input precision: [rfft complex64 x] on float32 input keeps the spectrum in
-    single precision. The transform itself computes in double precision
-    regardless of [dtype].
+    [dtype] selects the storage precision of the result, independent of the
+    input's: the natural pairings are [float32] with [complex64] and [float64]
+    with [complex128], but any pairing is accepted and a narrowing one rounds
+    the spectrum. The result is accurate to at least [dtype]'s precision.
+
+    The normalisation implied by [norm] is applied after the result has been
+    stored as [dtype], so a spectrum whose unnormalised magnitudes overflow
+    [dtype] stays infinite. Transform at the wider dtype and {!cast} afterwards
+    if the input's dynamic range approaches that limit.
 
     {@ocaml[
       # create float64 [| 4 |] [| 0.; 1.; 2.; 3. |]
@@ -2540,8 +2545,7 @@ val irfft :
   (float, 'b) t
 (** [irfft dtype ?axis ?n ?norm x] is the inverse of {!rfft}, producing real
     output stored as [dtype]. Assumes Hermitian symmetry. As with {!rfft},
-    [dtype] is independent of the input precision and the transform computes in
-    double precision.
+    [dtype] selects the storage precision independent of the input's.
 
     See also {!rfft}. *)
 
@@ -2552,7 +2556,9 @@ val rfft2 :
   ?norm:fft_norm ->
   (float, 'a) t ->
   (Complex.t, 'b) t
-(** [rfft2 dtype ?axes ?s ?norm x] is the 2-D FFT of real input.
+(** [rfft2 dtype ?axes ?s ?norm x] is the 2-D FFT of real input, stored as
+    [dtype]. As with {!rfftn}, the intermediate spectrum is carried at [dtype]
+    between the two axis passes.
 
     See also {!irfft2}, {!rfft}. *)
 
@@ -2572,7 +2578,14 @@ val rfftn :
   ?norm:fft_norm ->
   (float, 'a) t ->
   (Complex.t, 'b) t
-(** [rfftn dtype ?axes ?s ?norm x] is the N-D FFT of real input.
+(** [rfftn dtype ?axes ?s ?norm x] is the N-D FFT of real input, stored as
+    [dtype].
+
+    The real-to-complex pass runs along the last of [axes] and the remaining
+    axes are then transformed in place, so with more than one axis the
+    intermediate spectrum is carried at [dtype] rather than at a wider working
+    precision. A narrow [dtype] therefore rounds once per axis. Pass
+    [complex128] and {!cast} afterwards to keep the intermediates wide.
 
     See also {!irfftn}, {!rfft}. *)
 
@@ -2602,7 +2615,8 @@ val ihfft :
   ?norm:fft_norm ->
   (float, 'a) t ->
   (Complex.t, 'b) t
-(** [ihfft dtype ?axis ?n ?norm x] is the inverse of {!hfft}. *)
+(** [ihfft dtype ?axis ?n ?norm x] is the inverse of {!hfft}, producing complex
+    output stored as [dtype]. *)
 
 val dct :
   ?type_:int -> ?axis:int -> ?norm:fft_norm -> (float, 'a) t -> (float, 'a) t

--- a/packages/nx/lib/nx.mli
+++ b/packages/nx/lib/nx.mli
@@ -2508,86 +2508,101 @@ val ifftn :
 (** [ifftn ?axes ?s ?norm x] is the inverse of {!fftn}. *)
 
 val rfft :
+  (Complex.t, 'b) dtype ->
   ?axis:int ->
   ?n:int ->
   ?norm:fft_norm ->
   (float, 'a) t ->
-  (Complex.t, complex64_elt) t
-(** [rfft ?axis ?n ?norm x] is the 1-D FFT of real input. Returns only the
-    non-redundant positive frequencies; the output size along the transformed
-    axis is [n/2 + 1].
+  (Complex.t, 'b) t
+(** [rfft dtype ?axis ?n ?norm x] is the 1-D FFT of real input, stored as
+    [dtype]. Returns only the non-redundant positive frequencies; the output
+    size along the transformed axis is [n/2 + 1].
+
+    [dtype] selects the storage precision of the result independently of the
+    input precision: [rfft complex64 x] on float32 input keeps the spectrum in
+    single precision. The transform itself computes in double precision
+    regardless of [dtype].
 
     {@ocaml[
       # create float64 [| 4 |] [| 0.; 1.; 2.; 3. |]
-        |> rfft |> shape
+        |> rfft complex128 |> shape
       - : int array = [|3|]
     ]}
 
     See also {!irfft}, {!fft}. *)
 
 val irfft :
+  (float, 'b) dtype ->
   ?axis:int ->
   ?n:int ->
   ?norm:fft_norm ->
   (Complex.t, 'a) t ->
-  (float, float64_elt) t
-(** [irfft ?axis ?n ?norm x] is the inverse of {!rfft}, producing real output.
-    Assumes Hermitian symmetry.
+  (float, 'b) t
+(** [irfft dtype ?axis ?n ?norm x] is the inverse of {!rfft}, producing real
+    output stored as [dtype]. Assumes Hermitian symmetry. As with {!rfft},
+    [dtype] is independent of the input precision and the transform computes in
+    double precision.
 
     See also {!rfft}. *)
 
 val rfft2 :
+  (Complex.t, 'b) dtype ->
   ?axes:int list ->
   ?s:int list ->
   ?norm:fft_norm ->
   (float, 'a) t ->
-  (Complex.t, complex64_elt) t
-(** [rfft2 ?axes ?s ?norm x] is the 2-D FFT of real input.
+  (Complex.t, 'b) t
+(** [rfft2 dtype ?axes ?s ?norm x] is the 2-D FFT of real input.
 
     See also {!irfft2}, {!rfft}. *)
 
 val irfft2 :
+  (float, 'b) dtype ->
   ?axes:int list ->
   ?s:int list ->
   ?norm:fft_norm ->
   (Complex.t, 'a) t ->
-  (float, float64_elt) t
-(** [irfft2 ?axes ?s ?norm x] is the inverse of {!rfft2}. *)
+  (float, 'b) t
+(** [irfft2 dtype ?axes ?s ?norm x] is the inverse of {!rfft2}. *)
 
 val rfftn :
+  (Complex.t, 'b) dtype ->
   ?axes:int list ->
   ?s:int list ->
   ?norm:fft_norm ->
   (float, 'a) t ->
-  (Complex.t, complex64_elt) t
-(** [rfftn ?axes ?s ?norm x] is the N-D FFT of real input.
+  (Complex.t, 'b) t
+(** [rfftn dtype ?axes ?s ?norm x] is the N-D FFT of real input.
 
     See also {!irfftn}, {!rfft}. *)
 
 val irfftn :
+  (float, 'b) dtype ->
   ?axes:int list ->
   ?s:int list ->
   ?norm:fft_norm ->
   (Complex.t, 'a) t ->
-  (float, float64_elt) t
-(** [irfftn ?axes ?s ?norm x] is the inverse of {!rfftn}. *)
+  (float, 'b) t
+(** [irfftn dtype ?axes ?s ?norm x] is the inverse of {!rfftn}. *)
 
 val hfft :
+  (float, 'b) dtype ->
   ?axis:int ->
   ?n:int ->
   ?norm:fft_norm ->
   (Complex.t, 'a) t ->
-  (float, float64_elt) t
-(** [hfft ?axis ?n ?norm x] is the FFT of a signal with Hermitian symmetry,
-    producing real output. *)
+  (float, 'b) t
+(** [hfft dtype ?axis ?n ?norm x] is the FFT of a signal with Hermitian
+    symmetry, producing real output stored as [dtype]. *)
 
 val ihfft :
+  (Complex.t, 'b) dtype ->
   ?axis:int ->
   ?n:int ->
   ?norm:fft_norm ->
   (float, 'a) t ->
-  (Complex.t, complex64_elt) t
-(** [ihfft ?axis ?n ?norm x] is the inverse of {!hfft}. *)
+  (Complex.t, 'b) t
+(** [ihfft dtype ?axis ?n ?norm x] is the inverse of {!hfft}. *)
 
 val dct :
   ?type_:int -> ?axis:int -> ?norm:fft_norm -> (float, 'a) t -> (float, 'a) t

--- a/packages/nx/lib/nx.mli
+++ b/packages/nx/lib/nx.mli
@@ -2428,86 +2428,101 @@ val ifftn :
 (** [ifftn ?axes ?s ?norm x] is the inverse of {!fftn}. *)
 
 val rfft :
+  (Complex.t, 'b) dtype ->
   ?axis:int ->
   ?n:int ->
   ?norm:fft_norm ->
   (float, 'a) t ->
-  (Complex.t, complex64_elt) t
-(** [rfft ?axis ?n ?norm x] is the 1-D FFT of real input. Returns only the
-    non-redundant positive frequencies; the output size along the transformed
-    axis is [n/2 + 1].
+  (Complex.t, 'b) t
+(** [rfft dtype ?axis ?n ?norm x] is the 1-D FFT of real input, stored as
+    [dtype]. Returns only the non-redundant positive frequencies; the output
+    size along the transformed axis is [n/2 + 1].
+
+    [dtype] selects the storage precision of the result independently of the
+    input precision: [rfft complex64 x] on float32 input keeps the spectrum in
+    single precision. The transform itself computes in double precision
+    regardless of [dtype].
 
     {@ocaml[
       # create float64 [| 4 |] [| 0.; 1.; 2.; 3. |]
-        |> rfft |> shape
+        |> rfft complex128 |> shape
       - : int array = [|3|]
     ]}
 
     See also {!irfft}, {!fft}. *)
 
 val irfft :
+  (float, 'b) dtype ->
   ?axis:int ->
   ?n:int ->
   ?norm:fft_norm ->
   (Complex.t, 'a) t ->
-  (float, float64_elt) t
-(** [irfft ?axis ?n ?norm x] is the inverse of {!rfft}, producing real output.
-    Assumes Hermitian symmetry.
+  (float, 'b) t
+(** [irfft dtype ?axis ?n ?norm x] is the inverse of {!rfft}, producing real
+    output stored as [dtype]. Assumes Hermitian symmetry. As with {!rfft},
+    [dtype] is independent of the input precision and the transform computes in
+    double precision.
 
     See also {!rfft}. *)
 
 val rfft2 :
+  (Complex.t, 'b) dtype ->
   ?axes:int list ->
   ?s:int list ->
   ?norm:fft_norm ->
   (float, 'a) t ->
-  (Complex.t, complex64_elt) t
-(** [rfft2 ?axes ?s ?norm x] is the 2-D FFT of real input.
+  (Complex.t, 'b) t
+(** [rfft2 dtype ?axes ?s ?norm x] is the 2-D FFT of real input.
 
     See also {!irfft2}, {!rfft}. *)
 
 val irfft2 :
+  (float, 'b) dtype ->
   ?axes:int list ->
   ?s:int list ->
   ?norm:fft_norm ->
   (Complex.t, 'a) t ->
-  (float, float64_elt) t
-(** [irfft2 ?axes ?s ?norm x] is the inverse of {!rfft2}. *)
+  (float, 'b) t
+(** [irfft2 dtype ?axes ?s ?norm x] is the inverse of {!rfft2}. *)
 
 val rfftn :
+  (Complex.t, 'b) dtype ->
   ?axes:int list ->
   ?s:int list ->
   ?norm:fft_norm ->
   (float, 'a) t ->
-  (Complex.t, complex64_elt) t
-(** [rfftn ?axes ?s ?norm x] is the N-D FFT of real input.
+  (Complex.t, 'b) t
+(** [rfftn dtype ?axes ?s ?norm x] is the N-D FFT of real input.
 
     See also {!irfftn}, {!rfft}. *)
 
 val irfftn :
+  (float, 'b) dtype ->
   ?axes:int list ->
   ?s:int list ->
   ?norm:fft_norm ->
   (Complex.t, 'a) t ->
-  (float, float64_elt) t
-(** [irfftn ?axes ?s ?norm x] is the inverse of {!rfftn}. *)
+  (float, 'b) t
+(** [irfftn dtype ?axes ?s ?norm x] is the inverse of {!rfftn}. *)
 
 val hfft :
+  (float, 'b) dtype ->
   ?axis:int ->
   ?n:int ->
   ?norm:fft_norm ->
   (Complex.t, 'a) t ->
-  (float, float64_elt) t
-(** [hfft ?axis ?n ?norm x] is the FFT of a signal with Hermitian symmetry,
-    producing real output. *)
+  (float, 'b) t
+(** [hfft dtype ?axis ?n ?norm x] is the FFT of a signal with Hermitian
+    symmetry, producing real output stored as [dtype]. *)
 
 val ihfft :
+  (Complex.t, 'b) dtype ->
   ?axis:int ->
   ?n:int ->
   ?norm:fft_norm ->
   (float, 'a) t ->
-  (Complex.t, complex64_elt) t
-(** [ihfft ?axis ?n ?norm x] is the inverse of {!hfft}. *)
+  (Complex.t, 'b) t
+(** [ihfft dtype ?axis ?n ?norm x] is the inverse of {!hfft}. *)
 
 val dct :
   ?type_:int -> ?axis:int -> ?norm:fft_norm -> (float, 'a) t -> (float, 'a) t

--- a/packages/nx/test/backend_contract.ml
+++ b/packages/nx/test/backend_contract.ml
@@ -3025,6 +3025,83 @@ struct
                   1. +. root2;
                 |]
                 (F.to_array back));
+          case classify path "rfft-complex64-vs-dft" (fun () ->
+              (* ~dtype fixes the output's storage precision. Every value here
+                 is exactly representable in float32, so the only error left is
+                 the complex64 store. *)
+              let n = 8 in
+              let data =
+                Array.init n (fun i -> float_of_int ((i mod 4) - 1) +. 0.5)
+              in
+              let t = F.create ctx F.float32 [| n |] data in
+              let spec = B.rfft t ~dtype:F.complex64 ~axes:[| 0 |] in
+              let full =
+                dft ~inverse:false (Array.map (fun v -> z v 0.) data)
+              in
+              equal ~msg:"rfft complex64 = half of DFT"
+                (array (ctest ~rel:1e-5 ~abs:1e-5))
+                (Array.sub full 0 ((n / 2) + 1))
+                (F.to_array spec));
+          case classify path "rfft-irfft-complex64-roundtrip" (fun () ->
+              let n = 8 in
+              let data =
+                Array.init n (fun i -> float_of_int ((i mod 4) - 1) +. 0.5)
+              in
+              let t = F.create ctx F.float32 [| n |] data in
+              let spec = B.rfft t ~dtype:F.complex64 ~axes:[| 0 |] in
+              let back =
+                B.irfft ~s:[| n |] spec ~dtype:F.float32 ~axes:[| 0 |]
+              in
+              equal ~msg:"irfft(rfft x) = n x"
+                (array (ftest ~rel:1e-5 ~abs:1e-5))
+                (Array.map (fun v -> v *. float_of_int n) data)
+                (F.to_array back));
+          case classify path "rfft-dtype-independent-of-input" (fun () ->
+              (* the requested dtype is not derived from the input's: a float64
+                 signal may be stored as complex64 and a complex128 spectrum
+                 inverted to float32 *)
+              let n = 8 in
+              let data =
+                Array.init n (fun i -> float_of_int ((i mod 4) - 1) +. 0.5)
+              in
+              let t = F.create ctx F.float64 [| n |] data in
+              let narrow = B.rfft t ~dtype:F.complex64 ~axes:[| 0 |] in
+              let full =
+                dft ~inverse:false (Array.map (fun v -> z v 0.) data)
+              in
+              equal ~msg:"float64 in, complex64 out"
+                (array (ctest ~rel:1e-5 ~abs:1e-5))
+                (Array.sub full 0 ((n / 2) + 1))
+                (F.to_array narrow);
+              let wide = B.rfft t ~dtype:F.complex128 ~axes:[| 0 |] in
+              let back =
+                B.irfft ~s:[| n |] wide ~dtype:F.float32 ~axes:[| 0 |]
+              in
+              equal ~msg:"complex128 in, float32 out"
+                (array (ftest ~rel:1e-5 ~abs:1e-5))
+                (Array.map (fun v -> v *. float_of_int n) data)
+                (F.to_array back));
+          case classify path "rfft-2d-complex64-roundtrip" (fun () ->
+              (* two axes: the real→complex pass writes at ~dtype and the
+                 remaining axis is transformed in place at that same dtype *)
+              let rows = 3 and columns = 4 in
+              let data =
+                Array.init (rows * columns) (fun i ->
+                    float_of_int ((i mod 4) - 1) +. 0.5)
+              in
+              let t = F.create ctx F.float32 [| rows; columns |] data in
+              let spec = B.rfft t ~dtype:F.complex64 ~axes:[| 0; 1 |] in
+              equal ~msg:"half-spectrum shape" (array int)
+                [| rows; (columns / 2) + 1 |]
+                (F.shape spec);
+              let back =
+                B.irfft ~s:[| rows; columns |] spec ~dtype:F.float32
+                  ~axes:[| 0; 1 |]
+              in
+              equal ~msg:"irfft(rfft x) = rows*columns x"
+                (array (ftest ~rel:1e-5 ~abs:1e-5))
+                (Array.map (fun v -> v *. float_of_int (rows * columns)) data)
+                (F.to_array back));
           case classify path "fft-known-value" (fun () ->
               (* hand-computed: fft([1,1,1,1]) = [4,0,0,0]; fft of a unit delta
                  [1,0,0,0] = [1,1,1,1] (all ones). *)

--- a/packages/nx/test/test_nx_complex.ml
+++ b/packages/nx/test/test_nx_complex.ml
@@ -231,7 +231,7 @@ let test_rfft_magnitude () =
     Array.init n (fun i ->
         cos (two_pi *. float_of_int k *. float_of_int i /. float_of_int n))
   in
-  let spectrum = Nx.rfft (Nx.create Nx.float64 [| n |] signal) in
+  let spectrum = Nx.rfft Nx.complex128 (Nx.create Nx.float64 [| n |] signal) in
   let expected =
     Array.init
       ((n / 2) + 1)

--- a/packages/nx/test/test_nx_fft.ml
+++ b/packages/nx/test/test_nx_fft.ml
@@ -592,30 +592,62 @@ let test_hfft_ihfft () =
 let test_fftfreq () =
   let n = 5 in
   let shape = [| n |] in
-  let freq = Nx.fftfreq n in
+  let freq = Nx.fftfreq Nx.float64 n in
   let expected_data = [| 0.0; 0.2; 0.4; -0.4; -0.2 |] in
   check_t "fftfreq odd" shape expected_data freq;
 
   let n_even = 4 in
   let shape_even = [| n_even |] in
-  let freq_even = Nx.fftfreq n_even ~d:0.5 in
+  let freq_even = Nx.fftfreq Nx.float64 n_even ~d:0.5 in
   let expected_even_data = [| 0.0; 0.5; -1.0; -0.5 |] in
   check_t "fftfreq even" shape_even expected_even_data freq_even
 
 let test_rfftfreq () =
   let n = 8 in
   let shape = [| (n / 2) + 1 |] in
-  let freq = Nx.rfftfreq n in
+  let freq = Nx.rfftfreq Nx.float64 n in
   let expected_data = [| 0.0; 0.125; 0.25; 0.375; 0.5 |] in
   check_t "rfftfreq even" shape expected_data freq;
 
   let n_odd = 9 in
   let shape_odd = [| (n_odd / 2) + 1 |] in
-  let freq_odd = Nx.rfftfreq n_odd ~d:2.0 in
+  let freq_odd = Nx.rfftfreq Nx.float64 n_odd ~d:2.0 in
   let expected_odd_data =
     [| 0.0; 0.055555555555; 0.111111111111; 0.166666666666; 0.222222222222 |]
   in
   check_t ~eps:1e-8 "rfftfreq odd" shape_odd expected_odd_data freq_odd
+
+let test_fftfreq_dtypes () =
+  (* The frequency axis is a constructor: its dtype is chosen, not derived, so
+     it can be matched to the dtype the spectrum was transformed at. *)
+  let n = 4 in
+  let shape = [| n |] in
+  let spectrum_shape = [| (n / 2) + 1 |] in
+  let expected = [| 0.0; 0.25; -0.5; -0.25 |] in
+  let freq32 = Nx.fftfreq Nx.float32 n in
+  equal ~msg:"fftfreq float32 dtype" string "float32"
+    (Nx_core.Dtype.to_string (Nx.dtype freq32));
+  check_t ~eps:1e-7 "fftfreq float32 values" shape expected freq32;
+
+  let rexpected = [| 0.0; 0.25; 0.5 |] in
+  let rfreq32 = Nx.rfftfreq Nx.float32 n in
+  equal ~msg:"rfftfreq float32 dtype" string "float32"
+    (Nx_core.Dtype.to_string (Nx.dtype rfreq32));
+  check_t ~eps:1e-7 "rfftfreq float32 values" spectrum_shape rexpected rfreq32;
+
+  (* The point of the dtype argument: a single-precision spectrum and its
+     frequency axis combine with no cast in between. *)
+  let signal = Nx.create Nx.float32 shape [| 1.0; 0.0; -1.0; 0.0 |] in
+  let spectrum = Nx.rfft Nx.complex64 signal in
+  equal ~msg:"rfftfreq matches rfft bin count" (array int) (Nx.shape spectrum)
+    (Nx.shape rfreq32);
+  let re =
+    Nx.create Nx.float32 (Nx.shape spectrum)
+      (Array.map (fun c -> c.Complex.re) (Nx.to_array spectrum))
+  in
+  let weighted = [| 0.0; 0.5; 0.0 |] in
+  check_t ~eps:1e-6 "rfftfreq weights an rfft spectrum without a cast"
+    spectrum_shape weighted (Nx.mul rfreq32 re)
 
 let test_fftshift () =
   let x_shape = [| 4 |] in
@@ -838,6 +870,7 @@ let suite =
       [
         test "fftfreq" test_fftfreq;
         test "rfftfreq" test_rfftfreq;
+        test "freq dtypes" test_fftfreq_dtypes;
         test "shifts" test_fftshift;
       ];
   ]

--- a/packages/nx/test/test_nx_fft.ml
+++ b/packages/nx/test/test_nx_fft.ml
@@ -181,6 +181,20 @@ let reference_real_transform_2d ~family ~type_ ~norm rows columns data =
   done;
   result
 
+let reference_rfft x =
+  let n = Array.length x in
+  Array.init
+    ((n / 2) + 1)
+    (fun k ->
+      let re = ref 0.0 in
+      let im = ref 0.0 in
+      for j = 0 to n - 1 do
+        let angle = two_pi *. float_of_int (j * k) /. float_of_int n in
+        re := !re +. (x.(j) *. cos angle);
+        im := !im -. (x.(j) *. sin angle)
+      done;
+      Complex.{ re = !re; im = !im })
+
 (* Test standard FFT/IFFT *)
 let test_fft_ifft () =
   (* 1D even length *)
@@ -365,11 +379,11 @@ let test_rfft_irfft () =
         sin (two_pi *. Float.of_int i /. Float.of_int n_even))
   in
   let input_even = Nx.create Nx.float64 shape_even signal_even in
-  let rfft_even = Nx.rfft input_even in
+  let rfft_even = Nx.rfft Nx.complex128 input_even in
   equal ~msg:"rfft even shape" (array int)
     [| (n_even / 2) + 1 |]
     (Nx.shape rfft_even);
-  let irfft_even = Nx.irfft rfft_even ~n:n_even in
+  let irfft_even = Nx.irfft Nx.float64 rfft_even ~n:n_even in
   check_t ~eps:1e-10 "rfft even reconstruct" shape_even signal_even irfft_even;
 
   (* 1D odd *)
@@ -377,11 +391,11 @@ let test_rfft_irfft () =
   let shape_odd = [| n_odd |] in
   let signal_odd = Array.init n_odd (fun i -> Float.of_int i) in
   let input_odd = Nx.create Nx.float64 shape_odd signal_odd in
-  let rfft_odd = Nx.rfft input_odd in
+  let rfft_odd = Nx.rfft Nx.complex128 input_odd in
   equal ~msg:"rfft odd shape" (array int)
     [| (n_odd / 2) + 1 |]
     (Nx.shape rfft_odd);
-  let irfft_odd = Nx.irfft rfft_odd ~n:n_odd in
+  let irfft_odd = Nx.irfft Nx.float64 rfft_odd ~n:n_odd in
   check_t ~eps:1e-10 "rfft odd reconstruct" shape_odd signal_odd irfft_odd;
 
   (* 2D *)
@@ -389,9 +403,9 @@ let test_rfft_irfft () =
   let shape_2d = [| m; n |] in
   let signal_2d = Array.init (m * n) Float.of_int in
   let input_2d = Nx.create Nx.float64 shape_2d signal_2d in
-  let rfft_2d = Nx.rfft2 input_2d in
+  let rfft_2d = Nx.rfft2 Nx.complex128 input_2d in
   equal ~msg:"rfft2 shape" (array int) [| m; (n / 2) + 1 |] (Nx.shape rfft_2d);
-  let irfft_2d = Nx.irfft2 rfft_2d ~s:[ m; n ] in
+  let irfft_2d = Nx.irfft2 Nx.float64 rfft_2d ~s:[ m; n ] in
   check_t "rfft2 reconstruct" shape_2d signal_2d irfft_2d;
 
   (* ND last axis transform *)
@@ -399,10 +413,10 @@ let test_rfft_irfft () =
   let size_nd = 2 * 3 * 8 in
   let signal_nd = Array.init size_nd (fun i -> Float.of_int i) in
   let input_nd = Nx.create Nx.float64 shape_nd signal_nd in
-  let rfft_nd = Nx.rfftn input_nd ~axes:[ 2 ] in
+  let rfft_nd = Nx.rfftn Nx.complex128 input_nd ~axes:[ 2 ] in
   equal ~msg:"rfftn last axis shape" (array int) [| 2; 3; 5 |]
     (Nx.shape rfft_nd);
-  let irfft_nd = Nx.irfftn rfft_nd ~axes:[ 2 ] ~s:[ 8 ] in
+  let irfft_nd = Nx.irfftn Nx.float64 rfft_nd ~axes:[ 2 ] ~s:[ 8 ] in
   check_t "rfftn last axis reconstruct" shape_nd signal_nd irfft_nd
 
 let test_rfft_axes () =
@@ -412,15 +426,15 @@ let test_rfft_axes () =
   let input = Nx.create Nx.float64 shape signal in
 
   (* Specific axis *)
-  let rfft_axis1 = Nx.rfftn input ~axes:[ 1 ] in
+  let rfft_axis1 = Nx.rfftn Nx.complex128 input ~axes:[ 1 ] in
   equal ~msg:"rfft axis 1" (array int) [| 4; 4; 8 |] (Nx.shape rfft_axis1);
 
   (* Multiple axes, last is halved *)
-  let rfft_axes_01 = Nx.rfftn input ~axes:[ 0; 1 ] in
+  let rfft_axes_01 = Nx.rfftn Nx.complex128 input ~axes:[ 0; 1 ] in
   equal ~msg:"rfft axes [0;1]" (array int) [| 4; 4; 8 |] (Nx.shape rfft_axes_01);
 
   (* Negative axis *)
-  let rfft_neg1 = Nx.rfftn input ~axes:[ -1 ] in
+  let rfft_neg1 = Nx.rfftn Nx.complex128 input ~axes:[ -1 ] in
   equal ~msg:"rfft axis -1" (array int) [| 4; 6; 5 |] (Nx.shape rfft_neg1)
 
 let test_rfft_size () =
@@ -433,11 +447,11 @@ let test_rfft_size () =
 
   (* Pad last axis *)
   let pad_size = 16 in
-  let rfft_padded = Nx.rfft input ~n:pad_size in
+  let rfft_padded = Nx.rfft Nx.complex128 input ~n:pad_size in
   equal ~msg:"rfft padded" (array int)
     [| (pad_size / 2) + 1 |]
     (Nx.shape rfft_padded);
-  let irfft_padded = Nx.irfft rfft_padded ~n in
+  let irfft_padded = Nx.irfft Nx.float64 rfft_padded ~n in
   (* Note: rfft(x, n=16) -> irfft(X, n=8) does NOT give back the original
      signal. This is expected behavior that matches NumPy. *)
   equal ~msg:"rfft pad reconstruct shape" (array int) shape
@@ -460,7 +474,7 @@ let test_rfft_size () =
 
   (* Truncate *)
   let trunc_size = 4 in
-  let rfft_trunc = Nx.rfft input ~n:trunc_size in
+  let rfft_trunc = Nx.rfft Nx.complex128 input ~n:trunc_size in
   equal ~msg:"rfft trunc" (array int)
     [| (trunc_size / 2) + 1 |]
     (Nx.shape rfft_trunc)
@@ -472,33 +486,94 @@ let test_rfft_norm () =
   let input = Nx.create Nx.float64 shape signal in
 
   (* Backward *)
-  let rfft_backward = Nx.rfft input ~norm:`Backward in
-  let irfft_backward = Nx.irfft rfft_backward ~n ~norm:`Backward in
+  let rfft_backward = Nx.rfft Nx.complex128 input ~norm:`Backward in
+  let irfft_backward = Nx.irfft Nx.float64 rfft_backward ~n ~norm:`Backward in
   check_t "rfft backward" shape signal irfft_backward;
 
   (* Forward *)
-  let rfft_forward = Nx.rfft input ~norm:`Forward in
-  let irfft_forward = Nx.irfft rfft_forward ~n ~norm:`Forward in
+  let rfft_forward = Nx.rfft Nx.complex128 input ~norm:`Forward in
+  let irfft_forward = Nx.irfft Nx.float64 rfft_forward ~n ~norm:`Forward in
   check_t "rfft forward" shape signal irfft_forward;
 
   (* Ortho *)
-  let rfft_ortho = Nx.rfft input ~norm:`Ortho in
-  let irfft_ortho = Nx.irfft rfft_ortho ~n ~norm:`Ortho in
+  let rfft_ortho = Nx.rfft Nx.complex128 input ~norm:`Ortho in
+  let irfft_ortho = Nx.irfft Nx.float64 rfft_ortho ~n ~norm:`Ortho in
   check_t "rfft ortho" shape signal irfft_ortho
 
 let test_rfft_edge_cases () =
   (* Empty - NumPy raises an error for empty arrays, so we skip this test let
-     empty = Nx.empty Nx.float64 [| 0 |] in let rfft_empty = Nx.rfft empty in
-     Alcotest.(check (array int)) "rfft empty" [| 1 |] (Nx.shape rfft_empty); *)
+     empty = Nx.empty Nx.float64 [| 0 |] in let rfft_empty = Nx.rfft
+     Nx.complex128 empty in Alcotest.(check (array int)) "rfft empty" [| 1 |]
+     (Nx.shape rfft_empty); *)
 
   (* Size 1 *)
   let shape = [| 1 |] in
   let signal_data = [| 5.0 |] in
   let single = Nx.create Nx.float64 shape signal_data in
-  let rfft_single = Nx.rfft single in
+  let rfft_single = Nx.rfft Nx.complex128 single in
   equal ~msg:"rfft size 1 shape" (array int) [| 1 |] (Nx.shape rfft_single);
-  let irfft_single = Nx.irfft rfft_single ~n:1 in
+  let irfft_single = Nx.irfft Nx.float64 rfft_single ~n:1 in
   check_t "rfft size 1 reconstruct" shape signal_data irfft_single
+
+let test_rfft_dtypes () =
+  let n = 8 in
+  let shape = [| n |] in
+  let spectrum_shape = [| (n / 2) + 1 |] in
+  let signal =
+    Array.init n (fun i ->
+        sin (two_pi *. Float.of_int i /. Float.of_int n) +. 0.25)
+  in
+  let expected = reference_rfft signal in
+  let f32 = Nx.create Nx.float32 shape signal in
+  let f64 = Nx.create Nx.float64 shape signal in
+
+  (* float32 input stays in single precision *)
+  let spectrum32 = Nx.rfft Nx.complex64 f32 in
+  equal ~msg:"rfft complex64 dtype" string "complex64"
+    (Nx_core.Dtype.to_string (Nx.dtype spectrum32));
+  check_t ~eps:1e-5 "rfft complex64 values" spectrum_shape expected spectrum32;
+  let roundtrip32 = Nx.irfft Nx.float32 spectrum32 ~n in
+  equal ~msg:"irfft float32 dtype" string "float32"
+    (Nx_core.Dtype.to_string (Nx.dtype roundtrip32));
+  check_t ~eps:1e-5 "rfft/irfft float32 roundtrip" shape signal roundtrip32;
+
+  (* float64 input keeps the double-precision behaviour *)
+  let spectrum64 = Nx.rfft Nx.complex128 f64 in
+  equal ~msg:"rfft complex128 dtype" string "complex128"
+    (Nx_core.Dtype.to_string (Nx.dtype spectrum64));
+  check_t ~eps:1e-10 "rfft complex128 values" spectrum_shape expected
+    spectrum64;
+  let roundtrip64 = Nx.irfft Nx.float64 spectrum64 ~n in
+  equal ~msg:"irfft float64 dtype" string "float64"
+    (Nx_core.Dtype.to_string (Nx.dtype roundtrip64));
+  check_t ~eps:1e-10 "rfft/irfft float64 roundtrip" shape signal roundtrip64;
+
+  (* The output dtype is independent of the input precision: mixed pairings
+     store the double-precision transform at the requested precision *)
+  let widened = Nx.rfft Nx.complex128 f32 in
+  equal ~msg:"rfft float32 to complex128 dtype" string "complex128"
+    (Nx_core.Dtype.to_string (Nx.dtype widened));
+  check_t ~eps:1e-5 "rfft float32 to complex128 values" spectrum_shape expected
+    widened;
+  let narrowed = Nx.rfft Nx.complex64 f64 in
+  equal ~msg:"rfft float64 to complex64 dtype" string "complex64"
+    (Nx_core.Dtype.to_string (Nx.dtype narrowed));
+  check_t ~eps:1e-5 "rfft float64 to complex64 values" spectrum_shape expected
+    narrowed;
+  let narrowed_real = Nx.irfft Nx.float32 spectrum64 ~n in
+  equal ~msg:"irfft complex128 to float32 dtype" string "float32"
+    (Nx_core.Dtype.to_string (Nx.dtype narrowed_real));
+  check_t ~eps:1e-5 "irfft complex128 to float32 values" shape signal
+    narrowed_real;
+
+  (* Hermitian pair at single precision *)
+  let ihfft32 = Nx.ihfft Nx.complex64 f32 ~n in
+  equal ~msg:"ihfft complex64 dtype" string "complex64"
+    (Nx_core.Dtype.to_string (Nx.dtype ihfft32));
+  let hfft32 = Nx.hfft Nx.float32 ihfft32 ~n in
+  equal ~msg:"hfft float32 dtype" string "float32"
+    (Nx_core.Dtype.to_string (Nx.dtype hfft32));
+  check_t ~eps:1e-5 "hfft/ihfft float32 roundtrip" shape signal hfft32
 
 (* Test Hermitian FFT *)
 let test_hfft_ihfft () =
@@ -508,9 +583,9 @@ let test_hfft_ihfft () =
     Array.init n (fun i -> sin (two_pi *. Float.of_int i /. Float.of_int n))
   in
   let input = Nx.create Nx.float64 shape signal in
-  let ihfft_out = Nx.ihfft input ~n in
+  let ihfft_out = Nx.ihfft Nx.complex128 input ~n in
   equal ~msg:"ihfft shape" (array int) [| (n / 2) + 1 |] (Nx.shape ihfft_out);
-  let hfft_out = Nx.hfft ihfft_out ~n in
+  let hfft_out = Nx.hfft Nx.float64 ihfft_out ~n in
   check_t "hfft/ihfft" shape signal hfft_out
 
 (* Test helper routines *)
@@ -740,6 +815,7 @@ let suite =
         test "size" test_rfft_size;
         test "norm" test_rfft_norm;
         test "edge_cases" test_rfft_edge_cases;
+        test "dtypes" test_rfft_dtypes;
       ];
     group "hfft/ihfft" [ test "basic" test_hfft_ihfft ];
     group "dct/idct"

--- a/packages/nx/test/test_nx_fft.ml
+++ b/packages/nx/test/test_nx_fft.ml
@@ -195,6 +195,31 @@ let reference_rfft x =
       done;
       Complex.{ re = !re; im = !im })
 
+(* Full 2-D DFT keeping the non-redundant half of the last axis, row-major. *)
+let reference_rfft2 rows columns x =
+  let half = (columns / 2) + 1 in
+  Array.init (rows * half) (fun idx ->
+      let r = idx / half and c = idx mod half in
+      let re = ref 0.0 in
+      let im = ref 0.0 in
+      for y = 0 to rows - 1 do
+        for z = 0 to columns - 1 do
+          let angle =
+            two_pi
+            *. ((float_of_int (r * y) /. float_of_int rows)
+               +. (float_of_int (c * z) /. float_of_int columns))
+          in
+          let v = x.((y * columns) + z) in
+          re := !re +. (v *. cos angle);
+          im := !im -. (v *. sin angle)
+        done
+      done;
+      Complex.{ re = !re; im = !im })
+
+(* Round through float32 so a reference can be compared against a float32 input
+   without the input's own quantisation swamping the tolerance. *)
+let to_float32 v = Int32.float_of_bits (Int32.bits_of_float v)
+
 (* Test standard FFT/IFFT *)
 let test_fft_ifft () =
   (* 1D even length *)
@@ -524,6 +549,8 @@ let test_rfft_dtypes () =
         sin (two_pi *. Float.of_int i /. Float.of_int n) +. 0.25)
   in
   let expected = reference_rfft signal in
+  let signal32 = Array.map to_float32 signal in
+  let expected32 = reference_rfft signal32 in
   let f32 = Nx.create Nx.float32 shape signal in
   let f64 = Nx.create Nx.float64 shape signal in
 
@@ -531,11 +558,11 @@ let test_rfft_dtypes () =
   let spectrum32 = Nx.rfft Nx.complex64 f32 in
   equal ~msg:"rfft complex64 dtype" string "complex64"
     (Nx_core.Dtype.to_string (Nx.dtype spectrum32));
-  check_t ~eps:1e-5 "rfft complex64 values" spectrum_shape expected spectrum32;
+  check_t ~eps:1e-5 "rfft complex64 values" spectrum_shape expected32 spectrum32;
   let roundtrip32 = Nx.irfft Nx.float32 spectrum32 ~n in
   equal ~msg:"irfft float32 dtype" string "float32"
     (Nx_core.Dtype.to_string (Nx.dtype roundtrip32));
-  check_t ~eps:1e-5 "rfft/irfft float32 roundtrip" shape signal roundtrip32;
+  check_t ~eps:1e-5 "rfft/irfft float32 roundtrip" shape signal32 roundtrip32;
 
   (* float64 input keeps the double-precision behaviour *)
   let spectrum64 = Nx.rfft Nx.complex128 f64 in
@@ -548,13 +575,15 @@ let test_rfft_dtypes () =
     (Nx_core.Dtype.to_string (Nx.dtype roundtrip64));
   check_t ~eps:1e-10 "rfft/irfft float64 roundtrip" shape signal roundtrip64;
 
-  (* The output dtype is independent of the input precision: mixed pairings
-     store the double-precision transform at the requested precision *)
+  (* The output dtype is independent of the input precision. Against a reference
+     built from the float32-rounded signal the only remaining error is the
+     storage precision, so this tolerance fails if the result is silently
+     narrowed to complex64. *)
   let widened = Nx.rfft Nx.complex128 f32 in
   equal ~msg:"rfft float32 to complex128 dtype" string "complex128"
     (Nx_core.Dtype.to_string (Nx.dtype widened));
-  check_t ~eps:1e-5 "rfft float32 to complex128 values" spectrum_shape expected
-    widened;
+  check_t ~eps:1e-12 "rfft float32 to complex128 values" spectrum_shape
+    expected32 widened;
   let narrowed = Nx.rfft Nx.complex64 f64 in
   equal ~msg:"rfft float64 to complex64 dtype" string "complex64"
     (Nx_core.Dtype.to_string (Nx.dtype narrowed));
@@ -574,6 +603,61 @@ let test_rfft_dtypes () =
   equal ~msg:"hfft float32 dtype" string "float32"
     (Nx_core.Dtype.to_string (Nx.dtype hfft32));
   check_t ~eps:1e-5 "hfft/ihfft float32 roundtrip" shape signal hfft32
+
+let test_rfft_dtypes_nd () =
+  (* Multi-axis rfft transforms the last axis real→complex and then the
+     remaining axes in place at the output dtype, so a narrow dtype rounds the
+     intermediate spectrum once per extra axis. Both precisions are checked
+     against the same reference to pin that difference down. *)
+  let rows = 4 and columns = 8 in
+  let shape = [| rows; columns |] in
+  let spectrum_shape = [| rows; (columns / 2) + 1 |] in
+  let signal =
+    Array.init (rows * columns) (fun i ->
+        sin (two_pi *. Float.of_int i /. 6.0) +. 0.5)
+  in
+  let signal32 = Array.map to_float32 signal in
+  let expected = reference_rfft2 rows columns signal32 in
+  let f32 = Nx.create Nx.float32 shape signal in
+
+  let wide = Nx.rfft2 Nx.complex128 f32 in
+  equal ~msg:"rfft2 complex128 dtype" string "complex128"
+    (Nx_core.Dtype.to_string (Nx.dtype wide));
+  check_t ~eps:1e-10 "rfft2 complex128 values" spectrum_shape expected wide;
+
+  let narrow = Nx.rfft2 Nx.complex64 f32 in
+  equal ~msg:"rfft2 complex64 dtype" string "complex64"
+    (Nx_core.Dtype.to_string (Nx.dtype narrow));
+  check_t ~eps:1e-4 "rfft2 complex64 values" spectrum_shape expected narrow;
+
+  let back = Nx.irfft2 Nx.float32 narrow ~s:[ rows; columns ] in
+  equal ~msg:"irfft2 float32 dtype" string "float32"
+    (Nx_core.Dtype.to_string (Nx.dtype back));
+  check_t ~eps:1e-5 "rfft2/irfft2 float32 roundtrip" shape signal32 back;
+
+  (* N-D over a subset of axes, batched over the leading one. *)
+  let batch = 2 in
+  let nd_shape = [| batch; rows; columns |] in
+  let nd_signal =
+    Array.init
+      (batch * rows * columns)
+      (fun i -> sin (two_pi *. Float.of_int i /. 7.0))
+  in
+  let nd_signal32 = Array.map to_float32 nd_signal in
+  let nd = Nx.create Nx.float32 nd_shape nd_signal in
+  let spectrum_nd = Nx.rfftn Nx.complex64 nd ~axes:[ 1; 2 ] in
+  equal ~msg:"rfftn complex64 dtype" string "complex64"
+    (Nx_core.Dtype.to_string (Nx.dtype spectrum_nd));
+  equal ~msg:"rfftn complex64 shape" (array int)
+    [| batch; rows; (columns / 2) + 1 |]
+    (Nx.shape spectrum_nd);
+  let back_nd =
+    Nx.irfftn Nx.float32 spectrum_nd ~axes:[ 1; 2 ] ~s:[ rows; columns ]
+  in
+  equal ~msg:"irfftn float32 dtype" string "float32"
+    (Nx_core.Dtype.to_string (Nx.dtype back_nd));
+  check_t ~eps:1e-5 "rfftn/irfftn float32 roundtrip" nd_shape nd_signal32
+    back_nd
 
 (* Test Hermitian FFT *)
 let test_hfft_ihfft () =
@@ -848,6 +932,7 @@ let suite =
         test "norm" test_rfft_norm;
         test "edge_cases" test_rfft_edge_cases;
         test "dtypes" test_rfft_dtypes;
+        test "dtypes 2-d and n-d" test_rfft_dtypes_nd;
       ];
     group "hfft/ihfft" [ test "basic" test_hfft_ihfft ];
     group "dct/idct"

--- a/packages/nx/test/test_nx_stft.ml
+++ b/packages/nx/test/test_nx_stft.ml
@@ -57,7 +57,9 @@ let test_stft_matches_framed_rfft () =
   List.iter
     (fun (window, step) ->
       let shape, frames = framed ~window ~step data in
-      let expected = Nx.rfft (Nx.create Nx.float64 shape frames) ~axis:(-1) in
+      let expected =
+        Nx.rfft Nx.complex128 (Nx.create Nx.float64 shape frames) ~axis:(-1)
+      in
       let actual = Nx.stft Nx.complex128 ~window ~step ~win:(rect window) x in
       check_nx ~epsilon:1e-11
         (Printf.sprintf "window %d step %d" window step)
@@ -72,7 +74,9 @@ let test_stft_windowed () =
   let w = Nx.hann Nx.float64 window in
   let shape, frames = framed ~window ~step data in
   let expected =
-    Nx.rfft (Nx.mul (Nx.create Nx.float64 shape frames) w) ~axis:(-1)
+    Nx.rfft Nx.complex128
+      (Nx.mul (Nx.create Nx.float64 shape frames) w)
+      ~axis:(-1)
   in
   check_nx ~epsilon:1e-11 "tapered frames" expected
     (Nx.stft Nx.complex128 ~window ~step ~win:w


### PR DESCRIPTION
Take the output `dtype` as the first argument of `rfft`, `irfft`, `rfft2`, `irfft2`, `rfftn`, `irfftn`, `hfft`, and `ihfft`, following the constructor convention, instead of hardcoding `complex128` and `float64` results. This means that now, a `float32` signal can now keep its spectrum in `complex64`, which will have for effect to halving the memory of single-precision spectral pipelines.
