### PR TITLE
Uniform parameter trees

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,17 +18,16 @@ All notable changes to this project will be documented in this file.
   but the deriver only knew qualified types whose name ends in `t`, so the field
   had to be spelled `(int32, int32_elt) Nx.t`.
 
+- Add `~mirror` to the deriver: `[@@deriving ptree ~mirror]` on a concrete
+  record also generates its payload-generic `module Uniform`, `to_uniform`, and
+  — when every leaf dtype is statically known — a dtype-checked `of_uniform`.
+- Extend `[@@deriving ptree]` to payload-generic types: a type with one
+  parameter occurring outside tensor leaves derives `map`, `map2`, `iter`,
+  `fold` and `fold2` over dot-joined leaf paths, plus `names : 'a t -> string t`.
 - Add the `ppx_ptree` deriver, which generates the `map`, `map2`, and `iter`
   operations required by `Nx.Ptree.S` for records, products, containers, and
   recursive parameter types, with generated code and diagnostics located at the
   originating source forms.
-- Extend `[@@deriving ptree]` to payload-generic types: on a type with one
-  parameter occurring outside tensor leaves it derives the uniform traversals
-  (`map`, `map2`, `iter`, `fold` and `fold2` with dot-joined leaf paths, and
-  `names : 'a t -> string t`, the tree of leaf paths). Concrete types keep the
-  rank-2 traversals, and `[@@deriving ptree ~mirror]` additionally generates
-  their uniform mirror (`module Uniform`, `to_uniform`, and — when leaf dtypes
-  are statically known — `of_uniform` with per-leaf error paths).
 - Add a runnable linear-regression example using a derived parameter module
   directly with `Rune.grad` and `Rune.jit2`.
 
@@ -455,32 +454,6 @@ thread.
 - Runtimes: CPU (via Clang) and Metal. Renderers additionally target CUDA,
   AMD/HIP, and OpenCL for GPU code generation.
 
-### Kaun
-
-- Add `Kaun.ptree`, an alias of `Nx.Ptree.instantiate`: `let mlp = Kaun.ptree
-  (module Mlp)` is the walker the transformations take, so kaun users never
-  touch the `Nx.Ptree` machinery directly.
-- **Breaking:** the layers are payload-generic parameter trees: `Linear`,
-  `Conv`, `Embedding`, `Layer_norm`, `Batch_norm` (and its `Stats`),
-  `Attention` (and its `Cache`) each expose one `'a t` record with payload
-  holes and the six `Nx.Ptree.Uniform` traversals (`map`, `map2`, `iter`,
-  `fold`, `fold2`, `names`). Parameters are the record at tensor payloads —
-  `Nx.float32_t Linear.t` replaces the old `Nx.float32_elt Linear.params` and
-  the zero-argument `Linear.t` alias. One declaration now also serves
-  parameter-shaped data: freeze masks (`bool t`), per-leaf learning rates
-  (`float t`), checkpoint names (`string t`).
-- **Breaking:** the layers' `astype` is removed — `map (Nx.cast dt)` is the
-  same differentiable cast — and the `names : _ -> string list` functions are
-  replaced by the tree-shaped `names` and path-threading `fold` of the
-  `Uniform` contract.
-- **Breaking:** `Checkpoint` consumes `Nx.Ptree.Uniform` instances directly
-  and `Checkpoint.Named` is removed: `of_params`/`to_params` take
-  `(module U : Nx.Ptree.Uniform)` with typed leaves and name entries by leaf
-  paths, and the new `of_packed`/`to_packed` handle structures with mixed
-  leaf dtypes (the stock dynamic tree via `(module Rune.Ptree.Tree)`).
-  Hand-written `names` lists — and the name-per-leaf mismatch errors —
-  disappear: names are structural, so they can no longer be miscounted.
-
 ### Vega (new)
 
 - The structural optimizers (`sgd_step`, `adam_step`, `adamw_step`) pass
@@ -488,6 +461,10 @@ thread.
   carrying an `Nx.Rng.key` alongside its parameters survives a step. Adam is
   where it showed: its direction runs each leaf through a square root and a
   division.
+- The structural functions take their parameter-tree module as
+  `(module Nx.Ptree.S with type t = 'p)`, so a first-class module value —
+  e.g. the result of `Nx.Ptree.instantiate` — can be bound once and passed
+  to the optimizer steps and gradient transformations.
 - Add `Loss_scale` for float16 training: static and dynamic loss scales
   with `scale`/`unscale`/`grads_finite`/`adjust`; all state is scalar
   tensors updated by `Nx.where` arithmetic, so it threads through
@@ -610,6 +587,22 @@ thread.
 - Fix `Nx.Rng.randint` skewing towards zero for a negative `low`: it truncated
   the shifted float, so `low` was never drawn and `0` was drawn twice as often.
   Values for a fixed key change.
+- **Breaking:** the stock dynamic tree is payload-generic: `Nx.Ptree.Tree` is
+  a `Uniform` structure (constructors `Leaf`/`List`/`Dict`, paths from list
+  positions and dict keys) and `Nx.Ptree.t` is `tensor Tree.t`. The `Tensor`
+  constructor is now `Tree.Leaf`; the `tensor`/`list`/`dict` constructors and
+  the rank-2 traversals are unchanged.
+- Add `Nx.Ptree.instantiate`, which fills a `Ptree.Uniform` structure's payload
+  hole at one tensor type as a first-class `Ptree.S` module — `let mlp =
+  Ptree.instantiate (module Mlp)` — so a payload-generic tree passes to
+  `Rune.grad` and the Vega optimizers with typed leaves and no packing.
+- Add the payload-generic module types `Nx.Ptree.Traverse` (the traversal
+  core: `map`, `map2`, `iter`) and `Nx.Ptree.Uniform` (the core plus
+  `fold`/`fold2` over dot-joined leaf paths and `names`, the tree of those
+  paths), and `Nx.Ptree.Make`, which turns a `Traverse` into an `Nx.Ptree.S`
+  with packed tensor leaves — so one `'a params` declaration serves both the
+  model and parameter-shaped data. `Nx.Ptree.unpack` recovers a typed tensor
+  from a packed leaf, naming the position in the error on a dtype mismatch.
 - **Breaking:** the real FFT family (`rfft`, `irfft`, `hfft`, `ihfft` and their
   2-D/N-D variants) and `fftfreq`/`rfftfreq` now take the output dtype first,
   like the constructors. It selects storage precision independent of the
@@ -863,12 +856,6 @@ thread.
   user structure implementing its three traversals (`map`, `map2`, `iter`).
   A stock dynamic tree (`Ptree.t` with tensor, list, and dict nodes) covers
   structures only known at runtime.
-- Add `Nx.Ptree.Uniform`, the module type of payload-generic structures
-  (`map`, `map2`, `iter`, `fold` and `fold2` with dot-joined leaf paths), and
-  the `Nx.Ptree.Make` functor deriving an `Nx.Ptree.S` from any `Uniform` with
-  packed tensor leaves, so one `'a params` declaration serves both the model
-  and parameter-shaped data. Add `Nx.Ptree.unpack` for dtype-checked
-  unpacking of packed tensors with an optional path in the error message.
 - Require OCaml >= 5.5.0 (module-dependent functions are used by the
   `Ptree.S`-based APIs downstream).
 - Fix `flatten` raising on rank-0 tensors; it now reshapes them to `[|1|]`.
@@ -919,6 +906,10 @@ thread.
 - Fix the derivative of `abs` on complex tensors for cotangents that are not
   real: the modulus is real-valued, so the rule now keeps only the real part of
   the cotangent and pushes forward to a real tangent.
+- The transformations take their parameter-tree module as
+  `(module Ptree.S with type t = 'p)` instead of a dependent module argument,
+  so a first-class module value — e.g. the result of `Nx.Ptree.instantiate` —
+  can be bound once and passed to `grad`, `jit`, `vjp`, and friends.
 - Fix the derivative of `abs` on complex tensors, in both forward and reverse
   mode: it pulled back through `sign z` instead of its conjugate, which negated
   the imaginary part's contribution. Gradients of a real-valued function that

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -457,6 +457,9 @@ thread.
 
 ### Kaun
 
+- Add `Kaun.ptree`, an alias of `Nx.Ptree.instantiate`: `let mlp = Kaun.ptree
+  (module Mlp)` is the walker the transformations take, so kaun users never
+  touch the `Nx.Ptree` machinery directly.
 - **Breaking:** the layers are payload-generic parameter trees: `Linear`,
   `Conv`, `Embedding`, `Layer_norm`, `Batch_norm` (and its `Stats`),
   `Attention` (and its `Cache`) each expose one `'a t` record with payload

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -834,11 +834,12 @@ thread.
   user structure implementing its three traversals (`map`, `map2`, `iter`).
   A stock dynamic tree (`Ptree.t` with tensor, list, and dict nodes) covers
   structures only known at runtime.
-- Add `Nx.Ptree.Gtree` module type for uniform homomorphic structures
-  (`map`, `map2`, `iter`, `fold` with dotted paths, `fold2`), plus the
-  `Nx.Ptree.Tensor_tree` functor bridging any `Gtree` to `Nx.Ptree.S` for
-  rune/vega/kaun interop, and `Nx.Ptree.unpack` for dtype-checked existential
-  unpacking with optional path annotation.
+- Add `Nx.Ptree.Uniform`, the module type of payload-generic structures
+  (`map`, `map2`, `iter`, `fold` and `fold2` with dot-joined leaf paths), and
+  the `Nx.Ptree.Make` functor deriving an `Nx.Ptree.S` from any `Uniform` with
+  packed tensor leaves, so one `'a params` declaration serves both the model
+  and parameter-shaped data. Add `Nx.Ptree.unpack` for dtype-checked
+  unpacking of packed tensors with an optional path in the error message.
 - Require OCaml >= 5.5.0 (module-dependent functions are used by the
   `Ptree.S`-based APIs downstream).
 - Fix `flatten` raising on rank-0 tensors; it now reshapes them to `[|1|]`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -455,6 +455,21 @@ thread.
 - Runtimes: CPU (via Clang) and Metal. Renderers additionally target CUDA,
   AMD/HIP, and OpenCL for GPU code generation.
 
+### Kaun
+
+- **Breaking:** the layers are payload-generic parameter trees: `Linear`,
+  `Conv`, `Embedding`, `Layer_norm`, `Batch_norm` (and its `Stats`),
+  `Attention` (and its `Cache`) each expose one `'a t` record with payload
+  holes and the six `Nx.Ptree.Uniform` traversals (`map`, `map2`, `iter`,
+  `fold`, `fold2`, `names`). Parameters are the record at tensor payloads —
+  `Nx.float32_t Linear.t` replaces the old `Nx.float32_elt Linear.params` and
+  the zero-argument `Linear.t` alias. One declaration now also serves
+  parameter-shaped data: freeze masks (`bool t`), per-leaf learning rates
+  (`float t`), checkpoint names (`string t`).
+- **Breaking:** the layers' `astype` is removed — `map (Nx.cast dt)` is the
+  same differentiable cast — and the `names : _ -> string list` functions are
+  replaced by the tree-shaped `names` and path-threading `fold` of the
+  `Uniform` contract.
 ### Vega (new)
 
 - The structural optimizers (`sgd_step`, `adam_step`, `adamw_step`) pass

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -470,6 +470,14 @@ thread.
   same differentiable cast — and the `names : _ -> string list` functions are
   replaced by the tree-shaped `names` and path-threading `fold` of the
   `Uniform` contract.
+- **Breaking:** `Checkpoint` consumes `Nx.Ptree.Uniform` instances directly
+  and `Checkpoint.Named` is removed: `of_params`/`to_params` take
+  `(module U : Nx.Ptree.Uniform)` with typed leaves and name entries by leaf
+  paths, and the new `of_packed`/`to_packed` handle structures with mixed
+  leaf dtypes (the stock dynamic tree via `(module Rune.Ptree.Tree)`).
+  Hand-written `names` lists — and the name-per-leaf mismatch errors —
+  disappear: names are structural, so they can no longer be miscounted.
+
 ### Vega (new)
 
 - The structural optimizers (`sgd_step`, `adam_step`, `adamw_step`) pass

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,10 @@ All notable changes to this project will be documented in this file.
   operations required by `Nx.Ptree.S` for records, products, containers, and
   recursive parameter types, with generated code and diagnostics located at the
   originating source forms.
+- Add `[@@deriving gtree]` support for uniform homomorphic traversals on
+  parameterised records (`map`, `map2`, `iter`, `fold` with dotted paths,
+  `fold2`, `names`), plus mirror mode via `[@@deriving ptree, gtree]` on
+  concrete records (generates `module Gtree`, `to_gtree`, `of_gtree`).
 - Add a runnable linear-regression example using a derived parameter module
   directly with `Rune.grad` and `Rune.jit2`.
 
@@ -830,6 +834,11 @@ thread.
   user structure implementing its three traversals (`map`, `map2`, `iter`).
   A stock dynamic tree (`Ptree.t` with tensor, list, and dict nodes) covers
   structures only known at runtime.
+- Add `Nx.Ptree.Gtree` module type for uniform homomorphic structures
+  (`map`, `map2`, `iter`, `fold` with dotted paths, `fold2`), plus the
+  `Nx.Ptree.Tensor_tree` functor bridging any `Gtree` to `Nx.Ptree.S` for
+  rune/vega/kaun interop, and `Nx.Ptree.unpack` for dtype-checked existential
+  unpacking with optional path annotation.
 - Require OCaml >= 5.5.0 (module-dependent functions are used by the
   `Ptree.S`-based APIs downstream).
 - Fix `flatten` raising on rank-0 tensors; it now reshapes them to `[|1|]`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,10 +22,13 @@ All notable changes to this project will be documented in this file.
   operations required by `Nx.Ptree.S` for records, products, containers, and
   recursive parameter types, with generated code and diagnostics located at the
   originating source forms.
-- Add `[@@deriving gtree]` support for uniform homomorphic traversals on
-  parameterised records (`map`, `map2`, `iter`, `fold` with dotted paths,
-  `fold2`, `names`), plus mirror mode via `[@@deriving ptree, gtree]` on
-  concrete records (generates `module Gtree`, `to_gtree`, `of_gtree`).
+- Extend `[@@deriving ptree]` to payload-generic types: on a type with one
+  parameter occurring outside tensor leaves it derives the uniform traversals
+  (`map`, `map2`, `iter`, `fold` and `fold2` with dot-joined leaf paths, and
+  `names : 'a t -> string t`, the tree of leaf paths). Concrete types keep the
+  rank-2 traversals, and `[@@deriving ptree ~mirror]` additionally generates
+  their uniform mirror (`module Uniform`, `to_uniform`, and — when leaf dtypes
+  are statically known — `of_uniform` with per-leaf error paths).
 - Add a runnable linear-regression example using a derived parameter module
   directly with `Rune.grad` and `Rune.jit2`.
 

--- a/doc/coming-from-python.md
+++ b/doc/coming-from-python.md
@@ -35,7 +35,7 @@ let a = Nx.create Nx.Int32 [|3|] [|1l; 2l; 3l|]
 (* Nx.add a (Nx.scalar Nx.Float32 1.5)  -- type error *)
 
 (* Cast explicitly *)
-let a_f = Nx.astype Nx.Float32 a
+let a_f = Nx.cast Nx.Float32 a
 let b = Nx.add a_f (Nx.scalar Nx.Float32 1.5)
 ```
 
@@ -130,7 +130,7 @@ model = Model()
 <!-- $MDX skip -->
 ```ocaml
 (* Kaun: a model is a typed record of layer records *)
-type model = { linear : Kaun.Linear.t }
+type 'a model = { linear : 'a Kaun.Linear.t }
 
 let apply p x = Kaun.Linear.apply p.linear x
 let params = { linear = Kaun.Linear.init ~inputs:784 ~outputs:10 }

--- a/doc/ecosystem-overview.md
+++ b/doc/ecosystem-overview.md
@@ -108,7 +108,7 @@ compose `Rune.value_and_grad` with a Vega optimizer update.
 ```ocaml
 open Kaun
 
-type mlp = { l1 : Linear.t; l2 : Linear.t }
+type 'a mlp = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
 let apply p x = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -81,30 +81,32 @@ let () =
 
 ## Step 3: Training with Kaun
 
-Kaun provides layers, losses, and initializers built on Rune. A model is a plain record with a hand-written traversal (`Nx.Ptree.S`), the training step is `value_and_grad` plus one Vega optimizer update, and the loop is a plain for loop — no trainer, no layer type.
+Kaun provides layers, losses, and initializers built on Rune. A model is a plain record with hand-written one-line traversals, instantiated by `Kaun.ptree`; the training step is `value_and_grad` plus one Vega optimizer update, and the loop is a plain for loop — no trainer, no layer type.
 
 <!-- $MDX skip -->
 ```ocaml
 open Kaun
 
 module Mlp = struct
-  type t = { l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; l2 } =
+  let map f { l1; l2 } =
     { l1 = Linear.map f l1; l2 = Linear.map f l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
+  let map2 f p q =
     { l1 = Linear.map2 f p.l1 q.l1; l2 = Linear.map2 f p.l2 q.l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; l2 } =
+  let iter f { l1; l2 } =
     Linear.iter f l1;
     Linear.iter f l2
 
   let apply p x = Linear.apply p.l2 (Nx.tanh (Linear.apply p.l1 x))
 end
 
+let mlp = Kaun.ptree (module Mlp)
+
 let () =
-  Nx.Rng.run ~seed:42 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->
 
   (* XOR dataset *)
   let x = Nx.create Nx.float32 [|4; 2|]
@@ -121,15 +123,15 @@ let () =
   (* Training step: value_and_grad + one Adam update *)
   let loss p = Loss.sigmoid_bce (Mlp.apply p x) y in
   let step (params, ostate) =
-    let l, grads = Rune.value_and_grad (module Mlp) loss params in
+    let l, grads = Rune.value_and_grad mlp loss params in
     let params, ostate =
-      Vega.adam_step (module Mlp) ~lr:0.05 ostate ~params ~grads
+      Vega.adam_step mlp ~lr:0.05 ostate ~params ~grads
     in
     ((params, ostate), Nx.item [] l)
   in
 
   (* Train *)
-  let state = ref (params, Vega.adam_init (module Mlp) params) in
+  let state = ref (params, Vega.adam_init mlp params) in
   for i = 1 to 500 do
     let s, l = step !state in
     state := s;

--- a/packages/fehu/examples/03-reinforce/main.ml
+++ b/packages/fehu/examples/03-reinforce/main.ml
@@ -54,21 +54,27 @@ let sparkline values =
    Linear layers with hand-written traversals (the Nx.Ptree.S contract). *)
 
 module Policy = struct
-  type t = { l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; l2 } =
-    { l1 = Linear.map f l1; l2 = Linear.map f l2 }
+  let map f { l1; l2 } =
+    let l1 = Linear.map f l1 in
+    let l2 = Linear.map f l2 in
+    { l1; l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
-    { l1 = Linear.map2 f p.l1 q.l1; l2 = Linear.map2 f p.l2 q.l2 }
+  let map2 f p q =
+    let l1 = Linear.map2 f p.l1 q.l1 in
+    let l2 = Linear.map2 f p.l2 q.l2 in
+    { l1; l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; l2 } =
+  let iter f { l1; l2 } =
     Linear.iter f l1;
     Linear.iter f l2
 
   (* Forward pass: obs [batch; 4] -> logits [batch; 2] *)
   let apply p obs = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 obs))
 end
+
+let policy_tree = Nx.Ptree.typed (module Policy)
 
 let count_parameters params =
   let n = ref 0 in
@@ -99,7 +105,7 @@ let () =
   Printf.printf "Parameters: %d\n\n" (count_parameters !params);
 
   (* Optimizer *)
-  let opt_state = ref (Vega.adam_init (module Policy) !params) in
+  let opt_state = ref (Vega.adam_init policy_tree !params) in
 
   let policy obs =
     let obs_batch = Nx.reshape [| 1; 4 |] obs in
@@ -162,9 +168,9 @@ let () =
       Nx.neg (Nx.mean weighted)
     in
 
-    let loss, grads = Rune.value_and_grad (module Policy) loss_fn !params in
+    let loss, grads = Rune.value_and_grad policy_tree loss_fn !params in
     let new_params, new_opt_state =
-      Vega.adam_step (module Policy) ~lr !opt_state ~params:!params ~grads
+      Vega.adam_step policy_tree ~lr !opt_state ~params:!params ~grads
     in
     params := new_params;
     opt_state := new_opt_state;

--- a/packages/fehu/examples/03-reinforce/main.ml
+++ b/packages/fehu/examples/03-reinforce/main.ml
@@ -70,6 +70,20 @@ module Policy = struct
     Linear.iter f l1;
     Linear.iter f l2
 
+  let fold f acc { l1; l2 } =
+    let acc = Linear.fold (fun p -> f ("l1." ^ p)) acc l1 in
+    Linear.fold (fun p -> f ("l2." ^ p)) acc l2
+
+  let fold2 f acc p q =
+    let acc = Linear.fold2 (fun s -> f ("l1." ^ s)) acc p.l1 q.l1 in
+    Linear.fold2 (fun s -> f ("l2." ^ s)) acc p.l2 q.l2
+
+  let names p =
+    {
+      l1 = Linear.map (( ^ ) "l1.") (Linear.names p.l1);
+      l2 = Linear.map (( ^ ) "l2.") (Linear.names p.l2);
+    }
+
   (* Forward pass: obs [batch; 4] -> logits [batch; 2] *)
   let apply p obs = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 obs))
 end

--- a/packages/fehu/examples/03-reinforce/main.ml
+++ b/packages/fehu/examples/03-reinforce/main.ml
@@ -74,7 +74,7 @@ module Policy = struct
   let apply p obs = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 obs))
 end
 
-let policy_tree = Nx.Ptree.typed (module Policy)
+let policy_tree = Nx.Ptree.instantiate (module Policy)
 
 let count_parameters params =
   let n = ref 0 in

--- a/packages/fehu/examples/03-reinforce/main.ml
+++ b/packages/fehu/examples/03-reinforce/main.ml
@@ -70,20 +70,6 @@ module Policy = struct
     Linear.iter f l1;
     Linear.iter f l2
 
-  let fold f acc { l1; l2 } =
-    let acc = Linear.fold (fun p -> f ("l1." ^ p)) acc l1 in
-    Linear.fold (fun p -> f ("l2." ^ p)) acc l2
-
-  let fold2 f acc p q =
-    let acc = Linear.fold2 (fun s -> f ("l1." ^ s)) acc p.l1 q.l1 in
-    Linear.fold2 (fun s -> f ("l2." ^ s)) acc p.l2 q.l2
-
-  let names p =
-    {
-      l1 = Linear.map (( ^ ) "l1.") (Linear.names p.l1);
-      l2 = Linear.map (( ^ ) "l2.") (Linear.names p.l2);
-    }
-
   (* Forward pass: obs [batch; 4] -> logits [batch; 2] *)
   let apply p obs = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 obs))
 end

--- a/packages/fehu/examples/03-reinforce/main.ml
+++ b/packages/fehu/examples/03-reinforce/main.ml
@@ -88,7 +88,7 @@ module Policy = struct
   let apply p obs = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 obs))
 end
 
-let policy_tree = Nx.Ptree.instantiate (module Policy)
+let policy_tree = Kaun.ptree (module Policy)
 
 let count_parameters params =
   let n = ref 0 in

--- a/packages/fehu/examples/04-dqn/main.ml
+++ b/packages/fehu/examples/04-dqn/main.ml
@@ -80,6 +80,23 @@ module Q = struct
     Linear.iter f l2;
     Linear.iter f l3
 
+  let fold f acc { l1; l2; l3 } =
+    let acc = Linear.fold (fun p -> f ("l1." ^ p)) acc l1 in
+    let acc = Linear.fold (fun p -> f ("l2." ^ p)) acc l2 in
+    Linear.fold (fun p -> f ("l3." ^ p)) acc l3
+
+  let fold2 f acc p q =
+    let acc = Linear.fold2 (fun s -> f ("l1." ^ s)) acc p.l1 q.l1 in
+    let acc = Linear.fold2 (fun s -> f ("l2." ^ s)) acc p.l2 q.l2 in
+    Linear.fold2 (fun s -> f ("l3." ^ s)) acc p.l3 q.l3
+
+  let names p =
+    {
+      l1 = Linear.map (( ^ ) "l1.") (Linear.names p.l1);
+      l2 = Linear.map (( ^ ) "l2.") (Linear.names p.l2);
+      l3 = Linear.map (( ^ ) "l3.") (Linear.names p.l3);
+    }
+
   (* Forward pass: obs [batch; 4] -> q_values [batch; 2] *)
   let apply p obs =
     Linear.apply p.l3

--- a/packages/fehu/examples/04-dqn/main.ml
+++ b/packages/fehu/examples/04-dqn/main.ml
@@ -61,19 +61,21 @@ let sparkline values =
    Nx.Ptree.S contract). *)
 
 module Q = struct
-  type t = { l1 : Linear.t; l2 : Linear.t; l3 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t; l3 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; l2; l3 } =
-    { l1 = Linear.map f l1; l2 = Linear.map f l2; l3 = Linear.map f l3 }
+  let map f { l1; l2; l3 } =
+    let l1 = Linear.map f l1 in
+    let l2 = Linear.map f l2 in
+    let l3 = Linear.map f l3 in
+    { l1; l2; l3 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
-    {
-      l1 = Linear.map2 f p.l1 q.l1;
-      l2 = Linear.map2 f p.l2 q.l2;
-      l3 = Linear.map2 f p.l3 q.l3;
-    }
+  let map2 f p q =
+    let l1 = Linear.map2 f p.l1 q.l1 in
+    let l2 = Linear.map2 f p.l2 q.l2 in
+    let l3 = Linear.map2 f p.l3 q.l3 in
+    { l1; l2; l3 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; l2; l3 } =
+  let iter f { l1; l2; l3 } =
     Linear.iter f l1;
     Linear.iter f l2;
     Linear.iter f l3
@@ -83,6 +85,8 @@ module Q = struct
     Linear.apply p.l3
       (Fn.relu (Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 obs))))
 end
+
+let q_tree = Nx.Ptree.typed (module Q)
 
 let count_parameters params =
   let n = ref 0 in
@@ -129,7 +133,7 @@ let () =
   Printf.printf "Parameters: %d\n\n" (count_parameters !params);
 
   (* Optimizer *)
-  let opt_state = ref (Vega.adam_init (module Q) !params) in
+  let opt_state = ref (Vega.adam_init q_tree !params) in
 
   (* Replay buffer *)
   let buffer = Buffer.create ~capacity:buffer_capacity in
@@ -205,9 +209,9 @@ let () =
       Nx.mean (Nx.mul diff diff)
     in
 
-    let loss, grads = Rune.value_and_grad (module Q) loss_fn !params in
+    let loss, grads = Rune.value_and_grad q_tree loss_fn !params in
     let new_params, new_opt_state =
-      Vega.adam_step (module Q) ~lr !opt_state ~params:!params ~grads
+      Vega.adam_step q_tree ~lr !opt_state ~params:!params ~grads
     in
     params := new_params;
     opt_state := new_opt_state;

--- a/packages/fehu/examples/04-dqn/main.ml
+++ b/packages/fehu/examples/04-dqn/main.ml
@@ -103,7 +103,7 @@ module Q = struct
       (Fn.relu (Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 obs))))
 end
 
-let q_tree = Nx.Ptree.instantiate (module Q)
+let q_tree = Kaun.ptree (module Q)
 
 let count_parameters params =
   let n = ref 0 in

--- a/packages/fehu/examples/04-dqn/main.ml
+++ b/packages/fehu/examples/04-dqn/main.ml
@@ -80,23 +80,6 @@ module Q = struct
     Linear.iter f l2;
     Linear.iter f l3
 
-  let fold f acc { l1; l2; l3 } =
-    let acc = Linear.fold (fun p -> f ("l1." ^ p)) acc l1 in
-    let acc = Linear.fold (fun p -> f ("l2." ^ p)) acc l2 in
-    Linear.fold (fun p -> f ("l3." ^ p)) acc l3
-
-  let fold2 f acc p q =
-    let acc = Linear.fold2 (fun s -> f ("l1." ^ s)) acc p.l1 q.l1 in
-    let acc = Linear.fold2 (fun s -> f ("l2." ^ s)) acc p.l2 q.l2 in
-    Linear.fold2 (fun s -> f ("l3." ^ s)) acc p.l3 q.l3
-
-  let names p =
-    {
-      l1 = Linear.map (( ^ ) "l1.") (Linear.names p.l1);
-      l2 = Linear.map (( ^ ) "l2.") (Linear.names p.l2);
-      l3 = Linear.map (( ^ ) "l3.") (Linear.names p.l3);
-    }
-
   (* Forward pass: obs [batch; 4] -> q_values [batch; 2] *)
   let apply p obs =
     Linear.apply p.l3

--- a/packages/fehu/examples/04-dqn/main.ml
+++ b/packages/fehu/examples/04-dqn/main.ml
@@ -86,7 +86,7 @@ module Q = struct
       (Fn.relu (Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 obs))))
 end
 
-let q_tree = Nx.Ptree.typed (module Q)
+let q_tree = Nx.Ptree.instantiate (module Q)
 
 let count_parameters params =
   let n = ref 0 in

--- a/packages/kaun/README.md
+++ b/packages/kaun/README.md
@@ -8,7 +8,7 @@ checkpoints — as plain records and pure functions. There is no layer
 object and no trainer: a model is a typed record you write, and a
 training step is a few lines you own end to end.
 
-The glue is `Nx.Ptree.S`, the traversal interface from [nx](../nx/):
+The glue is `Nx.Ptree`, the traversal interface from [nx](../nx/):
 [rune](../rune/) (transformations) and [vega](../vega/)
 (optimizers) each sit on nx independently, kaun's library depends
 only on nx and rune, and the three compose in your code through
@@ -16,28 +16,32 @@ the one record type you define.
 
 ## The Core Idea
 
-A model is a record of layer records, made traversable by three
-one-liners. The same traversals serve differentiation (`Rune`),
+A model is a record of layer records with a payload hole, made
+traversable by one-line traversals (hand-written or
+`[@@deriving ptree]`); `Kaun.ptree` instantiates it at its tensor
+type. The same traversals serve differentiation (`Rune`),
 optimization (`Vega`), and checkpointing (`Checkpoint`):
 
 ```ocaml
 open Kaun
 
 module Mlp = struct
-  type t = { l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; l2 } =
+  let map f { l1; l2 } =
     { l1 = Linear.map f l1; l2 = Linear.map f l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
+  let map2 f p q =
     { l1 = Linear.map2 f p.l1 q.l1; l2 = Linear.map2 f p.l2 q.l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; l2 } =
+  let iter f { l1; l2 } =
     Linear.iter f l1;
     Linear.iter f l2
 
   let apply p x = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
+
+let mlp = Kaun.ptree (module Mlp)
 ```
 
 A training step composes `value_and_grad` with one optimizer update —
@@ -46,9 +50,9 @@ no framework in between:
 ```ocaml
 let step (params, ostate) (x, y) =
   let loss p = Loss.softmax_cross_entropy_sparse (Mlp.apply p x) y in
-  let l, grads = Rune.value_and_grad (module Mlp) loss params in
+  let l, grads = Rune.value_and_grad mlp loss params in
   let params, ostate =
-    Vega.adamw_step (module Mlp) ~lr:1e-3 ostate ~params ~grads
+    Vega.adamw_step mlp ~lr:1e-3 ostate ~params ~grads
   in
   ((params, ostate), Nx.item [] l)
 ```
@@ -59,7 +63,7 @@ it; add `vega` to your own project's dependencies.)
 And the training loop is ordinary `Seq` iteration over minibatches:
 
 ```ocaml
-let state = ref (params, Vega.adamw_init (module Mlp) params) in
+let state = ref (params, Vega.adamw_init mlp params) in
 Data.batches2 ~shuffle:true ~batch_size:128 (train_x, train_y)
 |> Seq.iter (fun batch ->
     let s, l = step !state batch in
@@ -74,7 +78,7 @@ checkpoint, or swap.
 ## Features
 
 - **Layers** — `Linear`, `Conv` (2-D, NCHW), `Embedding`, `Attention`
-  (multi-head, causal masking, plus the pure
+  (multi-head, causal masking, a KV cache for decoding, plus the pure
   `scaled_dot_product_attention` core), `Layer_norm`, `Batch_norm`
   (running statistics as explicit state); each is a parameter record
   with `init`/`make`, `apply`, and traversals
@@ -96,7 +100,7 @@ checkpoint, or swap.
   hold model, optimizer state, and counters side by side
 - **Optimizers** — from the independent [vega](../vega/) package:
   `adam`, `adamw`, `sgd` steps over the same record structures
-  (`Vega.adam_step (module Model) ...`); depend on it from your own
+  (`Vega.adam_step model ...`); depend on it from your own
   project
 - **Pretrained models** — `kaun.hf` downloads HuggingFace Hub
   checkpoints and adapts them (`rename`, `transpose`, `split`) onto your
@@ -122,13 +126,13 @@ let () =
   in
   let loss p = Loss.sigmoid_bce (Mlp.apply p x) y in
   let step (params, ostate) =
-    let l, grads = Rune.value_and_grad (module Mlp) loss params in
+    let l, grads = Rune.value_and_grad mlp loss params in
     let params, ostate =
-      Vega.adam_step (module Mlp) ~lr:0.05 ostate ~params ~grads
+      Vega.adam_step mlp ~lr:0.05 ostate ~params ~grads
     in
     ((params, ostate), Nx.item [] l)
   in
-  let state = ref (params, Vega.adam_init (module Mlp) params) in
+  let state = ref (params, Vega.adam_init mlp params) in
   for _ = 1 to 500 do
     let s, _ = step !state in
     state := s
@@ -187,11 +191,12 @@ weights, and generates text.
   flag. Note that `jit` unrolls `Rune.scan`, so a recurrence's compile
   time grows with its sequence length.
 - Layer coverage is deliberately small: no recurrent layers, and
-  `Attention` has no rotary embeddings or KV cache (write them from the
+  `Attention` has no rotary embeddings (write them from the
   `scaled_dot_product_attention` core when needed). `Conv` is
   im2col-based and not tuned for large inputs.
-- `Batch_norm` is single-precision only; the other layers are generic
-  over float dtypes.
+- `Batch_norm.init` builds float32 parameters (cast with
+  `map (Nx.cast dt)` for other precisions); `apply` is generic over
+  float dtypes, like the other layers.
 - `Metric.auc_roc` and macro-averaged scores do not decompose over
   batches — compute them on the full evaluation set (see the `Metric`
   docs).

--- a/packages/kaun/bench/bench_kaun.ml
+++ b/packages/kaun/bench/bench_kaun.ml
@@ -192,7 +192,7 @@ let () =
         [
           Thumper.bench "linear fwd" (fun () -> Kaun.Linear.apply lin lx);
           Thumper.bench "linear fwd+bwd" (fun () ->
-              Rune.value_and_grad (Nx.Ptree.typed (module Kaun.Linear)) lin_loss
+              Rune.value_and_grad (Nx.Ptree.instantiate (module Kaun.Linear)) lin_loss
                 lin);
         ];
     ]

--- a/packages/kaun/bench/bench_kaun.ml
+++ b/packages/kaun/bench/bench_kaun.ml
@@ -27,7 +27,11 @@ let d_h2 = 128
 let d_out = 10
 let lr = 1e-3
 
-type mlp = { l1 : Kaun.Linear.t; l2 : Kaun.Linear.t; l3 : Kaun.Linear.t }
+type mlp = {
+  l1 : Nx.float32_t Kaun.Linear.t;
+  l2 : Nx.float32_t Kaun.Linear.t;
+  l3 : Nx.float32_t Kaun.Linear.t;
+}
 
 module Mlp = struct
   type t = mlp
@@ -65,7 +69,11 @@ let cnn_batch = 32
 let cnn_img = 28
 let cnn_feats = 16 * 5 * 5
 
-type cnn = { c1 : Kaun.Conv.t; c2 : Kaun.Conv.t; head : Kaun.Linear.t }
+type cnn = {
+  c1 : Nx.float32_t Kaun.Conv.t;
+  c2 : Nx.float32_t Kaun.Conv.t;
+  head : Nx.float32_t Kaun.Linear.t;
+}
 
 module Cnn = struct
   type t = cnn
@@ -184,6 +192,7 @@ let () =
         [
           Thumper.bench "linear fwd" (fun () -> Kaun.Linear.apply lin lx);
           Thumper.bench "linear fwd+bwd" (fun () ->
-              Rune.value_and_grad (module Kaun.Linear) lin_loss lin);
+              Rune.value_and_grad (Nx.Ptree.typed (module Kaun.Linear)) lin_loss
+                lin);
         ];
     ]

--- a/packages/kaun/bench/bench_kaun.ml
+++ b/packages/kaun/bench/bench_kaun.ml
@@ -192,7 +192,7 @@ let () =
         [
           Thumper.bench "linear fwd" (fun () -> Kaun.Linear.apply lin lx);
           Thumper.bench "linear fwd+bwd" (fun () ->
-              Rune.value_and_grad (Nx.Ptree.instantiate (module Kaun.Linear)) lin_loss
+              Rune.value_and_grad (Kaun.ptree (module Kaun.Linear)) lin_loss
                 lin);
         ];
     ]

--- a/packages/kaun/doc/01-getting-started.md
+++ b/packages/kaun/doc/01-getting-started.md
@@ -30,29 +30,31 @@ Note the layering: kaun's library depends only on nx and rune. Optimizers come f
 
 ## A Model Is a Record
 
-A kaun layer is a plain record of tensors with an `apply` function; `Linear.t` holds a weight matrix and an optional bias. A model is a record of layers, made traversable by three one-liners that delegate to each field — the `Nx.Ptree.S` interface shared by the whole Raven ecosystem:
+A kaun layer is a plain record with a payload hole and an `apply` function; `'a Linear.t` holds a weight matrix and an optional bias. A model is a record of layers, made traversable by three one-liners that delegate to each field (hand-written here; `[@@deriving ptree]` derives them). `Kaun.ptree` instantiates the model at its tensor type into the `Nx.Ptree.S` walker shared by the whole Raven ecosystem:
 
 ```ocaml
 open Kaun
 
 module Mlp = struct
-  type t = { l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; l2 } =
+  let map f { l1; l2 } =
     { l1 = Linear.map f l1; l2 = Linear.map f l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
+  let map2 f p q =
     { l1 = Linear.map2 f p.l1 q.l1; l2 = Linear.map2 f p.l2 q.l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; l2 } =
+  let iter f { l1; l2 } =
     Linear.iter f l1;
     Linear.iter f l2
 
   let apply p x = Linear.apply p.l2 (Nx.tanh (Linear.apply p.l1 x))
 end
+
+let mlp = Kaun.ptree (module Mlp)
 ```
 
-`apply` is just a function — no base class, no forward method, no parameter registry. The three traversals are what let `Rune` differentiate values of `Mlp.t`, `Vega` step them, and `Checkpoint` save them.
+`apply` is just a function — no base class, no forward method, no parameter registry. The traversals are what let `Rune` differentiate your parameter values, `Vega` step them, and `Checkpoint` save them.
 
 ## Initialize Parameters
 
@@ -79,17 +81,17 @@ let () =
   let loss p = Loss.sigmoid_bce (Mlp.apply p x) y in
 
   (* The training step: value_and_grad + one Adam update. Gradients and
-     optimizer moments are values of Mlp.t, like the parameters. *)
+     optimizer moments have the parameters' record type. *)
   let step (params, ostate) =
-    let l, grads = Rune.value_and_grad (module Mlp) loss params in
+    let l, grads = Rune.value_and_grad mlp loss params in
     let params, ostate =
-      Vega.adam_step (module Mlp) ~lr:0.05 ostate ~params ~grads
+      Vega.adam_step mlp ~lr:0.05 ostate ~params ~grads
     in
     ((params, ostate), Nx.item [] l)
   in
 
   (* The loop: plain OCaml. *)
-  let state = ref (params, Vega.adam_init (module Mlp) params) in
+  let state = ref (params, Vega.adam_init mlp params) in
   for i = 1 to 500 do
     let s, l = step !state in
     state := s;
@@ -108,9 +110,9 @@ let () =
 
 This is the complete program — it is [`examples/01-xor`](https://github.com/raven-ml/raven/tree/main/packages/kaun/examples/01-xor) nearly verbatim. Three things to notice:
 
-- **Every piece of training state is a value of your type.** Parameters, gradients, and the Adam moments (`ostate.mu`, `ostate.nu`) are all `Mlp.t` values you can print, inspect, checkpoint, or swap.
-- **The step is yours.** Want gradient clipping? Insert `Vega.clip_by_global_norm (module Mlp) ~max_norm:1.0 grads` before the update. A learning-rate schedule? Evaluate one at your step counter. Nothing is hidden behind a trainer.
-- **`(module Mlp)` is the only plumbing.** The same first-class module drives differentiation, optimization, and (with `names` added) checkpointing.
+- **Every piece of training state is a value of your type.** Parameters, gradients, and the Adam moments (`ostate.mu`, `ostate.nu`) are all `Nx.float32_t Mlp.t` values you can print, inspect, checkpoint, or swap.
+- **The step is yours.** Want gradient clipping? Insert `Vega.clip_by_global_norm mlp ~max_norm:1.0 grads` before the update. A learning-rate schedule? Evaluate one at your step counter. Nothing is hidden behind a trainer.
+- **`Kaun.ptree (module Mlp)` is the only plumbing.** Bind the walker once; it drives differentiation and optimization, while `Checkpoint` takes `(module Mlp)` itself, since leaf names come from the structure.
 
 ## Scaling Up: Minibatches
 
@@ -120,7 +122,7 @@ For real datasets, `Data.batches2` cuts paired tensors into a `Seq.t` of minibat
 ```ocaml
 let train_x, train_y, test_x, test_y = Kaun_datasets.mnist () in
 let batches = Data.batches2 ~shuffle:true ~batch_size:128 (train_x, train_y) in
-let state = ref (params, Vega.adamw_init (module Mlp) params) in
+let state = ref (params, Vega.adamw_init mlp params) in
 for _epoch = 1 to 3 do
   batches
   |> Seq.iter (fun (x, y) ->
@@ -135,9 +137,9 @@ where `step` now takes the batch as an argument so the loss closes over it:
 ```ocaml
 let step (params, ostate) (x, y) =
   let loss p = Loss.softmax_cross_entropy_sparse (Mlp.apply p x) y in
-  let l, grads = Rune.value_and_grad (module Mlp) loss params in
+  let l, grads = Rune.value_and_grad mlp loss params in
   let params, ostate =
-    Vega.adamw_step (module Mlp) ~lr:1e-3 ostate ~params ~grads
+    Vega.adamw_step mlp ~lr:1e-3 ostate ~params ~grads
   in
   ((params, ostate), Nx.item [] l)
 ```

--- a/packages/kaun/doc/02-layers-and-models.md
+++ b/packages/kaun/doc/02-layers-and-models.md
@@ -6,10 +6,10 @@ Kaun has no layer abstraction. A layer is a plain record of tensors with an `app
 
 Every parameterized layer module follows the same shape, with `Linear` as the reference:
 
-- a parameter record — `Linear.t` is `{ w; b }` with `w : [| inputs; outputs |]` and an optional bias;
+- a parameter record with a payload hole — `'a Linear.t` is `{ w; b }`, at tensor payloads `w : [| inputs; outputs |]` and an optional bias;
 - constructors — `Linear.init ~inputs ~outputs` for the float32 defaults, `Linear.make` for initializer, bias, and dtype control;
 - an `apply` function — `Linear.apply p x` is `x @ p.w + p.b`, treating leading axes as batch axes;
-- traversals — `map`, `map2`, `iter` satisfying `Nx.Ptree.S`, plus `names` for checkpointing.
+- traversals — `map`, `map2`, `iter`, `fold`, `fold2`, `names` satisfying `Nx.Ptree.Uniform`.
 
 ```ocaml
 open Kaun
@@ -49,49 +49,51 @@ Every `apply` is differentiable through rune, in both reverse and forward mode.
 
 ## Models Are Records of Layers
 
-Records nest into records, and the traversals delegate field by field. Adding `names` — one name per leaf, prefixed by field — makes the same module usable with `Checkpoint`:
+Records nest into records, and the traversals delegate field by field, prefixing each leaf's path with the field name:
 
 ```ocaml
 module Mlp = struct
-  type t = { l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; l2 } =
+  let map f { l1; l2 } =
     { l1 = Linear.map f l1; l2 = Linear.map f l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
+  let map2 f p q =
     { l1 = Linear.map2 f p.l1 q.l1; l2 = Linear.map2 f p.l2 q.l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; l2 } =
+  let iter f { l1; l2 } =
     Linear.iter f l1;
     Linear.iter f l2
 
   let names { l1; l2 } =
-    List.map (( ^ ) "l1.") (Linear.names l1)
-    @ List.map (( ^ ) "l2.") (Linear.names l2)
+    {
+      l1 = Linear.map (( ^ ) "l1.") (Linear.names l1);
+      l2 = Linear.map (( ^ ) "l2.") (Linear.names l2);
+    }
 
   let apply p x = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
 ```
 
-The `map`/`map2`/`iter` trio is what `Rune.grad`, `Vega.adam_step`, and friends consume; `names` is the extra line `Checkpoint` needs (the `Checkpoint.Named` module type). This scales without new concepts: a transformer block is a record of five layers, a transformer is a record with a `block list` field traversed with `List.map`/`List.map2`/`List.iter`. [`examples/04-gpt2`](https://github.com/raven-ml/raven/tree/main/packages/kaun/examples/04-gpt2) defines all of GPT-2 this way in ~150 lines.
+The `map`/`map2`/`iter` trio, instantiated by `Kaun.ptree`, is what `Rune.grad`, `Vega.adam_step`, and friends consume; `names` (with `fold`/`fold2`, one-liners of the same shape) is what `Checkpoint` needs — together the `Nx.Ptree.Uniform` contract, which `[@@deriving ptree]` derives in one line. This scales without new concepts: a transformer block is a record of five layers, a transformer is a record with a `block list` field traversed with `List.map`/`List.map2`/`List.iter`. [`examples/04-gpt2`](https://github.com/raven-ml/raven/tree/main/packages/kaun/examples/04-gpt2) defines all of GPT-2 this way in ~150 lines.
 
 A CNN mixes parameterized and stateless pieces freely, since a forward pass is just function composition:
 
 ```ocaml
 module Cnn = struct
-  type t = { c1 : Conv.t; c2 : Conv.t; fc : Linear.t }
+  type 'a t = { c1 : 'a Conv.t; c2 : 'a Conv.t; fc : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { c1; c2; fc } =
+  let map f { c1; c2; fc } =
     { c1 = Conv.map f c1; c2 = Conv.map f c2; fc = Linear.map f fc }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
+  let map2 f p q =
     {
       c1 = Conv.map2 f p.c1 q.c1;
       c2 = Conv.map2 f p.c2 q.c2;
       fc = Linear.map2 f p.fc q.fc;
     }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { c1; c2; fc } =
+  let iter f { c1; c2; fc } =
     Conv.iter f c1;
     Conv.iter f c2;
     Linear.iter f fc
@@ -152,7 +154,7 @@ let () =
   (* [3; 4] — one weighted average of value rows per query row *)
 ```
 
-There are no rotary embeddings or KV cache; write them from this core when needed.
+There are no rotary embeddings; write them from this core when needed. For autoregressive decoding, `apply_cached` runs causal self-attention over a functional key-value cache (`Attention.Cache`), so a generation step keeps fixed shapes and compiles once.
 
 ## Stateful Layers: Batch_norm
 
@@ -162,19 +164,19 @@ There are no rotary embeddings or KV cache; write them from this core when neede
 
 ```ocaml
 module Net = struct
-  type t = { l1 : Linear.t; bn : Batch_norm.t; l2 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; bn : 'a Batch_norm.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; bn; l2 } =
+  let map f { l1; bn; l2 } =
     { l1 = Linear.map f l1; bn = Batch_norm.map f bn; l2 = Linear.map f l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
+  let map2 f p q =
     {
       l1 = Linear.map2 f p.l1 q.l1;
       bn = Batch_norm.map2 f p.bn q.bn;
       l2 = Linear.map2 f p.l2 q.l2;
     }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; bn; l2 } =
+  let iter f { l1; bn; l2 } =
     Linear.iter f l1;
     Batch_norm.iter f bn;
     Linear.iter f l2
@@ -184,6 +186,8 @@ module Net = struct
     let h, stats = Batch_norm.apply p.bn stats ~training h in
     (Linear.apply p.l2 (Fn.relu h), stats)
 end
+
+let net = Kaun.ptree (module Net)
 
 let () =
   Nx.Rng.with_key (Nx.Rng.key 0) @@ fun () ->
@@ -205,15 +209,15 @@ let () =
       (Loss.mse pred y, stats')
     in
     let loss, grads, stats' =
-      Rune.value_and_grad_aux (module Net) objective params
+      Rune.value_and_grad_aux net objective params
     in
     let params, ostate =
-      Vega.adam_step (module Net) ~lr:1e-2 ostate ~params ~grads
+      Vega.adam_step net ~lr:1e-2 ostate ~params ~grads
     in
     ((params, stats', ostate), Nx.item [] loss)
   in
 
-  let state = ref (params, stats, Vega.adam_init (module Net) params) in
+  let state = ref (params, stats, Vega.adam_init net params) in
   for _ = 1 to 20 do
     let s, _ = step !state in
     state := s
@@ -226,9 +230,9 @@ let () =
   Format.printf "eval predictions: %a@." Nx.pp_shape (Nx.shape pred)
 ```
 
-The statistics update inside `apply` is detached, so no gradient flows through `stats'` — that is what makes the auxiliary channel safe. Statistics have their own traversals and `names` (`Batch_norm.Stats` is itself a `Ptree.S` structure), so they checkpoint like parameters under their own prefix; see [Checkpoints](04-checkpoints-and-pretrained/).
+The statistics update inside `apply` is detached, so no gradient flows through `stats'` — that is what makes the auxiliary channel safe. Statistics have their own traversals and `names` (`Batch_norm.Stats` satisfies `Nx.Ptree.Uniform` itself), so they checkpoint like parameters under their own prefix; see [Checkpoints](04-checkpoints-and-pretrained/).
 
-`Batch_norm` is single-precision only; the other layers are generic over float dtypes via their `make` constructors.
+`Batch_norm.init` builds float32 parameters (cast with `map (Nx.cast dt)` for other precisions); `apply` is generic over float dtypes, like the other layers' `make`, computing half- and quarter-precision statistics in a float32 island.
 
 ## Initializers
 

--- a/packages/kaun/doc/03-training.md
+++ b/packages/kaun/doc/03-training.md
@@ -14,37 +14,39 @@ Every training step in kaun has the same three lines: a loss closing over the ba
 open Kaun
 
 module Mlp = struct
-  type t = { l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; l2 } =
+  let map f { l1; l2 } =
     { l1 = Linear.map f l1; l2 = Linear.map f l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
+  let map2 f p q =
     { l1 = Linear.map2 f p.l1 q.l1; l2 = Linear.map2 f p.l2 q.l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; l2 } =
+  let iter f { l1; l2 } =
     Linear.iter f l1;
     Linear.iter f l2
 
   let apply p x = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
 
+let mlp = Kaun.ptree (module Mlp)
+
 let step (params, ostate) (x, y) =
   let loss p = Loss.softmax_cross_entropy_sparse (Mlp.apply p x) y in
-  let l, grads = Rune.value_and_grad (module Mlp) loss params in
+  let l, grads = Rune.value_and_grad mlp loss params in
   let params, ostate =
-    Vega.adamw_step (module Mlp) ~lr:1e-3 ostate ~params ~grads
+    Vega.adamw_step mlp ~lr:1e-3 ostate ~params ~grads
   in
   ((params, ostate), Nx.item [] l)
 ```
 
-The state is a pair `(params, ostate)` of ordinary values — parameters of type `Mlp.t`, optimizer state a record of `Mlp.t`-shaped moments. Nothing is hidden: print a gradient leaf, swap the optimizer, or checkpoint everything mid-run.
+The state is a pair `(params, ostate)` of ordinary values — parameters of type `Nx.float32_t Mlp.t`, optimizer state a record of like-shaped moments. Nothing is hidden: print a gradient leaf, swap the optimizer, or checkpoint everything mid-run.
 
 Because the step is yours, extensions are insertions, not configuration. Gradient clipping goes between the backward pass and the update:
 
 <!-- $MDX skip -->
 ```ocaml
-let grads = Vega.clip_by_global_norm (module Mlp) ~max_norm:1.0 grads in
+let grads = Vega.clip_by_global_norm mlp ~max_norm:1.0 grads in
 ```
 
 A learning-rate schedule is a function `int -> float` you evaluate at your own step counter:
@@ -56,7 +58,7 @@ let sched =
 in
 let step k (params, ostate) (x, y) =
   ...
-  Vega.adamw_step (module Mlp) ~lr:(sched k) ostate ~params ~grads
+  Vega.adamw_step mlp ~lr:(sched k) ostate ~params ~grads
 ```
 
 ## Optimizers
@@ -80,8 +82,8 @@ let () =
       l2 = Linear.init ~inputs:16 ~outputs:3;
     }
   in
-  let ostate = Vega.adamw_init (module Mlp) params in
-  (* The moments are Mlp.t values, inspectable like the parameters. *)
+  let ostate = Vega.adamw_init mlp params in
+  (* The moments have the parameters' type, inspectable like them. *)
   Format.printf "mu.l1.w: %a  step: %d@." Nx.pp_shape
     (Nx.shape ostate.mu.l1.w)
     ostate.step
@@ -132,7 +134,7 @@ Without shuffling, batches are views of the data, not copies, in order. With `~s
 ```ocaml
 Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->
 let data = Data.batches2 ~shuffle:true ~batch_size:128 (train_x, train_y) in
-let state = ref (params, Vega.adamw_init (module Mlp) params) in
+let state = ref (params, Vega.adamw_init mlp params) in
 for _epoch = 1 to 10 do
   data |> Seq.iter (fun batch -> state := fst (step !state batch))
 done

--- a/packages/kaun/doc/04-checkpoints-and-pretrained.md
+++ b/packages/kaun/doc/04-checkpoints-and-pretrained.md
@@ -4,33 +4,43 @@ A checkpoint is an immutable collection of tensors keyed by distinct, non-empty 
 
 ## Named Structures
 
-`Checkpoint` consumes `Checkpoint.Named` modules: `Nx.Ptree.S` plus one function, `names`, giving each tensor leaf a stable name in traversal order. By convention leaves are named after record fields, with nested structures joined by `"."`:
+`Checkpoint` consumes the structure's `Nx.Ptree.Uniform` module — the same traversals the model already has, whose `fold`/`fold2`/`names` give each tensor leaf a stable path. Leaves are named after record fields, with nested structures joined by `"."`:
 
 ```ocaml
 open Kaun
 
 module Mlp = struct
-  type t = { l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; l2 } =
+  let map f { l1; l2 } =
     { l1 = Linear.map f l1; l2 = Linear.map f l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
+  let map2 f p q =
     { l1 = Linear.map2 f p.l1 q.l1; l2 = Linear.map2 f p.l2 q.l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; l2 } =
+  let iter f { l1; l2 } =
     Linear.iter f l1;
     Linear.iter f l2
 
+  let fold f acc { l1; l2 } =
+    let acc = Linear.fold (fun s -> f ("l1." ^ s)) acc l1 in
+    Linear.fold (fun s -> f ("l2." ^ s)) acc l2
+
+  let fold2 f acc p q =
+    let acc = Linear.fold2 (fun s -> f ("l1." ^ s)) acc p.l1 q.l1 in
+    Linear.fold2 (fun s -> f ("l2." ^ s)) acc p.l2 q.l2
+
   let names { l1; l2 } =
-    List.map (( ^ ) "l1.") (Linear.names l1)
-    @ List.map (( ^ ) "l2.") (Linear.names l2)
+    {
+      l1 = Linear.map (( ^ ) "l1.") (Linear.names l1);
+      l2 = Linear.map (( ^ ) "l2.") (Linear.names l2);
+    }
 
   let apply p x = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
 ```
 
-Each layer module ships its own `names` (`Linear.names` is `["w"; "b"]`, or `["w"]` without a bias), so a model's `names` is the same one-liner shape as its traversals. For structures only known at runtime, `Checkpoint.Ptree` names dynamic `Rune.Ptree.t` trees by their path from the root.
+Each layer module ships its own traversals (`Linear.names p` is `{ w = "w"; b = Some "b" }`, with `b` absent when the layer has no bias), so a model's `fold`/`fold2`/`names` are one-liners of the same shape as its `map` — or one `[@@deriving ptree]`. Structures with mixed leaf dtypes hold packed leaves and go through `of_packed`/`to_packed` instead; for the stock dynamic tree `Rune.Ptree.t`, pass `(module Rune.Ptree.Tree)`, which names leaves by dict keys and list positions from the root.
 
 ## Saving and Loading
 
@@ -82,7 +92,7 @@ let () =
     }
   in
   let params = init () in
-  let ostate = Vega.adam_init (module Mlp) params in
+  let ostate = Vega.adam_init (Kaun.ptree (module Mlp)) params in
 
   let path = Filename.temp_file "kaun-doc" ".safetensors" in
   Checkpoint.save path
@@ -112,7 +122,7 @@ let () =
   Printf.printf "resumed at step %d\n" ostate.step
 ```
 
-The optimizer moments checkpoint with the *model's* module because they have the model's shape — one more payoff of parameter-shaped state. `Batch_norm` running statistics work the same way, under their own prefix with `(module Model.Stats)`.
+The optimizer moments checkpoint with the *model's* module because they have the model's shape — one more payoff of parameter-shaped state. `Batch_norm` running statistics work the same way, under their own prefix with `(module Batch_norm.Stats)`.
 
 To load a file into a partially different model — a new head on a pretrained backbone, say — extract each sub-structure with its own module and prefix; entries for the parts you replace are simply never asked for.
 

--- a/packages/kaun/doc/05-pytorch-comparison.md
+++ b/packages/kaun/doc/05-pytorch-comparison.md
@@ -17,18 +17,18 @@ The main shift is from mutable objects to immutable records: a PyTorch model is 
 | Language | Python, dynamic | OCaml, statically typed |
 | Model definition | `nn.Module` subclass with `forward` | plain record + `apply` function |
 | Parameter storage | mutable attributes, auto-registered | fields of your record |
-| Parameter traversal | `model.parameters()` (reflection) | `map`/`map2`/`iter` — 3 one-liners you write |
+| Parameter traversal | `model.parameters()` (reflection) | `map`/`map2`/`iter` — one-liners you write (or `[@@deriving ptree]`) |
 | Forward pass | `model(x)` (stateful method) | `Model.apply params x` (pure function) |
 | Autograd | dynamic tape on tensors (`loss.backward()`) | `Rune.value_and_grad` (effect handlers) |
 | Gradients | `.grad` attributes, mutated in place | a fresh value of your record type |
-| Optimizer | `torch.optim.AdamW(model.parameters())` | `Vega.adamw_step (module Model)` — pure, state threaded explicitly |
+| Optimizer | `torch.optim.AdamW(model.parameters())` | `Vega.adamw_step model` — pure, state threaded explicitly |
 | Train/eval mode | `model.train()` / `model.eval()` | explicit `~training` arguments |
 | Buffers (running stats) | hidden module state | explicit `Stats.t` you thread through the loop |
 | Data loading | `DataLoader` | `Data.batches2` returning a `Seq.t` |
 | Checkpointing | `state_dict()` + `torch.save` (pickle) | named entries + safetensors via `Checkpoint` |
 | Pretrained models | `from_pretrained` per architecture | `kaun.hf` + generic `rename`/`transpose`/`split` |
 | RNG | global `torch.manual_seed` | scoped `Nx.Rng.with_key` |
-| Device | `model.to("cuda")` | CPU only |
+| Device | `model.to("cuda")` | eager on CPU; GPU via `Rune.jit ~device` |
 
 ---
 
@@ -57,20 +57,22 @@ model = MLP()
 open Kaun
 
 module Mlp = struct
-  type t = { l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; l2 } =
+  let map f { l1; l2 } =
     { l1 = Linear.map f l1; l2 = Linear.map f l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
+  let map2 f p q =
     { l1 = Linear.map2 f p.l1 q.l1; l2 = Linear.map2 f p.l2 q.l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; l2 } =
+  let iter f { l1; l2 } =
     Linear.iter f l1;
     Linear.iter f l2
 
   let apply p x = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
+
+let mlp = Kaun.ptree (module Mlp)
 
 let () =
   Nx.Rng.with_key (Nx.Rng.key 0) @@ fun () ->
@@ -84,7 +86,7 @@ let () =
   ignore y
 ```
 
-Where `nn.Module` registers parameters by reflection on attribute assignment, kaun asks you to write the traversal by hand — three mechanical one-liners per record. That is the entire cost, and it buys full typing: `model.l1.w` is a tensor field you can read directly, gradients of `Mlp.t` are `Mlp.t`, and there is no string-keyed parameter store to drift out of sync.
+Where `nn.Module` registers parameters by reflection on attribute assignment, kaun asks you to write the traversal by hand (or derive it with `[@@deriving ptree]`) — mechanical one-liners per record, instantiated once by `Kaun.ptree`. That is the entire cost, and it buys full typing: `model.l1.w` is a tensor field you can read directly, gradients of a model value have the model's own record type, and there is no string-keyed parameter store to drift out of sync.
 
 One deliberate difference: layer *hyper*-parameters that do not change the parameter shapes are arguments of `apply`, not stored configuration — `Attention.apply ~num_heads:12 ~causal:true`, `Layer_norm.apply ~eps:1e-5`.
 
@@ -110,19 +112,19 @@ def step(x, y):
 ```ocaml
 let step (params, ostate) (x, y) =
   let loss p = Loss.softmax_cross_entropy_sparse (Mlp.apply p x) y in
-  let l, grads = Rune.value_and_grad (module Mlp) loss params in
+  let l, grads = Rune.value_and_grad mlp loss params in
   let params, ostate =
-    Vega.adamw_step (module Mlp) ~lr:1e-3 ostate ~params ~grads
+    Vega.adamw_step mlp ~lr:1e-3 ostate ~params ~grads
   in
   ((params, ostate), Nx.item [] l)
 ```
 
 Point-by-point:
 
-- `loss.backward()` → `Rune.value_and_grad (module Mlp) loss params`. No `.grad` attributes: the gradient is returned as a value.
+- `loss.backward()` → `Rune.value_and_grad mlp loss params`. No `.grad` attributes: the gradient is returned as a value.
 - `opt.zero_grad()` → nothing. Gradients are fresh values, never accumulated in place.
-- `opt.step()` → `Vega.adamw_step`. The optimizer holds no reference to the model; its state (`mu`, `nu`, `step`) is a record of `Mlp.t`-shaped values your loop threads explicitly.
-- `torch.nn.utils.clip_grad_norm_` → `Vega.clip_by_global_norm (module Mlp) ~max_norm grads`, a pure function applied between the two.
+- `opt.step()` → `Vega.adamw_step`. The optimizer holds no reference to the model; its state (`mu`, `nu`, `step`) is a record of parameter-shaped values your loop threads explicitly.
+- `torch.nn.utils.clip_grad_norm_` → `Vega.clip_by_global_norm mlp ~max_norm grads`, a pure function applied between the two.
 - LR schedulers → a `Vega.Schedule.t` is `int -> float`; evaluate it at your own step counter and pass `~lr`.
 
 Note the layering: `Vega` is an independent package composed in user code — kaun's library does not depend on it.
@@ -189,7 +191,7 @@ ckpt = torch.load(path)
 model.load_state_dict(ckpt["model"])
 ```
 
-**kaun** — `state_dict()` becomes `Checkpoint.of_params` over a `Named` module (your traversals plus a `names` one-liner), and files are safetensors, not pickles:
+**kaun** — `state_dict()` becomes `Checkpoint.of_params` over your model's `Nx.Ptree.Uniform` module (the same traversals; `names` supplies the leaf paths), and files are safetensors, not pickles:
 
 <!-- $MDX skip -->
 ```ocaml
@@ -237,10 +239,10 @@ let params =
 
 | PyTorch feature | Status in kaun |
 | --- | --- |
-| GPU / `model.to("cuda")` | Not available. Everything runs eagerly on CPU through Nx. |
-| `torch.compile` / JIT | Not available. |
-| Layer coverage | Deliberately small: no recurrent layers; `Attention` has no rotary embeddings or KV cache (write them from `scaled_dot_product_attention`); `Conv` is im2col-based and not tuned for large inputs. |
-| Mixed precision / AMP | No; `Batch_norm` is single-precision only, other layers are generic over float dtypes. |
+| GPU / `model.to("cuda")` | Eager execution is CPU-only; compile a step with `Rune.jit` and pass `~device:"CUDA"` or `~device:"METAL"`. |
+| `torch.compile` / JIT | `Rune.jit` compiles a step (note it unrolls `Rune.scan`). |
+| Layer coverage | Deliberately small: no recurrent layers; `Attention` has no rotary embeddings (write them from `scaled_dot_product_attention`; decoding uses `Attention.apply_cached`'s KV cache); `Conv` is im2col-based and not tuned for large inputs. |
+| Mixed precision / AMP | Manual: cast with `map (Nx.cast dt)` and scale losses with `Vega.Loss_scale`; there is no automatic wrapper. |
 | `DataLoader` workers | No; data is in-memory tensors and a `Seq.t`. |
 | Distributed (`DDP`) | Not available. |
 
@@ -250,12 +252,12 @@ let params =
 
 | Task | PyTorch | kaun |
 | --- | --- | --- |
-| Define a model | `nn.Module` subclass | record + `apply` + 3 traversals |
+| Define a model | `nn.Module` subclass | record + `apply` + one-line traversals |
 | Construct | `MLP()` | `{ l1 = Linear.init ~inputs ~outputs; ... }` |
 | Forward | `model(x)` | `Mlp.apply params x` |
-| Backward | `loss.backward()` | `Rune.value_and_grad (module Mlp) loss params` |
+| Backward | `loss.backward()` | `Rune.value_and_grad mlp loss params` |
 | Zero grads | `opt.zero_grad()` | not needed |
-| Optimizer step | `opt.step()` | `Vega.adamw_step (module Mlp) ~lr st ~params ~grads` |
+| Optimizer step | `opt.step()` | `Vega.adamw_step mlp ~lr st ~params ~grads` |
 | Clip gradients | `clip_grad_norm_` | `Vega.clip_by_global_norm` |
 | LR schedule | `lr_scheduler` object | `Vega.Schedule.t`, evaluated at your counter |
 | Train mode | `model.train()` | `~training:true` arguments |

--- a/packages/kaun/doc/index.md
+++ b/packages/kaun/doc/index.md
@@ -2,7 +2,7 @@
 
 Kaun is a neural network library for OCaml built on [rune](/docs/rune/) autodiff. It provides the building blocks for training networks — layers, activations, initializers, losses, data batching, metrics, checkpoints — as plain records and pure functions. There is no layer object and no trainer: a model is a typed record you write, and a training step is a few lines you own end to end.
 
-The glue is `Nx.Ptree.S`, the traversal interface from [nx](/docs/nx/): [rune](/docs/rune/) (transformations) and [vega](/docs/vega/) (optimizers) each sit on nx independently, kaun's library depends only on nx and rune, and the three compose in your code through the one record type you define.
+The glue is `Nx.Ptree`, the traversal interface from [nx](/docs/nx/): [rune](/docs/rune/) (transformations) and [vega](/docs/vega/) (optimizers) each sit on nx independently, kaun's library depends only on nx and rune, and the three compose in your code through the one record type you define.
 
 ## Features
 
@@ -24,20 +24,22 @@ Train a two-layer network on XOR — the model is a record, the training step is
 open Kaun
 
 module Mlp = struct
-  type t = { l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; l2 } =
+  let map f { l1; l2 } =
     { l1 = Linear.map f l1; l2 = Linear.map f l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
+  let map2 f p q =
     { l1 = Linear.map2 f p.l1 q.l1; l2 = Linear.map2 f p.l2 q.l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; l2 } =
+  let iter f { l1; l2 } =
     Linear.iter f l1;
     Linear.iter f l2
 
   let apply p x = Linear.apply p.l2 (Nx.tanh (Linear.apply p.l1 x))
 end
+
+let mlp = Kaun.ptree (module Mlp)
 
 let () =
   Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->
@@ -53,13 +55,13 @@ let () =
   in
   let loss p = Loss.sigmoid_bce (Mlp.apply p x) y in
   let step (params, ostate) =
-    let l, grads = Rune.value_and_grad (module Mlp) loss params in
+    let l, grads = Rune.value_and_grad mlp loss params in
     let params, ostate =
-      Vega.adam_step (module Mlp) ~lr:0.05 ostate ~params ~grads
+      Vega.adam_step mlp ~lr:0.05 ostate ~params ~grads
     in
     ((params, ostate), Nx.item [] l)
   in
-  let state = ref (params, Vega.adam_init (module Mlp) params) in
+  let state = ref (params, Vega.adam_init mlp params) in
   for _ = 1 to 500 do
     let s, _ = step !state in
     state := s

--- a/packages/kaun/examples/01-xor/main.ml
+++ b/packages/kaun/examples/01-xor/main.ml
@@ -9,20 +9,26 @@
 open Kaun
 
 module Mlp = struct
-  type t = { l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; l2 } =
-    { l1 = Linear.map f l1; l2 = Linear.map f l2 }
+  let map f { l1; l2 } =
+    let l1 = Linear.map f l1 in
+    let l2 = Linear.map f l2 in
+    { l1; l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
-    { l1 = Linear.map2 f p.l1 q.l1; l2 = Linear.map2 f p.l2 q.l2 }
+  let map2 f p q =
+    let l1 = Linear.map2 f p.l1 q.l1 in
+    let l2 = Linear.map2 f p.l2 q.l2 in
+    { l1; l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; l2 } =
+  let iter f { l1; l2 } =
     Linear.iter f l1;
     Linear.iter f l2
 
   let apply p x = Linear.apply p.l2 (Nx.tanh (Linear.apply p.l1 x))
 end
+
+let mlp = Nx.Ptree.typed (module Mlp)
 
 let () =
   Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->
@@ -43,15 +49,15 @@ let () =
   (* Training step: value_and_grad + one Adam update *)
   let loss p = Loss.sigmoid_bce (Mlp.apply p x) y in
   let step (params, ostate) =
-    let l, grads = Rune.value_and_grad (module Mlp) loss params in
+    let l, grads = Rune.value_and_grad mlp loss params in
     let params, ostate =
-      Vega.adam_step (module Mlp) ~lr:0.05 ostate ~params ~grads
+      Vega.adam_step mlp ~lr:0.05 ostate ~params ~grads
     in
     ((params, ostate), Nx.item [] l)
   in
 
   (* Fit *)
-  let state = ref (params, Vega.adam_init (module Mlp) params) in
+  let state = ref (params, Vega.adam_init mlp params) in
   for i = 1 to 500 do
     let s, l = step !state in
     state := s;

--- a/packages/kaun/examples/01-xor/main.ml
+++ b/packages/kaun/examples/01-xor/main.ml
@@ -25,20 +25,6 @@ module Mlp = struct
     Linear.iter f l1;
     Linear.iter f l2
 
-  let fold f acc { l1; l2 } =
-    let acc = Linear.fold (fun p -> f ("l1." ^ p)) acc l1 in
-    Linear.fold (fun p -> f ("l2." ^ p)) acc l2
-
-  let fold2 f acc p q =
-    let acc = Linear.fold2 (fun s -> f ("l1." ^ s)) acc p.l1 q.l1 in
-    Linear.fold2 (fun s -> f ("l2." ^ s)) acc p.l2 q.l2
-
-  let names p =
-    {
-      l1 = Linear.map (( ^ ) "l1.") (Linear.names p.l1);
-      l2 = Linear.map (( ^ ) "l2.") (Linear.names p.l2);
-    }
-
   let apply p x = Linear.apply p.l2 (Nx.tanh (Linear.apply p.l1 x))
 end
 

--- a/packages/kaun/examples/01-xor/main.ml
+++ b/packages/kaun/examples/01-xor/main.ml
@@ -25,6 +25,20 @@ module Mlp = struct
     Linear.iter f l1;
     Linear.iter f l2
 
+  let fold f acc { l1; l2 } =
+    let acc = Linear.fold (fun p -> f ("l1." ^ p)) acc l1 in
+    Linear.fold (fun p -> f ("l2." ^ p)) acc l2
+
+  let fold2 f acc p q =
+    let acc = Linear.fold2 (fun s -> f ("l1." ^ s)) acc p.l1 q.l1 in
+    Linear.fold2 (fun s -> f ("l2." ^ s)) acc p.l2 q.l2
+
+  let names p =
+    {
+      l1 = Linear.map (( ^ ) "l1.") (Linear.names p.l1);
+      l2 = Linear.map (( ^ ) "l2.") (Linear.names p.l2);
+    }
+
   let apply p x = Linear.apply p.l2 (Nx.tanh (Linear.apply p.l1 x))
 end
 

--- a/packages/kaun/examples/01-xor/main.ml
+++ b/packages/kaun/examples/01-xor/main.ml
@@ -28,7 +28,7 @@ module Mlp = struct
   let apply p x = Linear.apply p.l2 (Nx.tanh (Linear.apply p.l1 x))
 end
 
-let mlp = Nx.Ptree.typed (module Mlp)
+let mlp = Nx.Ptree.instantiate (module Mlp)
 
 let () =
   Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->

--- a/packages/kaun/examples/01-xor/main.ml
+++ b/packages/kaun/examples/01-xor/main.ml
@@ -42,7 +42,7 @@ module Mlp = struct
   let apply p x = Linear.apply p.l2 (Nx.tanh (Linear.apply p.l1 x))
 end
 
-let mlp = Nx.Ptree.instantiate (module Mlp)
+let mlp = Kaun.ptree (module Mlp)
 
 let () =
   Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->

--- a/packages/kaun/examples/02-mnist/main.ml
+++ b/packages/kaun/examples/02-mnist/main.ml
@@ -28,20 +28,6 @@ module Mlp = struct
     Linear.iter f l1;
     Linear.iter f l2
 
-  let fold f acc { l1; l2 } =
-    let acc = Linear.fold (fun p -> f ("l1." ^ p)) acc l1 in
-    Linear.fold (fun p -> f ("l2." ^ p)) acc l2
-
-  let fold2 f acc p q =
-    let acc = Linear.fold2 (fun s -> f ("l1." ^ s)) acc p.l1 q.l1 in
-    Linear.fold2 (fun s -> f ("l2." ^ s)) acc p.l2 q.l2
-
-  let names p =
-    {
-      l1 = Linear.map (( ^ ) "l1.") (Linear.names p.l1);
-      l2 = Linear.map (( ^ ) "l2.") (Linear.names p.l2);
-    }
-
   let apply p x = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
 

--- a/packages/kaun/examples/02-mnist/main.ml
+++ b/packages/kaun/examples/02-mnist/main.ml
@@ -12,20 +12,26 @@ let batch_size = 128
 let lr = 1e-3
 
 module Mlp = struct
-  type t = { l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; l2 } =
-    { l1 = Linear.map f l1; l2 = Linear.map f l2 }
+  let map f { l1; l2 } =
+    let l1 = Linear.map f l1 in
+    let l2 = Linear.map f l2 in
+    { l1; l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
-    { l1 = Linear.map2 f p.l1 q.l1; l2 = Linear.map2 f p.l2 q.l2 }
+  let map2 f p q =
+    let l1 = Linear.map2 f p.l1 q.l1 in
+    let l2 = Linear.map2 f p.l2 q.l2 in
+    { l1; l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; l2 } =
+  let iter f { l1; l2 } =
     Linear.iter f l1;
     Linear.iter f l2
 
   let apply p x = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
+
+let mlp = Nx.Ptree.typed (module Mlp)
 
 let () =
   Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->
@@ -50,9 +56,9 @@ let () =
       (* Training step: value_and_grad + one AdamW update *)
       let step (params, ostate) (x, y) =
         let loss p = Loss.softmax_cross_entropy_sparse (Mlp.apply p x) y in
-        let l, grads = Rune.value_and_grad (module Mlp) loss params in
+        let l, grads = Rune.value_and_grad mlp loss params in
         let params, ostate =
-          Vega.adamw_step (module Mlp) ~lr ostate ~params ~grads
+          Vega.adamw_step mlp ~lr ostate ~params ~grads
         in
         ((params, ostate), Nx.item [] l)
       in
@@ -69,7 +75,7 @@ let () =
             if i mod 50 = 0 || i = n_batches then
               Printf.printf "  batch %3d/%d  loss %.4f\n%!" i n_batches l;
             (state, i + 1))
-          ((params, Vega.adamw_init (module Mlp) params), 1)
+          ((params, Vega.adamw_init mlp params), 1)
           batches
       in
 

--- a/packages/kaun/examples/02-mnist/main.ml
+++ b/packages/kaun/examples/02-mnist/main.ml
@@ -45,7 +45,7 @@ module Mlp = struct
   let apply p x = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
 
-let mlp = Nx.Ptree.instantiate (module Mlp)
+let mlp = Kaun.ptree (module Mlp)
 
 let () =
   Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->

--- a/packages/kaun/examples/02-mnist/main.ml
+++ b/packages/kaun/examples/02-mnist/main.ml
@@ -28,6 +28,20 @@ module Mlp = struct
     Linear.iter f l1;
     Linear.iter f l2
 
+  let fold f acc { l1; l2 } =
+    let acc = Linear.fold (fun p -> f ("l1." ^ p)) acc l1 in
+    Linear.fold (fun p -> f ("l2." ^ p)) acc l2
+
+  let fold2 f acc p q =
+    let acc = Linear.fold2 (fun s -> f ("l1." ^ s)) acc p.l1 q.l1 in
+    Linear.fold2 (fun s -> f ("l2." ^ s)) acc p.l2 q.l2
+
+  let names p =
+    {
+      l1 = Linear.map (( ^ ) "l1.") (Linear.names p.l1);
+      l2 = Linear.map (( ^ ) "l2.") (Linear.names p.l2);
+    }
+
   let apply p x = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
 

--- a/packages/kaun/examples/02-mnist/main.ml
+++ b/packages/kaun/examples/02-mnist/main.ml
@@ -31,7 +31,7 @@ module Mlp = struct
   let apply p x = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
 
-let mlp = Nx.Ptree.typed (module Mlp)
+let mlp = Nx.Ptree.instantiate (module Mlp)
 
 let () =
   Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->

--- a/packages/kaun/examples/03-mnist-cnn/main.ml
+++ b/packages/kaun/examples/03-mnist-cnn/main.ml
@@ -74,7 +74,7 @@ module Cnn = struct
     |> Linear.apply p.fc
 end
 
-let cnn = Nx.Ptree.instantiate (module Cnn)
+let cnn = Kaun.ptree (module Cnn)
 
 let accuracy params (x, y) =
   Metric.accuracy (Cnn.apply params ~training:false x) y

--- a/packages/kaun/examples/03-mnist-cnn/main.ml
+++ b/packages/kaun/examples/03-mnist-cnn/main.ml
@@ -20,30 +20,41 @@ let lr = 3e-3
 (* conv(1->8) -> relu -> pool -> conv(8->16) -> relu -> pool -> dropout ->
    linear(400->10). Images are NCHW [n; 1; 28; 28]. *)
 module Cnn = struct
-  type t = { c1 : Conv.t; c2 : Conv.t; fc : Linear.t }
+  type 'a t = { c1 : 'a Conv.t; c2 : 'a Conv.t; fc : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { c1; c2; fc } =
-    { c1 = Conv.map f c1; c2 = Conv.map f c2; fc = Linear.map f fc }
+  let map f { c1; c2; fc } =
+    let c1 = Conv.map f c1 in
+    let c2 = Conv.map f c2 in
+    let fc = Linear.map f fc in
+    { c1; c2; fc }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
-    {
-      c1 = Conv.map2 f p.c1 q.c1;
-      c2 = Conv.map2 f p.c2 q.c2;
-      fc = Linear.map2 f p.fc q.fc;
-    }
+  let map2 f p q =
+    let c1 = Conv.map2 f p.c1 q.c1 in
+    let c2 = Conv.map2 f p.c2 q.c2 in
+    let fc = Linear.map2 f p.fc q.fc in
+    { c1; c2; fc }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { c1; c2; fc } =
+  let iter f { c1; c2; fc } =
     Conv.iter f c1;
     Conv.iter f c2;
     Linear.iter f fc
 
-  let names { c1; c2; fc } =
-    List.concat
-      [
-        List.map (( ^ ) "c1.") (Conv.names c1);
-        List.map (( ^ ) "c2.") (Conv.names c2);
-        List.map (( ^ ) "fc.") (Linear.names fc);
-      ]
+  let fold f acc { c1; c2; fc } =
+    let acc = Conv.fold (fun p -> f ("c1." ^ p)) acc c1 in
+    let acc = Conv.fold (fun p -> f ("c2." ^ p)) acc c2 in
+    Linear.fold (fun p -> f ("fc." ^ p)) acc fc
+
+  let fold2 f acc p q =
+    let acc = Conv.fold2 (fun s -> f ("c1." ^ s)) acc p.c1 q.c1 in
+    let acc = Conv.fold2 (fun s -> f ("c2." ^ s)) acc p.c2 q.c2 in
+    Linear.fold2 (fun s -> f ("fc." ^ s)) acc p.fc q.fc
+
+  let names p =
+    {
+      c1 = Conv.map (( ^ ) "c1.") (Conv.names p.c1);
+      c2 = Conv.map (( ^ ) "c2.") (Conv.names p.c2);
+      fc = Linear.map (( ^ ) "fc.") (Linear.names p.fc);
+    }
 
   let init () =
     {
@@ -63,10 +74,12 @@ module Cnn = struct
     |> Linear.apply p.fc
 end
 
+let cnn = Nx.Ptree.typed (module Cnn)
+
 let accuracy params (x, y) =
   Metric.accuracy (Cnn.apply params ~training:false x) y
 
-let save_training_state path (params, (ostate : Cnn.t Vega.adam_state)) =
+let save_training_state path (params, (ostate : Nx.float32_t Cnn.t Vega.adam_state)) =
   Checkpoint.save path
     (Checkpoint.concat
        [
@@ -79,7 +92,7 @@ let save_training_state path (params, (ostate : Cnn.t Vega.adam_state)) =
 let load_training_state path =
   let ckpt = Checkpoint.load path in
   let like = Cnn.init () in
-  let like_ostate = Vega.adamw_init (module Cnn) like in
+  let like_ostate = Vega.adamw_init cnn like in
   let params = Checkpoint.to_params (module Cnn) ~prefix:"model" ~like ckpt in
   let ostate =
     {
@@ -115,9 +128,9 @@ let () =
         let loss p =
           Loss.softmax_cross_entropy_sparse (Cnn.apply p ~training:true x) y
         in
-        let l, grads = Rune.value_and_grad (module Cnn) loss params in
+        let l, grads = Rune.value_and_grad cnn loss params in
         let params, ostate =
-          Vega.adamw_step (module Cnn) ~lr ostate ~params ~grads
+          Vega.adamw_step cnn ~lr ostate ~params ~grads
         in
         ((params, ostate), Nx.item [] l)
       in
@@ -127,7 +140,7 @@ let () =
       let batches =
         Data.batches2 ~shuffle:true ~batch_size (train_x, train_y)
       in
-      let state = ref (params, Vega.adamw_init (module Cnn) params) in
+      let state = ref (params, Vega.adamw_init cnn params) in
       for epoch = 1 to epochs do
         let losses = ref 0.0 and n = ref 0 in
         batches

--- a/packages/kaun/examples/03-mnist-cnn/main.ml
+++ b/packages/kaun/examples/03-mnist-cnn/main.ml
@@ -74,7 +74,7 @@ module Cnn = struct
     |> Linear.apply p.fc
 end
 
-let cnn = Nx.Ptree.typed (module Cnn)
+let cnn = Nx.Ptree.instantiate (module Cnn)
 
 let accuracy params (x, y) =
   Metric.accuracy (Cnn.apply params ~training:false x) y

--- a/packages/kaun/examples/04-gpt2/gpt2.ml
+++ b/packages/kaun/examples/04-gpt2/gpt2.ml
@@ -22,108 +22,126 @@ type config = {
 
 (* Model: plain records of kaun layers, generic over the float dtype *)
 
-type 'b block = {
-  ln1 : 'b Layer_norm.params;
-  attn : 'b Attention.params;
-  ln2 : 'b Layer_norm.params;
-  fc : 'b Linear.params;
-  proj : 'b Linear.params;
+type 'a block = {
+  ln1 : 'a Layer_norm.t;
+  attn : 'a Attention.t;
+  ln2 : 'a Layer_norm.t;
+  fc : 'a Linear.t;
+  proj : 'a Linear.t;
 }
 
-type 'b params = {
-  wte : 'b Embedding.params;
-  wpe : 'b Embedding.params;
-  blocks : 'b block list;
-  ln_f : 'b Layer_norm.params;
+type 'a params = {
+  wte : 'a Embedding.t;
+  wpe : 'a Embedding.t;
+  blocks : 'a block list;
+  ln_f : 'a Layer_norm.t;
 }
 
-type t = Nx.float32_elt params
+type t = Nx.float32_t params
 
 module Params = struct
-  type nonrec t = t
+  type nonrec 'a t = 'a params
 
-  let map_block (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) b =
-    {
-      ln1 = Layer_norm.map f b.ln1;
-      attn = Attention.map f b.attn;
-      ln2 = Layer_norm.map f b.ln2;
-      fc = Linear.map f b.fc;
-      proj = Linear.map f b.proj;
-    }
+  let map_block f b =
+    let ln1 = Layer_norm.map f b.ln1 in
+    let attn = Attention.map f b.attn in
+    let ln2 = Layer_norm.map f b.ln2 in
+    let fc = Linear.map f b.fc in
+    let proj = Linear.map f b.proj in
+    { ln1; attn; ln2; fc; proj }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p =
-    {
-      wte = Embedding.map f p.wte;
-      wpe = Embedding.map f p.wpe;
-      blocks = List.map (map_block f) p.blocks;
-      ln_f = Layer_norm.map f p.ln_f;
-    }
+  let map f p =
+    let wte = Embedding.map f p.wte in
+    let wpe = Embedding.map f p.wpe in
+    let blocks = List.map (map_block f) p.blocks in
+    let ln_f = Layer_norm.map f p.ln_f in
+    { wte; wpe; blocks; ln_f }
 
-  let map2_block (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) b
-      b' =
-    {
-      ln1 = Layer_norm.map2 f b.ln1 b'.ln1;
-      attn = Attention.map2 f b.attn b'.attn;
-      ln2 = Layer_norm.map2 f b.ln2 b'.ln2;
-      fc = Linear.map2 f b.fc b'.fc;
-      proj = Linear.map2 f b.proj b'.proj;
-    }
+  let map2_block f b b' =
+    let ln1 = Layer_norm.map2 f b.ln1 b'.ln1 in
+    let attn = Attention.map2 f b.attn b'.attn in
+    let ln2 = Layer_norm.map2 f b.ln2 b'.ln2 in
+    let fc = Linear.map2 f b.fc b'.fc in
+    let proj = Linear.map2 f b.proj b'.proj in
+    { ln1; attn; ln2; fc; proj }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p p' =
-    {
-      wte = Embedding.map2 f p.wte p'.wte;
-      wpe = Embedding.map2 f p.wpe p'.wpe;
-      blocks = List.map2 (map2_block f) p.blocks p'.blocks;
-      ln_f = Layer_norm.map2 f p.ln_f p'.ln_f;
-    }
+  let map2 f p p' =
+    let wte = Embedding.map2 f p.wte p'.wte in
+    let wpe = Embedding.map2 f p.wpe p'.wpe in
+    let blocks = List.map2 (map2_block f) p.blocks p'.blocks in
+    let ln_f = Layer_norm.map2 f p.ln_f p'.ln_f in
+    { wte; wpe; blocks; ln_f }
 
-  let iter_block (f : 'a 'b. ('a, 'b) Nx.t -> unit) b =
+  let iter_block f b =
     Layer_norm.iter f b.ln1;
     Attention.iter f b.attn;
     Layer_norm.iter f b.ln2;
     Linear.iter f b.fc;
     Linear.iter f b.proj
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) p =
+  let iter f p =
     Embedding.iter f p.wte;
     Embedding.iter f p.wpe;
     List.iter (iter_block f) p.blocks;
     Layer_norm.iter f p.ln_f
 
-  let names p =
-    let pre prefix ns = List.map (fun n -> prefix ^ "." ^ n) ns in
-    let block b =
-      pre "ln1" (Layer_norm.names b.ln1)
-      @ pre "attn" (Attention.names b.attn)
-      @ pre "ln2" (Layer_norm.names b.ln2)
-      @ pre "fc" (Linear.names b.fc)
-      @ pre "proj" (Linear.names b.proj)
-    in
-    pre "wte" (Embedding.names p.wte)
-    @ pre "wpe" (Embedding.names p.wpe)
-    @ List.concat
-        (List.mapi
-           (fun i b -> pre (Printf.sprintf "blocks.%d" i) (block b))
-           p.blocks)
-    @ pre "ln_f" (Layer_norm.names p.ln_f)
-end
+  let fold_block f acc b =
+    let acc = Layer_norm.fold (fun s -> f ("ln1." ^ s)) acc b.ln1 in
+    let acc = Attention.fold (fun s -> f ("attn." ^ s)) acc b.attn in
+    let acc = Layer_norm.fold (fun s -> f ("ln2." ^ s)) acc b.ln2 in
+    let acc = Linear.fold (fun s -> f ("fc." ^ s)) acc b.fc in
+    Linear.fold (fun s -> f ("proj." ^ s)) acc b.proj
 
-let astype dt p =
-  let block b =
+  let fold f acc p =
+    let acc = Embedding.fold (fun s -> f ("wte." ^ s)) acc p.wte in
+    let acc = Embedding.fold (fun s -> f ("wpe." ^ s)) acc p.wpe in
+    let _, acc =
+      List.fold_left
+        (fun (i, acc) b ->
+          let pre = Printf.sprintf "blocks.%d." i in
+          (i + 1, fold_block (fun s -> f (pre ^ s)) acc b))
+        (0, acc) p.blocks
+    in
+    Layer_norm.fold (fun s -> f ("ln_f." ^ s)) acc p.ln_f
+
+  let fold2_block f acc b b' =
+    let acc = Layer_norm.fold2 (fun s -> f ("ln1." ^ s)) acc b.ln1 b'.ln1 in
+    let acc = Attention.fold2 (fun s -> f ("attn." ^ s)) acc b.attn b'.attn in
+    let acc = Layer_norm.fold2 (fun s -> f ("ln2." ^ s)) acc b.ln2 b'.ln2 in
+    let acc = Linear.fold2 (fun s -> f ("fc." ^ s)) acc b.fc b'.fc in
+    Linear.fold2 (fun s -> f ("proj." ^ s)) acc b.proj b'.proj
+
+  let fold2 f acc p p' =
+    let acc = Embedding.fold2 (fun s -> f ("wte." ^ s)) acc p.wte p'.wte in
+    let acc = Embedding.fold2 (fun s -> f ("wpe." ^ s)) acc p.wpe p'.wpe in
+    let _, acc =
+      List.fold_left2
+        (fun (i, acc) b b' ->
+          let pre = Printf.sprintf "blocks.%d." i in
+          (i + 1, fold2_block (fun s -> f (pre ^ s)) acc b b'))
+        (0, acc) p.blocks p'.blocks
+    in
+    Layer_norm.fold2 (fun s -> f ("ln_f." ^ s)) acc p.ln_f p'.ln_f
+
+  let names_block i b =
+    let pre field s = Printf.sprintf "blocks.%d.%s.%s" i field s in
     {
-      ln1 = Layer_norm.astype dt b.ln1;
-      attn = Attention.astype dt b.attn;
-      ln2 = Layer_norm.astype dt b.ln2;
-      fc = Linear.astype dt b.fc;
-      proj = Linear.astype dt b.proj;
+      ln1 = Layer_norm.map (pre "ln1") (Layer_norm.names b.ln1);
+      attn = Attention.map (pre "attn") (Attention.names b.attn);
+      ln2 = Layer_norm.map (pre "ln2") (Layer_norm.names b.ln2);
+      fc = Linear.map (pre "fc") (Linear.names b.fc);
+      proj = Linear.map (pre "proj") (Linear.names b.proj);
     }
-  in
-  {
-    wte = Embedding.astype dt p.wte;
-    wpe = Embedding.astype dt p.wpe;
-    blocks = List.map block p.blocks;
-    ln_f = Layer_norm.astype dt p.ln_f;
-  }
+
+  let names p =
+    let pre field s = field ^ "." ^ s in
+    {
+      wte = Embedding.map (pre "wte") (Embedding.names p.wte);
+      wpe = Embedding.map (pre "wpe") (Embedding.names p.wpe);
+      blocks = List.mapi names_block p.blocks;
+      ln_f = Layer_norm.map (pre "ln_f") (Layer_norm.names p.ln_f);
+    }
+end
 
 let make cfg =
   let zeros = Init.zeros in

--- a/packages/kaun/examples/04-gpt2/gpt2.mli
+++ b/packages/kaun/examples/04-gpt2/gpt2.mli
@@ -43,7 +43,7 @@ type t = Nx.float32_t params
 (** The type for single-precision GPT-2 parameters, the checkpoint dtype. *)
 
 module Params : Nx.Ptree.Uniform with type 'a t = 'a params
-(** The parameter traversals: hand [Nx.Ptree.instantiate (module Params)] to the
+(** The parameter traversals: hand [Kaun.ptree (module Params)] to the
     transformations, and [(module Params)] to {!Kaun.Checkpoint.of_params} and
     {!Kaun.Checkpoint.to_params}. Leaves are named [wte.table],
     [blocks.0.attn.q.w], [ln_f.gamma], ...

--- a/packages/kaun/examples/04-gpt2/gpt2.mli
+++ b/packages/kaun/examples/04-gpt2/gpt2.mli
@@ -22,47 +22,46 @@ type config = {
 }
 (** The type for GPT-2 hyperparameters, as in HuggingFace's [config.json]. *)
 
-type 'b block = {
-  ln1 : 'b Kaun.Layer_norm.params;
-  attn : 'b Kaun.Attention.params;
-  ln2 : 'b Kaun.Layer_norm.params;
-  fc : 'b Kaun.Linear.params;  (** MLP up projection, [n_embd → n_inner]. *)
-  proj : 'b Kaun.Linear.params;  (** MLP down projection, [n_inner → n_embd]. *)
+type 'a block = {
+  ln1 : 'a Kaun.Layer_norm.t;
+  attn : 'a Kaun.Attention.t;
+  ln2 : 'a Kaun.Layer_norm.t;
+  fc : 'a Kaun.Linear.t;  (** MLP up projection, [n_embd → n_inner]. *)
+  proj : 'a Kaun.Linear.t;  (** MLP down projection, [n_inner → n_embd]. *)
 }
-(** The type for one pre-norm transformer block with float dtype layout ['b]. *)
+(** The type for one pre-norm transformer block over payload ['a]. *)
 
-type 'b params = {
-  wte : 'b Kaun.Embedding.params;
-      (** Token embeddings, also the tied LM head. *)
-  wpe : 'b Kaun.Embedding.params;  (** Learned position embeddings. *)
-  blocks : 'b block list;
-  ln_f : 'b Kaun.Layer_norm.params;
+type 'a params = {
+  wte : 'a Kaun.Embedding.t;  (** Token embeddings, also the tied LM head. *)
+  wpe : 'a Kaun.Embedding.t;  (** Learned position embeddings. *)
+  blocks : 'a block list;
+  ln_f : 'a Kaun.Layer_norm.t;
 }
-(** The type for GPT-2 parameters with float dtype layout ['b]. *)
+(** The type for GPT-2 parameters over payload ['a]. *)
 
-type t = Nx.float32_elt params
+type t = Nx.float32_t params
 (** The type for single-precision GPT-2 parameters, the checkpoint dtype. *)
 
-module Params : Kaun.Checkpoint.Named with type t = t
-(** Checkpoint plumbing for {!type:t}. Leaves are named [wte.table],
-    [blocks.0.attn.q.w], [ln_f.gamma], ... *)
+module Params : Nx.Ptree.Uniform with type 'a t = 'a params
+(** The parameter traversals: hand [Nx.Ptree.typed (module Params)] to the
+    transformations, and [(module Params)] to {!Kaun.Checkpoint.of_params} and
+    {!Kaun.Checkpoint.to_params}. Leaves are named [wte.table],
+    [blocks.0.attn.q.w], [ln_f.gamma], ...
+
+    [Params.map (Nx.cast dt) p] converts precision — for half precision
+    inference, cast a float32 checkpoint once; for mixed-precision training,
+    cast inside the loss function so the float32 parameters receive float32
+    gradients. The kaun layers keep their attention-score and layer-norm
+    statistics in float32 islands whatever [dt]. *)
 
 val make : config -> t
 (** [make cfg] is a zero-initialized model, the [~like] template for
     {!Kaun.Checkpoint.to_params}. *)
 
-val astype : (float, 'c) Nx.dtype -> 'b params -> 'c params
-(** [astype dt p] is [p] with every parameter leaf cast to [dt] — for half
-    precision inference, cast a float32 checkpoint once; for mixed-precision
-    training, cast inside the loss function so the float32 parameters receive
-    float32 gradients (see {!Kaun.Linear.astype}). The kaun layers keep their
-    attention-score and layer-norm statistics in float32 islands whatever [dt].
-*)
-
 val logits :
   config ->
   ?dropout:float * Nx.Rng.key ->
-  'b params ->
+  (float, 'b) Nx.t params ->
   (int32, Nx.int32_elt) Nx.t ->
   (float, 'b) Nx.t
 (** [logits cfg ?dropout p ids] is the next-token logits for the
@@ -80,22 +79,22 @@ val logits :
     Raises [Invalid_argument] if [ids] has more than [cfg.n_positions]
     positions. *)
 
-type 'b cache = 'b Kaun.Attention.Cache.t list
-(** The type for decoding state with float dtype layout ['b]: one key-value
-    cache per block, in block order. *)
+type 'a cache = 'a Kaun.Attention.Cache.t list
+(** The type for decoding state over payload ['a]: one key-value cache per
+    block, in block order. *)
 
-val cache : config -> len:int -> (float, 'b) Nx.dtype -> 'b cache
+val cache : config -> len:int -> (float, 'b) Nx.dtype -> (float, 'b) Nx.t cache
 (** [cache cfg ~len dtype] is an empty decoding state whose caches hold [len]
     positions: the total sequence length (prompt plus generated tokens) must not
     exceed [len]. [dtype] is the parameters' dtype. *)
 
 val logits_cached :
   config ->
-  'b params ->
+  (float, 'b) Nx.t params ->
   pos:(int32, Nx.int32_elt) Nx.t ->
-  'b cache ->
+  (float, 'b) Nx.t cache ->
   (int32, Nx.int32_elt) Nx.t ->
-  (float, 'b) Nx.t * 'b cache
+  (float, 'b) Nx.t * (float, 'b) Nx.t cache
 (** [logits_cached cfg p ~pos caches ids] is the next-token logits at the last
     position of [ids] — shape [[| batch; vocab_size |]] — and the updated
     caches, where [ids] holds the positions [pos] to [pos + seq - 1] of the
@@ -111,7 +110,11 @@ val logits_cached :
     {!Kaun.Attention.apply_cached}. *)
 
 val generate :
-  config -> 'b params -> max_tokens:int -> int32 array -> int32 array
+  config ->
+  (float, 'b) Nx.t params ->
+  max_tokens:int ->
+  int32 array ->
+  int32 array
 (** [generate cfg p ~max_tokens prompt] is [prompt] extended with [max_tokens]
     greedily decoded token ids: each step re-runs {!logits} on the whole
     sequence (the model keeps no key-value cache) and appends the argmax of the

--- a/packages/kaun/examples/04-gpt2/gpt2.mli
+++ b/packages/kaun/examples/04-gpt2/gpt2.mli
@@ -43,7 +43,7 @@ type t = Nx.float32_t params
 (** The type for single-precision GPT-2 parameters, the checkpoint dtype. *)
 
 module Params : Nx.Ptree.Uniform with type 'a t = 'a params
-(** The parameter traversals: hand [Nx.Ptree.typed (module Params)] to the
+(** The parameter traversals: hand [Nx.Ptree.instantiate (module Params)] to the
     transformations, and [(module Params)] to {!Kaun.Checkpoint.of_params} and
     {!Kaun.Checkpoint.to_params}. Leaves are named [wte.table],
     [blocks.0.attn.q.w], [ln_f.gamma], ...

--- a/packages/kaun/examples/04-gpt2/main.ml
+++ b/packages/kaun/examples/04-gpt2/main.ml
@@ -60,13 +60,14 @@ let load_tokenizer () =
    caches carry the same dtype as the weights, so [--dtype float16] decodes with
    half precision weights, activations and caches alike. *)
 
-let generate_jit (type b) ~device cfg (params : b Gpt2.params)
+let generate_jit (type b) ~device cfg
+    (params : (float, b) Nx.t Gpt2.params)
     (dt : (float, b) Nx.dtype) ~max_tokens prompt =
   let module Step = struct
     type t = {
       token : Nx.int32_t; (* [| 1; seq |]: the prompt, then one token *)
       pos : Nx.int32_t; (* [| 1 |], the position of [token]'s first entry *)
-      caches : b Gpt2.cache;
+      caches : (float, b) Nx.t Gpt2.cache;
     }
 
     let map (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) { token; pos; caches } =
@@ -161,14 +162,16 @@ let () =
   let cfg, params = load_model () in
   Printf.printf "loaded weights in %.2f s\n%!" (Unix.gettimeofday () -. t0);
   let ids = Array.map Int32.of_int (Brot.encode_ids tokenizer !prompt) in
-  let run : type b. (float, b) Nx.dtype -> b Gpt2.params -> int32 array =
+  let run :
+      type b. (float, b) Nx.dtype -> (float, b) Nx.t Gpt2.params -> int32 array
+      =
    fun dt params ->
     let bytes = ref 0 in
     let count_t t = bytes := !bytes + Nx.nbytes t in
     Kaun.Embedding.iter count_t params.wte;
     Kaun.Embedding.iter count_t params.wpe;
     List.iter
-      (fun (b : b Gpt2.block) ->
+      (fun (b : (float, b) Nx.t Gpt2.block) ->
         Kaun.Layer_norm.iter count_t b.ln1;
         Kaun.Attention.iter count_t b.attn;
         Kaun.Layer_norm.iter count_t b.ln2;
@@ -187,8 +190,8 @@ let () =
   let toks =
     match !dtype with
     | "float32" -> run Nx.float32 params
-    | "float16" -> run Nx.float16 (Gpt2.astype Nx.float16 params)
-    | "bfloat16" -> run Nx.bfloat16 (Gpt2.astype Nx.bfloat16 params)
+    | "float16" -> run Nx.float16 (Gpt2.Params.map (Nx.cast Nx.float16) params)
+    | "bfloat16" -> run Nx.bfloat16 (Gpt2.Params.map (Nx.cast Nx.bfloat16) params)
     | d -> failwith ("--dtype must be float32, float16 or bfloat16, got " ^ d)
   in
   let dt = Unix.gettimeofday () -. t0 in

--- a/packages/kaun/examples/04-gpt2/train.ml
+++ b/packages/kaun/examples/04-gpt2/train.ml
@@ -34,7 +34,7 @@
 
 open Kaun
 
-let gpt2_tree = Nx.Ptree.typed (module Gpt2.Params)
+let gpt2_tree = Nx.Ptree.instantiate (module Gpt2.Params)
 
 let gpt2_124m : Gpt2.config =
   {

--- a/packages/kaun/examples/04-gpt2/train.ml
+++ b/packages/kaun/examples/04-gpt2/train.ml
@@ -34,7 +34,7 @@
 
 open Kaun
 
-let gpt2_tree = Nx.Ptree.instantiate (module Gpt2.Params)
+let gpt2_tree = Kaun.ptree (module Gpt2.Params)
 
 let gpt2_124m : Gpt2.config =
   {

--- a/packages/kaun/examples/04-gpt2/train.ml
+++ b/packages/kaun/examples/04-gpt2/train.ml
@@ -18,9 +18,9 @@
    construction — same numbers as the single-device step up to fp32 reduction
    order - [--dropout RATE] (default 0, the reference protocol's dropout-free
    graph) enables the GPT-2 dropout sites in [Gpt2.logits]; the per-step mask
-   key is one more int32 leaf of the jitted step's inputs — keys must be inputs,
-   never captures — derived as [Nx.Rng.fold_in root step] from [--seed], so a
-   run is reproducible from its seed alone
+   key is one more int32 leaf of the jitted step's inputs — keys must be
+   inputs, never captures — derived as [Nx.Rng.fold_in root step] from
+   [--seed], so a run is reproducible from its seed alone
 
    Per step it emits the loss (shortest round-trip float64 repr of the fp32
    value), wall-clock ms, and fingerprints of six designated weights in the
@@ -33,6 +33,8 @@
    untouched h.N.attn.bias mask buffers copied from the input). *)
 
 open Kaun
+
+let gpt2_tree = Nx.Ptree.typed (module Gpt2.Params)
 
 let gpt2_124m : Gpt2.config =
   {
@@ -110,8 +112,9 @@ let batch_of_ids ids =
     Nx.create Nx.int32 [| batch_size * seq_len |] (take 1) )
 
 (* Loss: mean cross-entropy over all positions — log-softmax over the vocab
-   axis, NLL of the target id, mean. [?dropout] threads the rate and the step's
-   mask key to [Gpt2.logits]; absent, the graph is exactly the reference's. *)
+   axis, NLL of the target id, mean. [?dropout] threads the rate and the
+   step's mask key to [Gpt2.logits]; absent, the graph is exactly the
+   reference's. *)
 let loss_fn inputs targets ?dropout params =
   let logits = Gpt2.logits gpt2_124m ?dropout params inputs in
   let logits =
@@ -119,8 +122,9 @@ let loss_fn inputs targets ?dropout params =
   in
   Loss.softmax_cross_entropy_sparse logits targets
 
-(* Mixed-precision loss ([--compute-dtype bfloat16] or [float16]): the astype
-   sandwich. [Gpt2.astype] casts the float32 master weights to the compute dtype
+(* Mixed-precision loss ([--compute-dtype bfloat16] or [float16]): the cast
+   sandwich. [Params.map (Nx.cast dt)] casts the float32 master weights to the
+   compute dtype
    at the top of the objective and the logits come back up to float32 for the
    loss, so the objective's reductions run at full precision. The cast VJP
    returns cotangents at the pre-cast dtype, so the gradients — and the
@@ -134,7 +138,7 @@ let loss_fn inputs targets ?dropout params =
    DEBUG=4 shows them), so the bf16 weights are never materialized as a second
    tree. *)
 let loss_fn_half compute inputs targets ?dropout params =
-  let params = Gpt2.astype compute params in
+  let params = Gpt2.Params.map (Nx.cast compute) params in
   let logits = Gpt2.logits gpt2_124m ?dropout params inputs in
   let logits =
     Nx.reshape [| batch_size * seq_len; gpt2_124m.vocab_size |] logits
@@ -157,25 +161,19 @@ module Step_out = struct
 end
 
 let train_step objective params =
-  let loss, grads = Rune.value_and_grad (module Gpt2.Params) objective params in
+  let loss, grads = Rune.value_and_grad gpt2_tree objective params in
   (* Plain SGD: momentum is 0, so the zero velocity from [sgd_init] leaves the
      update exactly [w - lr * g] and needs no threading across steps. *)
-  let state = Vega.sgd_init (module Gpt2.Params) params in
+  let state = Vega.sgd_init gpt2_tree params in
   let params =
-    fst (Vega.sgd_step (module Gpt2.Params) ~lr state ~params ~grads)
+    fst (Vega.sgd_step gpt2_tree ~lr state ~params ~grads)
   in
   { Step_out.params; loss }
 
-(* The step's dropout key rides the input structures as one more optional int32
-   leaf: [Some key] when [--dropout] is positive, [None] otherwise — [None]
-   contributes no leaf, so dropout-free runs trace the exact reference graph.
-
-   The option is about whether dropout is on, not about where the key may live.
-   Rune carries a non-differentiable leaf through [grad] and [vjp], and Vega's
-   optimizers leave it alone, so the key could equally sit in the structure the
-   objective is differentiated against; the objective closes over it here only
-   because the loss-scaling path wants the parameters alone as its cotangent
-   domain. *)
+(* The step's dropout key rides the input structures as one more optional
+   int32 leaf: [Some key] when [--dropout] is positive, [None] otherwise —
+   [None] contributes no leaf, so dropout-free runs trace the exact reference
+   graph. *)
 let map2_key f a b =
   match (a, b) with
   | Some a, Some b -> Some (f a b)
@@ -208,7 +206,11 @@ end
    flag, so the step still traces once). *)
 
 module Scaled_in = struct
-  type t = { params : Gpt2.t; ls : Vega.Loss_scale.t; key : Nx.Rng.key option }
+  type t = {
+    params : Gpt2.t;
+    ls : Vega.Loss_scale.t;
+    key : Nx.Rng.key option;
+  }
 
   let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) t =
     {
@@ -262,15 +264,14 @@ let train_step_scaled objective { Scaled_in.params; ls; key } =
      of this model renders a whole-vocab-axis vectorized store,
      [make_float50257], which NVRTC rejects.) *)
   let loss, grads =
-    Rune.vjp
-      (module Gpt2.Params)
-      (objective key) params ls.Vega.Loss_scale.scale
+    Rune.vjp gpt2_tree (objective key) params
+      ls.Vega.Loss_scale.scale
   in
-  let grads = Vega.Loss_scale.unscale (module Gpt2.Params) ls grads in
-  let finite = Vega.Loss_scale.grads_finite (module Gpt2.Params) grads in
-  let state = Vega.sgd_init (module Gpt2.Params) params in
+  let grads = Vega.Loss_scale.unscale gpt2_tree ls grads in
+  let finite = Vega.Loss_scale.grads_finite gpt2_tree grads in
+  let state = Vega.sgd_init gpt2_tree params in
   let params' =
-    fst (Vega.sgd_step (module Gpt2.Params) ~lr state ~params ~grads)
+    fst (Vega.sgd_step gpt2_tree ~lr state ~params ~grads)
   in
   let params =
     Gpt2.Params.map2 (fun p p' -> Nx.where finite p' p) params params'
@@ -380,9 +381,9 @@ let bias name = function
 
 let checkpoint_of_params original (p : Gpt2.t) =
   let tensor = Checkpoint.of_tensor in
-  let block i (b : Nx.float32_elt Gpt2.block) =
+  let block i (b : Nx.float32_t Gpt2.block) =
     let key leaf = Printf.sprintf "h.%d.%s" i leaf in
-    let linear leaf (l : Linear.t) =
+    let linear leaf (l : Nx.float32_t Linear.t) =
       [
         tensor (key (leaf ^ ".weight")) l.w;
         tensor (key (leaf ^ ".bias")) (bias (key leaf) l.b);
@@ -528,8 +529,8 @@ let () =
         failwith
           ("--compute-dtype must be float32, bfloat16 or float16, got " ^ d)
   in
-  (* [obj key inputs targets] is the shard objective for one step's dropout key;
-     [None] (the default rate 0) is the dropout-free reference graph. *)
+  (* [obj key inputs targets] is the shard objective for one step's dropout
+     key; [None] (the default rate 0) is the dropout-free reference graph. *)
   let rate = !dropout in
   if rate < 0.0 || rate >= 1.0 then failwith "--dropout must be in [0, 1)";
   let obj key inputs targets params =
@@ -542,9 +543,9 @@ let () =
      capture. *)
   let root = Nx.Rng.key !seed in
   let key_at i = if rate = 0.0 then None else Some (Nx.Rng.fold_in root i) in
-  (* [step i] maps parameters to updated parameters and the pre-update loss; the
-     float16 variant additionally threads its loss-scale state, hidden in the
-     closure. *)
+  (* [step i] maps parameters to updated parameters and the pre-update loss;
+     the float16 variant additionally threads its loss-scale state, hidden in
+     the closure. *)
   let step : int -> Gpt2.t -> Gpt2.t * float =
     if !devices = "" then
       if !compute_dtype = "float16" then begin
@@ -583,7 +584,7 @@ let () =
       let in_axes =
         List.init n_params (fun _ -> None)
         @ [ Some 0; Some 0 ]
-        @ if rate = 0.0 then [] else [ None ]
+        @ (if rate = 0.0 then [] else [ None ])
       in
       let f =
         Rune.pmap2 ~devices:devs ~in_axes

--- a/packages/kaun/lib/attention.ml
+++ b/packages/kaun/lib/attention.ml
@@ -3,48 +3,50 @@
   SPDX-License-Identifier: ISC
   ---------------------------------------------------------------------------*)
 
-type 'b params = {
-  q : 'b Linear.params;
-  k : 'b Linear.params;
-  v : 'b Linear.params;
-  out : 'b Linear.params;
+type 'a t = {
+  q : 'a Linear.t;
+  k : 'a Linear.t;
+  v : 'a Linear.t;
+  out : 'a Linear.t;
 }
 
-type t = Nx.float32_elt params
+let map f { q; k; v; out } =
+  let q = Linear.map f q in
+  let k = Linear.map f k in
+  let v = Linear.map f v in
+  let out = Linear.map f out in
+  { q; k; v; out }
 
-let map (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) { q; k; v; out } =
-  {
-    q = Linear.map f q;
-    k = Linear.map f k;
-    v = Linear.map f v;
-    out = Linear.map f out;
-  }
+let map2 f p p' =
+  let q = Linear.map2 f p.q p'.q in
+  let k = Linear.map2 f p.k p'.k in
+  let v = Linear.map2 f p.v p'.v in
+  let out = Linear.map2 f p.out p'.out in
+  { q; k; v; out }
 
-let map2 (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) p p' =
-  {
-    q = Linear.map2 f p.q p'.q;
-    k = Linear.map2 f p.k p'.k;
-    v = Linear.map2 f p.v p'.v;
-    out = Linear.map2 f p.out p'.out;
-  }
-
-let iter (f : 'a 'c. ('a, 'c) Nx.t -> unit) { q; k; v; out } =
+let iter f { q; k; v; out } =
   Linear.iter f q;
   Linear.iter f k;
   Linear.iter f v;
   Linear.iter f out
 
-let astype dt { q; k; v; out } =
-  {
-    q = Linear.astype dt q;
-    k = Linear.astype dt k;
-    v = Linear.astype dt v;
-    out = Linear.astype dt out;
-  }
+let join prefix path = if path = "" then prefix else prefix ^ "." ^ path
+
+let fold f acc { q; k; v; out } =
+  let under prefix acc l = Linear.fold (fun path -> f (join prefix path)) acc l in
+  under "out" (under "v" (under "k" (under "q" acc q) k) v) out
+
+let fold2 f acc p p' =
+  let under prefix acc l l' =
+    Linear.fold2 (fun path -> f (join prefix path)) acc l l'
+  in
+  under "out"
+    (under "v" (under "k" (under "q" acc p.q p'.q) p.k p'.k) p.v p'.v)
+    p.out p'.out
 
 let names p =
-  let sub prefix l = List.map (fun n -> prefix ^ "." ^ n) (Linear.names l) in
-  sub "q" p.q @ sub "k" p.k @ sub "v" p.v @ sub "out" p.out
+  let sub prefix l = Linear.map (join prefix) (Linear.names l) in
+  { q = sub "q" p.q; k = sub "k" p.k; v = sub "v" p.v; out = sub "out" p.out }
 
 let make ?w_init ?bias_init ?bias ~embed_dim dtype =
   if embed_dim <= 0 then
@@ -110,7 +112,7 @@ let scaled_dot_product_attention ?mask q k v =
 (* Key-value cache *)
 
 module Cache = struct
-  type 'b t = { keys : (float, 'b) Nx.t; values : (float, 'b) Nx.t }
+  type 'a t = { keys : 'a; values : 'a }
 
   let make ?(batch = 1) ~num_heads ~head_dim ~len dtype =
     if batch <= 0 || num_heads <= 0 || head_dim <= 0 || len <= 0 then
@@ -121,18 +123,26 @@ module Cache = struct
     let shape = [| batch; num_heads; len; head_dim |] in
     { keys = Nx.zeros dtype shape; values = Nx.zeros dtype shape }
 
-  let map (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) { keys; values } =
-    { keys = f keys; values = f values }
+  let map f { keys; values } =
+    let keys = f keys in
+    let values = f values in
+    { keys; values }
 
-  let map2 (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) c c' =
-    { keys = f c.keys c'.keys; values = f c.values c'.values }
+  let map2 f c c' =
+    let keys = f c.keys c'.keys in
+    let values = f c.values c'.values in
+    { keys; values }
 
-  let iter (f : 'a 'c. ('a, 'c) Nx.t -> unit) { keys; values } =
+  let iter f { keys; values } =
     f keys;
     f values
 
-  let astype dt { keys; values } =
-    { keys = Nx.cast dt keys; values = Nx.cast dt values }
+  let fold f acc { keys; values } = f "values" (f "keys" acc keys) values
+
+  let fold2 f acc c c' =
+    f "values" (f "keys" acc c.keys c'.keys) c.values c'.values
+
+  let names _ = { keys = "keys"; values = "values" }
 end
 
 let apply_cached ?(num_heads = 1) ~pos ~cache p x =

--- a/packages/kaun/lib/attention.mli
+++ b/packages/kaun/lib/attention.mli
@@ -11,8 +11,8 @@
     which splits the projections into heads, runs
     {!scaled_dot_product_attention} on each head and merges the results through
     the output projection. Like the other layers, it composes into models
-    through record nesting; {!map}, {!map2}, {!iter} and {!names} supply the
-    {!Nx.Ptree.S} and checkpoint plumbing.
+    through record nesting; the traversals supply the {!Nx.Ptree.Uniform} and
+    checkpoint plumbing.
 
     The head count is not a parameter: the projections are
     [embed_dim × embed_dim] whatever the head count, so [num_heads] is an
@@ -25,18 +25,14 @@
 
 (** {1:types Types} *)
 
-type 'b params = {
-  q : 'b Linear.params;
-  k : 'b Linear.params;
-  v : 'b Linear.params;
-  out : 'b Linear.params;
+type 'a t = {
+  q : 'a Linear.t;
+  k : 'a Linear.t;
+  v : 'a Linear.t;
+  out : 'a Linear.t;
 }
-(** The type for attention parameters with float dtype layout ['b]: the query,
-    key, value and output projections, each [embed_dim] to [embed_dim] features.
-*)
-
-type t = Nx.float32_elt params
-(** The type for single-precision attention layers, the common case. *)
+(** The type for attention parameters over payload ['a]: the query, key, value
+    and output projections, each [embed_dim] to [embed_dim] features. *)
 
 (** {1:constructors Constructors} *)
 
@@ -46,7 +42,7 @@ val make :
   ?bias:bool ->
   embed_dim:int ->
   (float, 'b) Nx.dtype ->
-  'b params
+  (float, 'b) Nx.t t
 (** [make ~embed_dim dtype] is a fresh layer attending over [embed_dim]
     features: four {!Linear.make} projections with [inputs] and [outputs] both
     [embed_dim]. [w_init], [bias_init] and [bias] are passed to every projection
@@ -56,7 +52,7 @@ val make :
 
     Raises [Invalid_argument] if [embed_dim] is not positive. *)
 
-val init : embed_dim:int -> t
+val init : embed_dim:int -> Nx.float32_t t
 (** [init ~embed_dim] is [make ~embed_dim Nx.float32]: Glorot-uniform weights,
     zero biases. *)
 
@@ -65,7 +61,7 @@ val init : embed_dim:int -> t
 val apply :
   ?num_heads:int ->
   ?causal:bool ->
-  'b params ->
+  (float, 'b) Nx.t t ->
   (float, 'b) Nx.t ->
   (float, 'b) Nx.t
 (** [apply p x] is multi-head self-attention over [x], with:
@@ -104,9 +100,9 @@ val apply :
 
 (** Key-value caches. *)
 module Cache : sig
-  type 'b t = { keys : (float, 'b) Nx.t; values : (float, 'b) Nx.t }
-  (** The type for key-value caches with float dtype layout ['b]: the projected
-      keys and values of the positions seen so far, each of shape
+  type 'a t = { keys : 'a; values : 'a }
+  (** The type for key-value caches over payload ['a]: the projected keys and
+      values of the positions seen so far, at tensor payloads each of shape
       [[| batch; num_heads; len; head_dim |]]. Slots at positions not yet seen
       hold zeros and are never attended to. *)
 
@@ -116,7 +112,7 @@ module Cache : sig
     head_dim:int ->
     len:int ->
     (float, 'b) Nx.dtype ->
-    'b t
+    (float, 'b) Nx.t t
   (** [make ~num_heads ~head_dim ~len dtype] is an empty cache of [len] slots:
       zero tensors of shape [[| batch; num_heads; len; head_dim |]]. [batch]
       defaults to [1]. [len] bounds the total sequence length (prompt plus
@@ -124,36 +120,36 @@ module Cache : sig
 
       Raises [Invalid_argument] if any dimension is not positive. *)
 
-  val map : ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) -> 'b t -> 'b t
+  val map : ('a -> 'b) -> 'a t -> 'b t
   (** [map f c] is [c] with [f] applied to [c.keys] and [c.values], in that
-      order. With {!map2} and {!iter} it satisfies the {!Nx.Ptree.S} contract at
-      any fixed ['b], so caches can be leaves of a jitted step's parameter tree.
-  *)
+      order. The traversals satisfy the {!Nx.Ptree.Uniform} contract, so caches
+      can be part of a jitted step's parameter tree. *)
 
-  val map2 :
-    ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) ->
-    'b t ->
-    'b t ->
-    'b t
+  val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
   (** [map2 f c c'] combines [c] and [c'] leafwise with [f]. *)
 
-  val iter : ('a 'c. ('a, 'c) Nx.t -> unit) -> 'b t -> unit
+  val iter : ('a -> unit) -> 'a t -> unit
   (** [iter f c] applies [f] to [c.keys] and [c.values], in that order. *)
 
-  val astype : (float, 'c) Nx.dtype -> 'b t -> 'c t
-  (** [astype dt c] is [c] with [c.keys] and [c.values] cast to [dt].
-      Differentiable through Rune: gradients flow back at each original leaf's
-      dtype, so an astype of float32 parameters inside a loss function yields
-      float32 gradients. *)
+  val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+  (** [fold f acc c] reduces [c] leafwise; leaf paths are ["keys"] and
+      ["values"]. *)
+
+  val fold2 :
+    (string -> 'acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
+  (** [fold2 f acc c c'] is like {!fold} across two caches. *)
+
+  val names : 'a t -> string t
+  (** [names c] is [{ keys = "keys"; values = "values" }]. *)
 end
 
 val apply_cached :
   ?num_heads:int ->
   pos:(int32, Nx.int32_elt) Nx.t ->
-  cache:'b Cache.t ->
-  'b params ->
+  cache:(float, 'b) Nx.t Cache.t ->
+  (float, 'b) Nx.t t ->
   (float, 'b) Nx.t ->
-  (float, 'b) Nx.t * 'b Cache.t
+  (float, 'b) Nx.t * (float, 'b) Nx.t Cache.t
 (** [apply_cached ~pos ~cache p x] is causal multi-head self-attention of [x]
     over the cached sequence: the result, of [x]'s shape, and the cache with
     [x]'s keys and values written at slots [pos] to [pos + seq - 1].
@@ -212,34 +208,32 @@ val scaled_dot_product_attention :
 
 (** {1:traversals Traversals}
 
-    Plain traversals over the parameter leaves, in the order [q], [k], [v],
-    [out], each traversed as by {!Linear}. They satisfy the {!Nx.Ptree.S}
-    contract at any fixed ['b]. *)
+    Payload traversals in the order [q], [k], [v], [out], each traversed as by
+    {!Linear}, satisfying the {!Nx.Ptree.Uniform} contract. Leaf paths are the
+    projections' paths prefixed with the field name (["q.w"], ["q.b"], ...,
+    ["out.b"]). *)
 
-val map : ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) -> 'b params -> 'b params
-(** [map f p] is [p] with [f] applied to every parameter leaf. *)
+val map : ('a -> 'b) -> 'a t -> 'b t
+(** [map f p] is [p] with [f] applied to every payload leaf. [map (Nx.cast dt)]
+    converts a layer's precision; the cast is differentiable through Rune. *)
 
-val map2 :
-  ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) ->
-  'b params ->
-  'b params ->
-  'b params
+val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 (** [map2 f p p'] combines [p] and [p'] leafwise with [f].
 
     Raises [Invalid_argument] if a projection of [p] has a bias and the
     corresponding projection of [p'] does not (see {!Linear.map2}). *)
 
-val iter : ('a 'c. ('a, 'c) Nx.t -> unit) -> 'b params -> unit
-(** [iter f p] applies [f] to every parameter leaf of [p]. *)
+val iter : ('a -> unit) -> 'a t -> unit
+(** [iter f p] applies [f] to every payload leaf of [p]. *)
 
-val astype : (float, 'c) Nx.dtype -> 'b params -> 'c params
-(** [astype dt p] is [p] with every parameter leaf cast to [dt]. Differentiable
-    through Rune: gradients flow back at each original leaf's dtype, so an
-    astype of float32 parameters inside a loss function yields float32
-    gradients. *)
+val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+(** [fold f acc p] reduces [p] leafwise, threading each leaf's path. *)
 
-val names : 'b params -> string list
-(** [names p] is the checkpoint name of each parameter leaf of [p], in traversal
-    order: each projection's {!Linear.names} prefixed with ["q."], ["k."],
-    ["v."] and ["out."] (e.g. [["q.w"; "q.b"; ...; "out.b"]]). See
-    {!Checkpoint.Named}. *)
+val fold2 : (string -> 'acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
+(** [fold2 f acc p p'] is like {!fold} across two structurally equal layers.
+
+    Raises [Invalid_argument] if a projection of [p] has a bias and the
+    corresponding projection of [p'] does not. *)
+
+val names : 'a t -> string t
+(** [names p] is [p] with every payload replaced by its path. *)

--- a/packages/kaun/lib/batch_norm.ml
+++ b/packages/kaun/lib/batch_norm.ml
@@ -5,40 +5,46 @@
 
 let invalid_argf fmt = Printf.ksprintf invalid_arg fmt
 
-type 'b params = { gamma : (float, 'b) Nx.t; beta : (float, 'b) Nx.t }
-type t = Nx.float32_elt params
+type 'a t = { gamma : 'a; beta : 'a }
 
-let map (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) { gamma; beta } =
-  { gamma = f gamma; beta = f beta }
+let map f { gamma; beta } =
+  let gamma = f gamma in
+  let beta = f beta in
+  { gamma; beta }
 
-let map2 (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) p q =
-  { gamma = f p.gamma q.gamma; beta = f p.beta q.beta }
+let map2 f p q =
+  let gamma = f p.gamma q.gamma in
+  let beta = f p.beta q.beta in
+  { gamma; beta }
 
-let iter (f : 'a 'c. ('a, 'c) Nx.t -> unit) { gamma; beta } =
+let iter f { gamma; beta } =
   f gamma;
   f beta
 
-let astype dt { gamma; beta } =
-  { gamma = Nx.cast dt gamma; beta = Nx.cast dt beta }
-
-let names _ = [ "gamma"; "beta" ]
+let fold f acc { gamma; beta } = f "beta" (f "gamma" acc gamma) beta
+let fold2 f acc p q = f "beta" (f "gamma" acc p.gamma q.gamma) p.beta q.beta
+let names _ = { gamma = "gamma"; beta = "beta" }
 
 module Stats = struct
-  type 'b stats = { mean : (float, 'b) Nx.t; var : (float, 'b) Nx.t }
-  type t = Nx.float32_elt stats
+  type 'a t = { mean : 'a; var : 'a }
 
-  let map (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) { mean; var } =
-    { mean = f mean; var = f var }
+  let map f { mean; var } =
+    let mean = f mean in
+    let var = f var in
+    { mean; var }
 
-  let map2 (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) s s' =
-    { mean = f s.mean s'.mean; var = f s.var s'.var }
+  let map2 f s s' =
+    let mean = f s.mean s'.mean in
+    let var = f s.var s'.var in
+    { mean; var }
 
-  let iter (f : 'a 'c. ('a, 'c) Nx.t -> unit) { mean; var } =
+  let iter f { mean; var } =
     f mean;
     f var
 
-  let astype dt { mean; var } = { mean = Nx.cast dt mean; var = Nx.cast dt var }
-  let names _ = [ "mean"; "var" ]
+  let fold f acc { mean; var } = f "var" (f "mean" acc mean) var
+  let fold2 f acc s s' = f "var" (f "mean" acc s.mean s'.mean) s.var s'.var
+  let names _ = { mean = "mean"; var = "var" }
 end
 
 let init ~features =
@@ -62,7 +68,7 @@ let low_precision : type b. (float, b) Nx.dtype -> bool = function
   | Nx.Float32 | Nx.Float64 -> false
 
 let apply ?(axis = -1) ?(momentum = 0.99) ?(eps = 1e-5) p
-    (stats : _ Stats.stats) ~training x =
+    (stats : _ Stats.t) ~training x =
   if momentum < 0.0 || momentum > 1.0 then
     invalid_argf "Batch_norm.apply: momentum must be in [0, 1], got %g" momentum;
   if eps <= 0.0 then

--- a/packages/kaun/lib/batch_norm.mli
+++ b/packages/kaun/lib/batch_norm.mli
@@ -5,12 +5,12 @@
 
 (** Batch normalization layers (Ioffe and Szegedy, 2015).
 
-    A batch-norm layer is two structures: trainable parameters {!type:params}
-    (the affine [gamma] and [beta], differentiated and optimized like any other
-    parameters) and running statistics {!Stats.stats} (per-feature mean and
+    A batch-norm layer is two structures: trainable parameters {!type:t} (the
+    affine [gamma] and [beta], differentiated and optimized like any other
+    parameters) and running statistics {!Stats.t} (per-feature mean and
     variance, never differentiated, updated by every training forward). Both are
-    plain records with structural traversals; this module is the {!Nx.Ptree.S}
-    instance of its parameters and {!Stats} that of its statistics.
+    records with payload holes; this module is the {!Nx.Ptree.Uniform} instance
+    of its parameters and {!Stats} that of its statistics.
 
     {!apply} in training mode normalizes with the current batch's statistics and
     returns updated running statistics; in eval mode it normalizes with the
@@ -19,16 +19,15 @@
     auxiliary channel — they ride through differentiation undifferentiated:
 
     {[
+    let model = Nx.Ptree.typed (module Model) in
     let step (params, stats, ostate) =
       let objective p =
         let pred, stats' = Model.forward p stats ~training:true x in
         (Loss.mse pred y, stats')
       in
-      let loss, grads, stats' =
-        Rune.value_and_grad_aux (module Model) objective params
-      in
+      let loss, grads, stats' = Rune.value_and_grad_aux model objective params in
       let params, ostate =
-        Vega.adam_step (module Model) ~lr:1e-3 ostate ~params ~grads
+        Vega.adam_step model ~lr:1e-3 ostate ~params ~grads
       in
       ((params, stats', ostate), Nx.item [] loss)
     ]}
@@ -47,35 +46,30 @@
 
 (** {1:params Parameters} *)
 
-type 'b params = { gamma : (float, 'b) Nx.t; beta : (float, 'b) Nx.t }
-(** The type for batch-norm parameters with float dtype layout ['b]: per-feature
-    scale [gamma] and shift [beta], each of shape [[| features |]]. *)
+type 'a t = { gamma : 'a; beta : 'a }
+(** The type for batch-norm parameters over payload ['a]: per-feature scale
+    [gamma] and shift [beta], at tensor payloads each of shape
+    [[| features |]]. *)
 
-type t = Nx.float32_elt params
-(** The type for single-precision batch-norm parameters, the common case. *)
+val map : ('a -> 'b) -> 'a t -> 'b t
+(** [map f p] is [p] with [f] applied to [gamma] and [beta]. [map (Nx.cast dt)]
+    converts a layer's precision; the cast is differentiable through Rune. *)
 
-val map : ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) -> 'b params -> 'b params
-(** [map f p] is [p] with [f] applied to [gamma] and [beta]. *)
-
-val map2 :
-  ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) ->
-  'b params ->
-  'b params ->
-  'b params
+val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 (** [map2 f p q] combines [p] and [q] leafwise with [f]. *)
 
-val iter : ('a 'c. ('a, 'c) Nx.t -> unit) -> 'b params -> unit
+val iter : ('a -> unit) -> 'a t -> unit
 (** [iter f p] applies [f] to [gamma] and [beta], in that order. *)
 
-val astype : (float, 'c) Nx.dtype -> 'b params -> 'c params
-(** [astype dt p] is [p] with every parameter leaf cast to [dt]. Differentiable
-    through Rune: gradients flow back at each original leaf's dtype, so an
-    astype of float32 parameters inside a loss function yields float32
-    gradients. *)
+val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+(** [fold f acc p] reduces [p] leafwise; leaf paths are ["gamma"] and
+    ["beta"]. *)
 
-val names : 'b params -> string list
-(** [names p] is [["gamma"; "beta"]], pairing leaves in traversal order (see
-    {!Checkpoint.Named}). *)
+val fold2 : (string -> 'acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
+(** [fold2 f acc p q] is like {!fold} across two layers. *)
+
+val names : 'a t -> string t
+(** [names p] is [{ gamma = "gamma"; beta = "beta" }]. *)
 
 (** {1:stats Running statistics} *)
 
@@ -84,39 +78,36 @@ val names : 'b params -> string list
     consumed by eval-mode {!apply}. Not parameters — never differentiate or
     optimize them; thread them through the training loop as auxiliary state. *)
 module Stats : sig
-  type 'b stats = { mean : (float, 'b) Nx.t; var : (float, 'b) Nx.t }
-  (** The type for running statistics with float dtype layout ['b], each of
-      shape [[| features |]]. *)
+  type 'a t = { mean : 'a; var : 'a }
+  (** The type for running statistics over payload ['a], at tensor payloads
+      each of shape [[| features |]]. The exponential moving average
+      accumulates small increments, so keep statistics at float32 even when
+      the parameters are half precision. *)
 
-  type t = Nx.float32_elt stats
-  (** The type for single-precision running statistics, the common case. The
-      exponential moving average accumulates small increments, so keep
-      statistics at float32 even when the parameters are half precision. *)
-
-  val map : ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) -> 'b stats -> 'b stats
+  val map : ('a -> 'b) -> 'a t -> 'b t
   (** [map f s] is [s] with [f] applied to [mean] and [var]. *)
 
-  val map2 :
-    ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) ->
-    'b stats ->
-    'b stats ->
-    'b stats
+  val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
   (** [map2 f s s'] combines [s] and [s'] leafwise with [f]. *)
 
-  val iter : ('a 'c. ('a, 'c) Nx.t -> unit) -> 'b stats -> unit
+  val iter : ('a -> unit) -> 'a t -> unit
   (** [iter f s] applies [f] to [mean] and [var], in that order. *)
 
-  val astype : (float, 'c) Nx.dtype -> 'b stats -> 'c stats
-  (** [astype dt s] is [s] with [mean] and [var] cast to [dt]. *)
+  val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+  (** [fold f acc s] reduces [s] leafwise; leaf paths are ["mean"] and
+      ["var"]. *)
 
-  val names : 'b stats -> string list
-  (** [names s] is [["mean"; "var"]], pairing leaves in traversal order (see
-      {!Checkpoint.Named}). *)
+  val fold2 :
+    (string -> 'acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
+  (** [fold2 f acc s s'] is like {!fold} across two statistics. *)
+
+  val names : 'a t -> string t
+  (** [names s] is [{ mean = "mean"; var = "var" }]. *)
 end
 
 (** {1:constructors Constructors} *)
 
-val init : features:int -> t * Stats.t
+val init : features:int -> Nx.float32_t t * Nx.float32_t Stats.t
 (** [init ~features] is a fresh layer for [features]-dimensional features:
     parameters with [gamma] all ones and [beta] all zeros, and statistics with
     [mean] all zeros and [var] all ones (so an untrained layer's eval mode is
@@ -130,11 +121,11 @@ val apply :
   ?axis:int ->
   ?momentum:float ->
   ?eps:float ->
-  'b params ->
-  'b Stats.stats ->
+  (float, 'b) Nx.t t ->
+  (float, 'b) Nx.t Stats.t ->
   training:bool ->
   (float, 'b) Nx.t ->
-  (float, 'b) Nx.t * 'b Stats.stats
+  (float, 'b) Nx.t * (float, 'b) Nx.t Stats.t
 (** [apply p stats ~training x] is [(y, stats')] where [y] normalizes [x] per
     feature and applies the affine transform:
     [y = gamma * (x - mean) / sqrt (var + eps) + beta].

--- a/packages/kaun/lib/batch_norm.mli
+++ b/packages/kaun/lib/batch_norm.mli
@@ -19,7 +19,7 @@
     auxiliary channel — they ride through differentiation undifferentiated:
 
     {[
-    let model = Nx.Ptree.instantiate (module Model) in
+    let model = Kaun.ptree (module Model) in
     let step (params, stats, ostate) =
       let objective p =
         let pred, stats' = Model.forward p stats ~training:true x in

--- a/packages/kaun/lib/batch_norm.mli
+++ b/packages/kaun/lib/batch_norm.mli
@@ -19,7 +19,7 @@
     auxiliary channel — they ride through differentiation undifferentiated:
 
     {[
-    let model = Nx.Ptree.typed (module Model) in
+    let model = Nx.Ptree.instantiate (module Model) in
     let step (params, stats, ostate) =
       let objective p =
         let pred, stats' = Model.forward p stats ~training:true x in

--- a/packages/kaun/lib/checkpoint.ml
+++ b/packages/kaun/lib/checkpoint.ml
@@ -12,71 +12,67 @@ let invalid_argf fmt = Printf.ksprintf invalid_arg fmt
 let shape_to_string s =
   "[" ^ String.concat "; " (Array.to_list (Array.map string_of_int s)) ^ "]"
 
-module type Named = sig
-  include Nx.Ptree.S
+let full_name ?prefix path =
+  match prefix with
+  | None -> path
+  | Some p -> if path = "" then p else p ^ "." ^ path
 
-  val names : t -> string list
-end
+let add_entry ~op ?prefix path packed acc =
+  let name = full_name ?prefix path in
+  if name = "" then invalid_argf "Checkpoint.%s: empty tensor name" op;
+  if String_map.mem name acc then
+    invalid_argf "Checkpoint.%s: duplicate name %S" op name;
+  String_map.add name packed acc
 
-module Ptree = struct
-  include Rune.Ptree
-
-  let names tree =
-    List.rev (Tree.fold (fun path acc _ -> path :: acc) [] tree)
-end
-
-(* [leaf_names ~op (module P) ?prefix params] is the full entry name of each
-   leaf of [params], in traversal order, validated: one name per leaf, all
-   distinct and non-empty. [op] names the calling operation in errors. *)
-let leaf_names ~op (module P : Named) ?prefix (params : P.t) : string list =
-  let names = P.names params in
-  let leaves = ref 0 in
-  P.iter (fun _ -> incr leaves) params;
-  if List.length names <> !leaves then
-    invalid_argf "Checkpoint.%s: %d name(s) for %d tensor leaves" op
-      (List.length names) !leaves;
-  let full name =
-    match prefix with
-    | None -> name
-    | Some p -> if name = "" then p else p ^ "." ^ name
-  in
-  let names = List.map full names in
-  let _ =
-    List.fold_left
-      (fun seen name ->
-        if name = "" then invalid_argf "Checkpoint.%s: empty tensor name" op;
-        if String_map.mem name seen then
-          invalid_argf "Checkpoint.%s: duplicate name %S" op name;
-        String_map.add name () seen)
-      String_map.empty names
-  in
-  names
+(* Typed recovery: the template leaf carries its dtype and shape, so the packed
+   file tensor is witness-checked (or cast) against it. *)
+let fetch (type a b) ~op ~cast name (leaf : (a, b) Nx.t) (t : t) : (a, b) Nx.t
+    =
+  match String_map.find_opt name t with
+  | None -> invalid_argf "Checkpoint.%s: missing entry %S" op name
+  | Some (Rune.Ptree.P x) -> (
+      if Nx.shape x <> Nx.shape leaf then
+        invalid_argf
+          "Checkpoint.%s: shape mismatch for %S: expected %s, got %s" op name
+          (shape_to_string (Nx.shape leaf))
+          (shape_to_string (Nx.shape x));
+      match Nx_core.Dtype.equal_witness (Nx.dtype x) (Nx.dtype leaf) with
+      | Some Type.Equal -> x
+      | None ->
+          if cast then Nx.cast (Nx.dtype leaf) x
+          else
+            invalid_argf
+              "Checkpoint.%s: dtype mismatch for %S: expected %s, got %s \
+               (pass ~cast:true to convert)"
+              op name
+              (Nx_core.Dtype.to_string (Nx.dtype leaf))
+              (Nx_core.Dtype.to_string (Nx.dtype x)))
 
 let empty = String_map.empty
 
-let of_params (module P : Named) ?prefix (params : P.t) : t =
-  let remaining = ref (leaf_names ~op:"of_params" (module P) ?prefix params) in
-  let acc = ref String_map.empty in
-  P.iter
-    (fun leaf ->
-      match !remaining with
-      | [] -> assert false (* one name per leaf, checked by [leaf_names] *)
-      | name :: rest ->
-          remaining := rest;
-          acc := String_map.add name (Ptree.P leaf) !acc)
-    params;
-  !acc
+let of_params (module U : Nx.Ptree.Uniform) ?prefix (params : ('a, 'b) Nx.t U.t)
+    : t =
+  U.fold
+    (fun path acc leaf ->
+      add_entry ~op:"of_params" ?prefix path (Rune.Ptree.P leaf) acc)
+    String_map.empty params
+
+let of_packed (module U : Nx.Ptree.Uniform) ?prefix
+    (params : Rune.Ptree.tensor U.t) : t =
+  U.fold
+    (fun path acc packed -> add_entry ~op:"of_packed" ?prefix path packed acc)
+    String_map.empty params
 
 let of_tensor name x =
   if name = "" then invalid_arg "Checkpoint.of_tensor: empty tensor name";
-  String_map.singleton name (Ptree.P x)
+  String_map.singleton name (Rune.Ptree.P x)
 
 let of_int name i =
   if name = "" then invalid_arg "Checkpoint.of_int: empty tensor name";
   if Int32.to_int (Int32.of_int i) <> i then
     invalid_argf "Checkpoint.of_int: %d does not fit in an int32 entry" i;
   String_map.singleton name
-    (Ptree.P (Nx.full Nx.int32 [| 1 |] (Int32.of_int i)))
+    (Rune.Ptree.P (Nx.full Nx.int32 [| 1 |] (Int32.of_int i)))
 
 let concat ts =
   List.fold_left
@@ -95,69 +91,37 @@ let get name t =
   | Some entry -> entry
   | None -> invalid_argf "Checkpoint.get: no entry named %S" name
 
-let to_params (module P : Named) ?prefix ?(cast = false) ~(like : P.t) (t : t) :
-    P.t =
-  let names = leaf_names ~op:"to_params" (module P) ?prefix like in
-  (* Pair names with leaves by physical identity, in iteration order: positional
-     pairing inside [P.map] would be unsound, since the callback's evaluation
-     order is instance-defined (record fields evaluate right to left) while
-     [iter] has an explicit sequence. A tensor appearing as several leaves
-     queues one name per occurrence. *)
-  let queues : (Obj.t * string Queue.t) list ref = ref [] in
-  let remaining = ref names in
-  P.iter
-    (fun leaf ->
-      match !remaining with
-      | [] -> assert false (* one name per leaf, checked by [leaf_names] *)
-      | name :: rest ->
-          remaining := rest;
-          let key = Obj.repr leaf in
-          let queue =
-            match List.assq_opt key !queues with
-            | Some queue -> queue
-            | None ->
-                let queue = Queue.create () in
-                queues := (key, queue) :: !queues;
-                queue
-          in
-          Queue.add name queue)
-    like;
-  let name_of leaf =
-    match List.assq_opt (Obj.repr leaf) !queues with
-    | Some queue when not (Queue.is_empty queue) -> Queue.pop queue
-    | _ ->
-        invalid_arg "Checkpoint.to_params: map and iter visit different leaves"
-  in
-  (* Typed recovery: each template leaf carries its dtype, so the packed file
-     tensor is witness-checked (or cast) against it. *)
-  let fetch (type a b) name (leaf : (a, b) Nx.t) : (a, b) Nx.t =
-    match String_map.find_opt name t with
-    | None -> invalid_argf "Checkpoint.to_params: missing entry %S" name
-    | Some (Ptree.P x) -> (
-        if Nx.shape x <> Nx.shape leaf then
-          invalid_argf
-            "Checkpoint.to_params: shape mismatch for %S: expected %s, got %s"
-            name
-            (shape_to_string (Nx.shape leaf))
-            (shape_to_string (Nx.shape x));
-        match Nx_core.Dtype.equal_witness (Nx.dtype x) (Nx.dtype leaf) with
-        | Some Type.Equal -> x
-        | None ->
-            if cast then Nx.cast (Nx.dtype leaf) x
-            else
-              invalid_argf
-                "Checkpoint.to_params: dtype mismatch for %S: expected %s, got \
-                 %s (pass ~cast:true to convert)"
-                name
-                (Nx_core.Dtype.to_string (Nx.dtype leaf))
-                (Nx_core.Dtype.to_string (Nx.dtype x)))
-  in
-  P.map (fun leaf -> fetch (name_of leaf) leaf) like
+(* The template's names must be distinct and non-empty before they can be
+   looked up; a plain fold over the template checks them. *)
+let check_names ~op fold_names ?prefix like =
+  ignore
+    (fold_names
+       (fun path acc () -> add_entry ~op ?prefix path () acc)
+       String_map.empty like)
+
+let to_params (module U : Nx.Ptree.Uniform) ?prefix ?(cast = false)
+    ~(like : ('a, 'b) Nx.t U.t) (t : t) : ('a, 'b) Nx.t U.t =
+  check_names ~op:"to_params"
+    (fun f acc like -> U.fold (fun path acc _ -> f path acc ()) acc like)
+    ?prefix like;
+  U.map2
+    (fun path leaf -> fetch ~op:"to_params" ~cast (full_name ?prefix path) leaf t)
+    (U.names like) like
+
+let to_packed (module U : Nx.Ptree.Uniform) ?prefix ?(cast = false)
+    ~(like : Rune.Ptree.tensor U.t) (t : t) : Rune.Ptree.tensor U.t =
+  check_names ~op:"to_packed"
+    (fun f acc like -> U.fold (fun path acc _ -> f path acc ()) acc like)
+    ?prefix like;
+  U.map2
+    (fun path (Rune.Ptree.P leaf) ->
+      Rune.Ptree.P (fetch ~op:"to_packed" ~cast (full_name ?prefix path) leaf t))
+    (U.names like) like
 
 let to_int name t =
   match String_map.find_opt name t with
   | None -> invalid_argf "Checkpoint.to_int: no entry named %S" name
-  | Some (Ptree.P x) -> (
+  | Some (Rune.Ptree.P x) -> (
       if Nx.numel x <> 1 then
         invalid_argf "Checkpoint.to_int: %S is not a scalar (shape %s)" name
           (shape_to_string (Nx.shape x));
@@ -172,7 +136,7 @@ let save path t =
   let entries =
     String_map.fold
       (fun name entry acc ->
-        match entry with Ptree.P x -> (name, Nx_io.P x) :: acc)
+        match entry with Rune.Ptree.P x -> (name, Nx_io.P x) :: acc)
       t []
   in
   Nx_io.save_safetensors path entries
@@ -181,5 +145,5 @@ let load path =
   let archive = Nx_io.load_safetensors path in
   Hashtbl.fold
     (fun name entry acc ->
-      match entry with Nx_io.P x -> String_map.add name (Ptree.P x) acc)
+      match entry with Nx_io.P x -> String_map.add name (Rune.Ptree.P x) acc)
     archive String_map.empty

--- a/packages/kaun/lib/checkpoint.ml
+++ b/packages/kaun/lib/checkpoint.ml
@@ -22,19 +22,7 @@ module Ptree = struct
   include Rune.Ptree
 
   let names tree =
-    let join prefix seg = if prefix = "" then seg else prefix ^ "." ^ seg in
-    let rec go prefix acc = function
-      | Tensor _ -> prefix :: acc
-      | List ts ->
-          snd
-            (List.fold_left
-               (fun (i, acc) v ->
-                 (i + 1, go (join prefix (string_of_int i)) acc v))
-               (0, acc) ts)
-      | Dict kvs ->
-          List.fold_left (fun acc (k, v) -> go (join prefix k) acc v) acc kvs
-    in
-    List.rev (go "" [] tree)
+    List.rev (Tree.fold (fun path acc _ -> path :: acc) [] tree)
 end
 
 (* [leaf_names ~op (module P) ?prefix params] is the full entry name of each

--- a/packages/kaun/lib/checkpoint.mli
+++ b/packages/kaun/lib/checkpoint.mli
@@ -12,7 +12,9 @@
     instance: {!of_params} names each leaf by its path — record fields and
     container positions joined with ["."] — and {!to_params} rebuilds a
     structure from its entries, using an existing value as the template for
-    structure, dtypes, and shapes.
+    structure, dtypes, and shapes. Unlike the transformations, which take an
+    instantiated walker ({!Nx.Ptree.instantiate}), checkpointing takes the
+    structure's module itself: leaf names come from the structure's shape.
 
     Entries not named by the template are ignored on extraction, so one file
     holds several sections side by side — model parameters, parameter-shaped

--- a/packages/kaun/lib/checkpoint.mli
+++ b/packages/kaun/lib/checkpoint.mli
@@ -7,11 +7,12 @@
 
     A checkpoint is an immutable collection of tensors keyed by distinct,
     non-empty names, stored as a
-    {{:https://huggingface.co/docs/safetensors/}safetensors} file. Typed
-    parameter structures enter and leave checkpoints through {!Named}, which
-    extends {!Nx.Ptree.S} with stable leaf names: {!of_params} turns a structure
-    into named entries, and {!to_params} rebuilds one from them, using an
-    existing value as the template for structure, dtypes, and shapes.
+    {{:https://huggingface.co/docs/safetensors/}safetensors} file. Parameter
+    structures enter and leave checkpoints through their {!Nx.Ptree.Uniform}
+    instance: {!of_params} names each leaf by its path — record fields and
+    container positions joined with ["."] — and {!to_params} rebuilds a
+    structure from its entries, using an existing value as the template for
+    structure, dtypes, and shapes.
 
     Entries not named by the template are ignored on extraction, so one file
     holds several sections side by side — model parameters, parameter-shaped
@@ -33,29 +34,11 @@
     [to_params (module Model) ~prefix:"model" ~like:model (Checkpoint.load
      path)]. To load a file into a partially different model (say, a new head on
     a pretrained backbone), extract each sub-structure with its own module and
-    prefix. *)
+    prefix.
 
-(** {1:named Named structures} *)
-
-(** Parameter trees with stable leaf names.
-
-    Implementations must ensure that [names x] has exactly one name per tensor
-    leaf of [x], paired with leaves in traversal order (the order [iter] and
-    [map] visit them), and that the names are distinct and non-empty. By
-    convention leaves are named after record fields, with nested structures
-    joined by ["."] (e.g. ["encoder.w"]). *)
-module type Named = sig
-  include Nx.Ptree.S
-
-  val names : t -> string list
-  (** [names x] is the name of each tensor leaf of [x], in traversal order. *)
-end
-
-module Ptree : Named with type t = Rune.Ptree.t
-(** Dynamic parameter trees as a named structure. Leaves are named by their path
-    from the root: dict keys and zero-based list positions joined with ["."]
-    (e.g. ["layers.0.w"]). A bare root tensor has the empty path and is named by
-    the [prefix] argument of {!of_params} and {!to_params} alone. *)
+    Structures with mixed leaf dtypes — the stock dynamic tree
+    {!Rune.Ptree.t} among them — hold packed leaves, and enter and leave
+    checkpoints through {!of_packed} and {!to_packed}. *)
 
 (** {1:checkpoints Checkpoints} *)
 
@@ -66,13 +49,29 @@ type t
 val empty : t
 (** [empty] is the checkpoint with no entries. *)
 
-val of_params : (module P : Named) -> ?prefix:string -> P.t -> t
-(** [of_params (module P) ?prefix params] is a checkpoint with one entry per
-    tensor leaf of [params], named by [P.names params]. When [prefix] is given,
-    each name becomes [prefix ^ "." ^ name] ([prefix] alone for an empty name).
+val of_params :
+  (module U : Nx.Ptree.Uniform) -> ?prefix:string -> ('a, 'b) Nx.t U.t -> t
+(** [of_params (module U) ?prefix params] is a checkpoint with one entry per
+    leaf of [params], named by its path ([U.fold]'s path convention). When
+    [prefix] is given, each name becomes [prefix ^ "." ^ path] ([prefix] alone
+    for the empty path).
 
-    Raises [Invalid_argument] if [P.names params] does not have exactly one name
-    per leaf, or if the resulting names are not distinct and non-empty. *)
+    Raises [Invalid_argument] if the resulting names are not distinct and
+    non-empty. *)
+
+val of_packed :
+  (module U : Nx.Ptree.Uniform) ->
+  ?prefix:string ->
+  Rune.Ptree.tensor U.t ->
+  t
+(** [of_packed (module U) ?prefix params] is like {!of_params} for a structure
+    with packed leaves, whose dtypes may differ. For the stock dynamic tree,
+    pass [(module Rune.Ptree.Tree)]: leaves are named by dict keys and
+    zero-based list positions joined with ["."] (e.g. ["layers.0.w"]), and a
+    bare root tensor has the empty path and is named by [prefix] alone.
+
+    Raises [Invalid_argument] if the resulting names are not distinct and
+    non-empty. *)
 
 val of_tensor : string -> ('a, 'b) Nx.t -> t
 (** [of_tensor name x] is a checkpoint with the single entry [name] holding [x].
@@ -107,19 +106,35 @@ val get : string -> t -> Rune.Ptree.tensor
 (** {1:extraction Typed extraction} *)
 
 val to_params :
-  (module P : Named) -> ?prefix:string -> ?cast:bool -> like:P.t -> t -> P.t
-(** [to_params (module P) ?prefix ?cast ~like t] is [like] with every tensor
-    leaf replaced by [t]'s entry of the same name — [P.names like], prefixed as
-    in {!of_params}. [like] supplies the structure, names, dtypes, and shapes;
-    its values are discarded. Entries of [t] not named by [like] are ignored.
+  (module U : Nx.Ptree.Uniform) ->
+  ?prefix:string ->
+  ?cast:bool ->
+  like:('a, 'b) Nx.t U.t ->
+  t ->
+  ('a, 'b) Nx.t U.t
+(** [to_params (module U) ?prefix ?cast ~like t] is [like] with every leaf
+    replaced by [t]'s entry of the same name — the leaf's path, prefixed as in
+    {!of_params}. [like] supplies the structure, names, dtypes, and shapes; its
+    values are discarded. Entries of [t] not named by [like] are ignored.
 
-    Each entry must have its leaf's shape, and its dtype: when [cast] is [false]
-    (default) a dtype mismatch raises, when [true] mismatched entries are cast
-    to the leaf's dtype.
+    Each entry must have its leaf's shape, and its dtype: when [cast] is
+    [false] (default) a dtype mismatch raises, when [true] mismatched entries
+    are cast to the leaf's dtype.
 
     Raises [Invalid_argument] if an entry named by [like] is missing, on shape
-    mismatch, on dtype mismatch when [cast] is [false], or if [P.names like] is
-    invalid (see {!of_params}). *)
+    mismatch, on dtype mismatch when [cast] is [false], or if [like]'s names
+    are not distinct and non-empty. *)
+
+val to_packed :
+  (module U : Nx.Ptree.Uniform) ->
+  ?prefix:string ->
+  ?cast:bool ->
+  like:Rune.Ptree.tensor U.t ->
+  t ->
+  Rune.Ptree.tensor U.t
+(** [to_packed (module U) ?prefix ?cast ~like t] is like {!to_params} for a
+    structure with packed leaves, with names as in {!of_packed}. Each template
+    leaf's runtime dtype and shape check the corresponding entry. *)
 
 val to_int : string -> t -> int
 (** [to_int name t] is the integer stored at [name] by {!of_int}.

--- a/packages/kaun/lib/conv.ml
+++ b/packages/kaun/lib/conv.ml
@@ -3,32 +3,40 @@
   SPDX-License-Identifier: ISC
   ---------------------------------------------------------------------------*)
 
-type 'b params = { w : (float, 'b) Nx.t; b : (float, 'b) Nx.t option }
-type t = Nx.float32_elt params
+type 'a t = { w : 'a; b : 'a option }
 
-let map (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) { w; b } =
-  { w = f w; b = (match b with None -> None | Some b -> Some (f b)) }
+let map f { w; b } =
+  let w = f w in
+  let b = match b with None -> None | Some b -> Some (f b) in
+  { w; b }
 
-let map2 (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) p q =
+let map2 f p q =
+  let w = f p.w q.w in
   let b =
     match (p.b, q.b) with
     | Some pb, Some qb -> Some (f pb qb)
     | None, None -> None
     | Some _, None | None, Some _ -> invalid_arg "Conv.map2: bias mismatch"
   in
-  { w = f p.w q.w; b }
+  { w; b }
 
-let iter (f : 'a 'c. ('a, 'c) Nx.t -> unit) { w; b } =
+let iter f { w; b } =
   f w;
   match b with None -> () | Some b -> f b
 
-let astype dt { w; b } =
-  {
-    w = Nx.cast dt w;
-    b = (match b with None -> None | Some b -> Some (Nx.cast dt b));
-  }
+let fold f acc { w; b } =
+  let acc = f "w" acc w in
+  match b with None -> acc | Some b -> f "b" acc b
 
-let names p = match p.b with None -> [ "w" ] | Some _ -> [ "w"; "b" ]
+let fold2 f acc p q =
+  let acc = f "w" acc p.w q.w in
+  match (p.b, q.b) with
+  | Some pb, Some qb -> f "b" acc pb qb
+  | None, None -> acc
+  | Some _, None | None, Some _ -> invalid_arg "Conv.fold2: bias mismatch"
+
+let names p =
+  { w = "w"; b = (match p.b with None -> None | Some _ -> Some "b") }
 
 let make ?(w_init = Init.glorot_uniform) ?(bias_init = Init.zeros)
     ?(bias = true) ~in_channels ~out_channels ~kernel_size dtype =

--- a/packages/kaun/lib/conv.mli
+++ b/packages/kaun/lib/conv.mli
@@ -10,24 +10,21 @@
     layout — [[| batch; channels; height; width |]] — computing the
     cross-correlation used by deep-learning frameworks (no kernel flip).
     Construct parameters with {!init} or {!make} and convolve with {!apply};
-    {!map}, {!map2}, {!iter} and {!names} supply the {!Nx.Ptree.S} and
-    checkpoint plumbing, exactly as in {!Linear}.
+    the traversals supply the {!Nx.Ptree.Uniform} and checkpoint plumbing,
+    exactly as in {!Linear}.
 
     Pooling has no parameters and lives in {!Pool}. *)
 
 (** {1:types Types} *)
 
-type 'b params = { w : (float, 'b) Nx.t; b : (float, 'b) Nx.t option }
-(** The type for convolution parameters with float dtype layout ['b].
+type 'a t = { w : 'a; b : 'a option }
+(** The type for convolution parameters over payload ['a].
 
-    [w] has shape [[| out_channels; in_channels; kh; kw |]] — one
-    [in_channels × kh × kw] filter per output channel — and [b], when present,
-    shape [[| out_channels |]]. [b] is [None] for layers built without a bias
-    ({!make}[ ~bias:false]); such layers have no bias parameter at all, so
-    traversals skip it and {!apply} performs no shift. *)
-
-type t = Nx.float32_elt params
-(** The type for single-precision convolution layers, the common case. *)
+    At tensor payloads, [w] has shape [[| out_channels; in_channels; kh; kw |]]
+    — one [in_channels × kh × kw] filter per output channel — and [b], when
+    present, shape [[| out_channels |]]. [b] is [None] for layers built without
+    a bias ({!make}[ ~bias:false]); such layers have no bias parameter at all,
+    so traversals skip it and {!apply} performs no shift. *)
 
 (** {1:constructors Constructors} *)
 
@@ -39,7 +36,7 @@ val make :
   out_channels:int ->
   kernel_size:int * int ->
   (float, 'b) Nx.dtype ->
-  'b params
+  (float, 'b) Nx.t t
 (** [make ~in_channels ~out_channels ~kernel_size:(kh, kw) dtype] is a fresh
     layer of [out_channels] filters of shape [in_channels × kh × kw], with:
 
@@ -57,7 +54,8 @@ val make :
     Raises [Invalid_argument] if [in_channels], [out_channels], [kh] or [kw] is
     not positive. *)
 
-val init : in_channels:int -> out_channels:int -> kernel_size:int * int -> t
+val init :
+  in_channels:int -> out_channels:int -> kernel_size:int * int -> Nx.float32_t t
 (** [init ~in_channels ~out_channels ~kernel_size] is
     [make ~in_channels ~out_channels ~kernel_size Nx.float32]: Glorot-uniform
     weights, zero bias. *)
@@ -67,7 +65,7 @@ val init : in_channels:int -> out_channels:int -> kernel_size:int * int -> t
 val apply :
   ?stride:int * int ->
   ?padding:[ `Same | `Valid ] ->
-  'b params ->
+  (float, 'b) Nx.t t ->
   (float, 'b) Nx.t ->
   (float, 'b) Nx.t
 (** [apply p x] cross-correlates [p]'s filters with [x] and adds the bias (no
@@ -90,32 +88,30 @@ val apply :
 
 (** {1:traversals Traversals}
 
-    Plain traversals over the parameter leaves, in the order [w] then [b]. They
-    satisfy the {!Nx.Ptree.S} contract at any fixed ['b]. *)
+    Payload traversals in the order [w] then [b], satisfying the
+    {!Nx.Ptree.Uniform} contract. Leaf paths are ["w"] and ["b"]. *)
 
-val map : ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) -> 'b params -> 'b params
-(** [map f p] is [p] with [f] applied to every parameter leaf. *)
+val map : ('a -> 'b) -> 'a t -> 'b t
+(** [map f p] is [p] with [f] applied to every payload leaf. [map (Nx.cast dt)]
+    converts a layer's precision; the cast is differentiable through Rune. *)
 
-val map2 :
-  ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) ->
-  'b params ->
-  'b params ->
-  'b params
+val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 (** [map2 f p q] combines [p] and [q] leafwise with [f].
 
     Raises [Invalid_argument] if one of [p] and [q] has a bias and the other
     does not. *)
 
-val iter : ('a 'c. ('a, 'c) Nx.t -> unit) -> 'b params -> unit
-(** [iter f p] applies [f] to every parameter leaf of [p]. *)
+val iter : ('a -> unit) -> 'a t -> unit
+(** [iter f p] applies [f] to every payload leaf of [p]. *)
 
-val astype : (float, 'c) Nx.dtype -> 'b params -> 'c params
-(** [astype dt p] is [p] with every parameter leaf cast to [dt]. Differentiable
-    through Rune: gradients flow back at each original leaf's dtype, so an
-    astype of float32 parameters inside a loss function yields float32
-    gradients. *)
+val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+(** [fold f acc p] reduces [p] leafwise, threading each leaf's path. *)
 
-val names : 'b params -> string list
-(** [names p] is the checkpoint name of each parameter leaf of [p], in traversal
-    order: [["w"; "b"]], or [["w"]] when [p] has no bias. See
-    {!Checkpoint.Named}. *)
+val fold2 : (string -> 'acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
+(** [fold2 f acc p q] is like {!fold} across two structurally equal layers.
+
+    Raises [Invalid_argument] if one of [p] and [q] has a bias and the other
+    does not. *)
+
+val names : 'a t -> string t
+(** [names p] is [p] with every payload replaced by its path. *)

--- a/packages/kaun/lib/embedding.ml
+++ b/packages/kaun/lib/embedding.ml
@@ -3,18 +3,14 @@
   SPDX-License-Identifier: ISC
   ---------------------------------------------------------------------------*)
 
-type 'b params = { table : (float, 'b) Nx.t }
-type t = Nx.float32_elt params
+type 'a t = { table : 'a }
 
-let map (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) { table } =
-  { table = f table }
-
-let map2 (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) p q =
-  { table = f p.table q.table }
-
-let iter (f : 'a 'c. ('a, 'c) Nx.t -> unit) { table } = f table
-let astype dt { table } = { table = Nx.cast dt table }
-let names _ = [ "table" ]
+let map f { table } = { table = f table }
+let map2 f p q = { table = f p.table q.table }
+let iter f { table } = f table
+let fold f acc { table } = f "table" acc table
+let fold2 f acc p q = f "table" acc p.table q.table
+let names _ = { table = "table" }
 
 let make ?init ~vocab ~dim dtype =
   if vocab <= 0 || dim <= 0 then

--- a/packages/kaun/lib/embedding.mli
+++ b/packages/kaun/lib/embedding.mli
@@ -6,25 +6,25 @@
 (** Embedding layers.
 
     An embedding is a lookup table mapping integer token ids to learned dense
-    vectors: a plain record holding one [vocab × dim] parameter. Construct one
-    with {!init} or {!make} and turn id tensors into vector tensors with
-    {!apply}. Like the other layers, it composes into models through record
-    nesting; {!map}, {!map2}, {!iter} and {!names} supply the {!Nx.Ptree.S} and
-    checkpoint plumbing. *)
+    vectors: a record with one [vocab × dim] payload hole. Construct one with
+    {!init} or {!make} and turn id tensors into vector tensors with {!apply}.
+    Like the other layers, it composes into models through record nesting; the
+    traversals supply the {!Nx.Ptree.Uniform} and checkpoint plumbing. *)
 
 (** {1:types Types} *)
 
-type 'b params = { table : (float, 'b) Nx.t }
-(** The type for embedding parameters with float dtype layout ['b]. [table] has
-    shape [[| vocab; dim |]]: one row per token id. *)
-
-type t = Nx.float32_elt params
-(** The type for single-precision embeddings, the common case. *)
+type 'a t = { table : 'a }
+(** The type for embedding parameters over payload ['a]. At tensor payloads,
+    [table] has shape [[| vocab; dim |]]: one row per token id. *)
 
 (** {1:constructors Constructors} *)
 
 val make :
-  ?init:'b Init.t -> vocab:int -> dim:int -> (float, 'b) Nx.dtype -> 'b params
+  ?init:'b Init.t ->
+  vocab:int ->
+  dim:int ->
+  (float, 'b) Nx.dtype ->
+  (float, 'b) Nx.t t
 (** [make ~vocab ~dim dtype] is a fresh table of [vocab] rows of [dim] features.
     [init] initializes the table and is applied with [~fan_in:dim] and
     [~fan_out:dim], so variance-scaling initializers target a variance
@@ -34,13 +34,13 @@ val make :
 
     Raises [Invalid_argument] if [vocab] or [dim] is not positive. *)
 
-val init : vocab:int -> dim:int -> t
+val init : vocab:int -> dim:int -> Nx.float32_t t
 (** [init ~vocab ~dim] is [make ~vocab ~dim Nx.float32]: rows drawn from
     [N(0, 1)]. *)
 
 (** {1:applying Applying} *)
 
-val apply : 'b params -> (int32, Nx.int32_elt) Nx.t -> (float, 'b) Nx.t
+val apply : (float, 'b) Nx.t t -> (int32, Nx.int32_elt) Nx.t -> (float, 'b) Nx.t
 (** [apply p ids] gathers the table row of each id: the result has [ids]'s shape
     with a trailing axis of size [dim] appended, and its [(i, ..., :)] slice is
     row [ids.(i, ...)] of [p.table]. A scalar id yields a single row of shape
@@ -53,27 +53,24 @@ val apply : 'b params -> (int32, Nx.int32_elt) Nx.t -> (float, 'b) Nx.t
 
 (** {1:traversals Traversals}
 
-    Plain traversals over the single parameter leaf. They satisfy the
-    {!Nx.Ptree.S} contract at any fixed ['b]. *)
+    Payload traversals over the single leaf, satisfying the
+    {!Nx.Ptree.Uniform} contract. The leaf path is ["table"]. *)
 
-val map : ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) -> 'b params -> 'b params
-(** [map f p] is [p] with [f] applied to the table. *)
+val map : ('a -> 'b) -> 'a t -> 'b t
+(** [map f p] is [p] with [f] applied to the table. [map (Nx.cast dt) p]
+    converts the table's precision; the cast is differentiable through Rune. *)
 
-val map2 :
-  ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) ->
-  'b params ->
-  'b params ->
-  'b params
+val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 (** [map2 f p q] combines the tables of [p] and [q] with [f]. *)
 
-val iter : ('a 'c. ('a, 'c) Nx.t -> unit) -> 'b params -> unit
+val iter : ('a -> unit) -> 'a t -> unit
 (** [iter f p] applies [f] to the table. *)
 
-val astype : (float, 'c) Nx.dtype -> 'b params -> 'c params
-(** [astype dt p] is [p] with the table cast to [dt]. Differentiable through
-    Rune: gradients flow back at each original leaf's dtype, so an astype of
-    float32 parameters inside a loss function yields float32 gradients. *)
+val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+(** [fold f acc p] is [f "table" acc p.table]. *)
 
-val names : 'b params -> string list
-(** [names p] is [["table"]], the checkpoint name of the single parameter leaf.
-    See {!Checkpoint.Named}. *)
+val fold2 : (string -> 'acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
+(** [fold2 f acc p q] is [f "table" acc p.table q.table]. *)
+
+val names : 'a t -> string t
+(** [names p] is [{ table = "table" }]. *)

--- a/packages/kaun/lib/kaun.ml
+++ b/packages/kaun/lib/kaun.ml
@@ -17,3 +17,5 @@ module Pool = Pool
 module Conv = Conv
 module Attention = Attention
 module Checkpoint = Checkpoint
+
+let ptree = Nx.Ptree.instantiate

--- a/packages/kaun/lib/kaun.mli
+++ b/packages/kaun/lib/kaun.mli
@@ -8,13 +8,13 @@
     Kaun has no layer or trainer abstraction. A layer is a record of parameters
     with a payload hole and an [apply] function; a model is a record of layers
     with one-line traversals (the {!Nx.Ptree.Uniform} contract, hand-written or
-    derived with [ppx_ptree]; see {!Linear} for the pattern). [Nx.Ptree.typed]
+    derived with [ppx_ptree]; see {!Linear} for the pattern). [Nx.Ptree.instantiate]
     instantiates the model at its tensor type, a training step composes
     {!Rune.value_and_grad} with a [Vega] optimizer update, and the training
     loop is ordinary [Seq] iteration over {!Data} minibatches.
 
     {[
-    let model = Nx.Ptree.typed (module Model)
+    let model = Nx.Ptree.instantiate (module Model)
 
     let step (params, ostate) (x, y) =
       let loss p = Loss.softmax_cross_entropy_sparse (Model.apply p x) y in

--- a/packages/kaun/lib/kaun.mli
+++ b/packages/kaun/lib/kaun.mli
@@ -8,13 +8,13 @@
     Kaun has no layer or trainer abstraction. A layer is a record of parameters
     with a payload hole and an [apply] function; a model is a record of layers
     with one-line traversals (the {!Nx.Ptree.Uniform} contract, hand-written or
-    derived with [ppx_ptree]; see {!Linear} for the pattern). [Nx.Ptree.instantiate]
+    derived with [ppx_ptree]; see {!Linear} for the pattern). {!ptree}
     instantiates the model at its tensor type, a training step composes
     {!Rune.value_and_grad} with a [Vega] optimizer update, and the training
     loop is ordinary [Seq] iteration over {!Data} minibatches.
 
     {[
-    let model = Nx.Ptree.instantiate (module Model)
+    let model = Kaun.ptree (module Model)
 
     let step (params, ostate) (x, y) =
       let loss p = Loss.softmax_cross_entropy_sparse (Model.apply p x) y in
@@ -30,6 +30,19 @@
     what matters is the key the scope is rooted at, not whether a draw named
     one: root it at a key threaded through the step's inputs and the keyless
     draws inside compile, exactly as an explicit key ({!Dropout}) would. *)
+
+val ptree :
+  (module U : Nx.Ptree.Uniform) ->
+  (module Nx.Ptree.S with type t = ('a, 'b) Nx.t U.t)
+(** [ptree (module Model)] is your model's parameter tree: the walker the
+    transformations take. Bind it once per model:
+
+    {[
+      let mlp = Kaun.ptree (module Mlp) in
+      let l, grads = Rune.value_and_grad mlp loss params
+    ]}
+
+    This is [Nx.Ptree.instantiate]; see there for details. *)
 
 (** {1:layers Layers}
 

--- a/packages/kaun/lib/kaun.mli
+++ b/packages/kaun/lib/kaun.mli
@@ -5,19 +5,22 @@
 
 (** Neural networks as typed parameter records.
 
-    Kaun has no layer or trainer abstraction. A layer is a plain record of
-    tensors with an [apply] function; a model is a record of layers with
-    hand-written one-line traversals ({!Nx.Ptree.S} plus checkpoint [names], see
-    {!Linear} for the pattern); a training step composes {!Rune.value_and_grad}
-    with a [Vega] optimizer update; the training loop is ordinary [Seq]
-    iteration over {!Data} minibatches.
+    Kaun has no layer or trainer abstraction. A layer is a record of parameters
+    with a payload hole and an [apply] function; a model is a record of layers
+    with one-line traversals (the {!Nx.Ptree.Uniform} contract, hand-written or
+    derived with [ppx_ptree]; see {!Linear} for the pattern). [Nx.Ptree.typed]
+    instantiates the model at its tensor type, a training step composes
+    {!Rune.value_and_grad} with a [Vega] optimizer update, and the training
+    loop is ordinary [Seq] iteration over {!Data} minibatches.
 
     {[
+    let model = Nx.Ptree.typed (module Model)
+
     let step (params, ostate) (x, y) =
       let loss p = Loss.softmax_cross_entropy_sparse (Model.apply p x) y in
-      let l, grads = Rune.value_and_grad (module Model) loss params in
+      let l, grads = Rune.value_and_grad model loss params in
       let params, ostate =
-        Vega.adamw_step (module Model) ~lr:1e-3 ostate ~params ~grads
+        Vega.adamw_step model ~lr:1e-3 ostate ~params ~grads
       in
       ((params, ostate), Nx.item [] l)
     ]}

--- a/packages/kaun/lib/kaun.mli
+++ b/packages/kaun/lib/kaun.mli
@@ -32,7 +32,7 @@
     draws inside compile, exactly as an explicit key ({!Dropout}) would. *)
 
 val ptree :
-  (module U : Nx.Ptree.Uniform) ->
+  (module U : Nx.Ptree.Traverse) ->
   (module Nx.Ptree.S with type t = ('a, 'b) Nx.t U.t)
 (** [ptree (module Model)] is your model's parameter tree: the walker the
     transformations take. Bind it once per model:

--- a/packages/kaun/lib/layer_norm.ml
+++ b/packages/kaun/lib/layer_norm.ml
@@ -3,23 +3,25 @@
   SPDX-License-Identifier: ISC
   ---------------------------------------------------------------------------*)
 
-type 'b params = { gamma : (float, 'b) Nx.t; beta : (float, 'b) Nx.t }
-type t = Nx.float32_elt params
+type 'a t = { gamma : 'a; beta : 'a }
 
-let map (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) { gamma; beta } =
-  { gamma = f gamma; beta = f beta }
+let map f { gamma; beta } =
+  let gamma = f gamma in
+  let beta = f beta in
+  { gamma; beta }
 
-let map2 (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) p q =
-  { gamma = f p.gamma q.gamma; beta = f p.beta q.beta }
+let map2 f p q =
+  let gamma = f p.gamma q.gamma in
+  let beta = f p.beta q.beta in
+  { gamma; beta }
 
-let iter (f : 'a 'c. ('a, 'c) Nx.t -> unit) { gamma; beta } =
+let iter f { gamma; beta } =
   f gamma;
   f beta
 
-let astype dt { gamma; beta } =
-  { gamma = Nx.cast dt gamma; beta = Nx.cast dt beta }
-
-let names _ = [ "gamma"; "beta" ]
+let fold f acc { gamma; beta } = f "beta" (f "gamma" acc gamma) beta
+let fold2 f acc p q = f "beta" (f "gamma" acc p.gamma q.gamma) p.beta q.beta
+let names _ = { gamma = "gamma"; beta = "beta" }
 
 let make ~dim dtype =
   if dim <= 0 then

--- a/packages/kaun/lib/layer_norm.mli
+++ b/packages/kaun/lib/layer_norm.mli
@@ -10,33 +10,29 @@
     ([gamma]) and shift ([beta]). Unlike batch normalization it is stateless and
     independent of the batch: the same function at training and inference time.
     Construct parameters with {!init} or {!make} and normalize with {!apply};
-    {!map}, {!map2}, {!iter} and {!names} supply the {!Nx.Ptree.S} and
-    checkpoint plumbing. *)
+    the traversals supply the {!Nx.Ptree.Uniform} and checkpoint plumbing. *)
 
 (** {1:types Types} *)
 
-type 'b params = { gamma : (float, 'b) Nx.t; beta : (float, 'b) Nx.t }
-(** The type for layer-norm parameters with float dtype layout ['b]. [gamma]
-    (the scale) and [beta] (the shift) both have shape [[| dim |]], one entry
-    per normalized feature. *)
-
-type t = Nx.float32_elt params
-(** The type for single-precision layer norms, the common case. *)
+type 'a t = { gamma : 'a; beta : 'a }
+(** The type for layer-norm parameters over payload ['a]. At tensor payloads,
+    [gamma] (the scale) and [beta] (the shift) both have shape [[| dim |]], one
+    entry per normalized feature. *)
 
 (** {1:constructors Constructors} *)
 
-val make : dim:int -> (float, 'b) Nx.dtype -> 'b params
+val make : dim:int -> (float, 'b) Nx.dtype -> (float, 'b) Nx.t t
 (** [make ~dim dtype] is a fresh identity normalization over [dim] features:
     [gamma] all ones, [beta] all zeros.
 
     Raises [Invalid_argument] if [dim] is not positive. *)
 
-val init : dim:int -> t
+val init : dim:int -> Nx.float32_t t
 (** [init ~dim] is [make ~dim Nx.float32]. *)
 
 (** {1:applying Applying} *)
 
-val apply : ?eps:float -> 'b params -> (float, 'b) Nx.t -> (float, 'b) Nx.t
+val apply : ?eps:float -> (float, 'b) Nx.t t -> (float, 'b) Nx.t -> (float, 'b) Nx.t
 (** [apply p x] normalizes each vector along [x]'s last axis and rescales it:
 
     {v (x - mean(x)) / sqrt (var(x) + eps) * gamma + beta v}
@@ -57,28 +53,24 @@ val apply : ?eps:float -> 'b params -> (float, 'b) Nx.t -> (float, 'b) Nx.t
 
 (** {1:traversals Traversals}
 
-    Plain traversals over the parameter leaves, in the order [gamma] then
-    [beta]. They satisfy the {!Nx.Ptree.S} contract at any fixed ['b]. *)
+    Payload traversals in the order [gamma] then [beta], satisfying the
+    {!Nx.Ptree.Uniform} contract. Leaf paths are ["gamma"] and ["beta"]. *)
 
-val map : ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) -> 'b params -> 'b params
-(** [map f p] is [p] with [f] applied to every parameter leaf. *)
+val map : ('a -> 'b) -> 'a t -> 'b t
+(** [map f p] is [p] with [f] applied to every payload leaf. [map (Nx.cast dt)]
+    converts a layer's precision; the cast is differentiable through Rune. *)
 
-val map2 :
-  ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) ->
-  'b params ->
-  'b params ->
-  'b params
+val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 (** [map2 f p q] combines [p] and [q] leafwise with [f]. *)
 
-val iter : ('a 'c. ('a, 'c) Nx.t -> unit) -> 'b params -> unit
-(** [iter f p] applies [f] to every parameter leaf of [p]. *)
+val iter : ('a -> unit) -> 'a t -> unit
+(** [iter f p] applies [f] to every payload leaf of [p]. *)
 
-val astype : (float, 'c) Nx.dtype -> 'b params -> 'c params
-(** [astype dt p] is [p] with every parameter leaf cast to [dt]. Differentiable
-    through Rune: gradients flow back at each original leaf's dtype, so an
-    astype of float32 parameters inside a loss function yields float32
-    gradients. *)
+val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+(** [fold f acc p] reduces [p] leafwise, threading each leaf's path. *)
 
-val names : 'b params -> string list
-(** [names p] is [["gamma"; "beta"]], the checkpoint names of the parameter
-    leaves in traversal order. See {!Checkpoint.Named}. *)
+val fold2 : (string -> 'acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
+(** [fold2 f acc p q] is like {!fold} across two layers. *)
+
+val names : 'a t -> string t
+(** [names p] is [{ gamma = "gamma"; beta = "beta" }]. *)

--- a/packages/kaun/lib/linear.ml
+++ b/packages/kaun/lib/linear.ml
@@ -3,32 +3,40 @@
   SPDX-License-Identifier: ISC
   ---------------------------------------------------------------------------*)
 
-type 'b params = { w : (float, 'b) Nx.t; b : (float, 'b) Nx.t option }
-type t = Nx.float32_elt params
+type 'a t = { w : 'a; b : 'a option }
 
-let map (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) { w; b } =
-  { w = f w; b = (match b with None -> None | Some b -> Some (f b)) }
+let map f { w; b } =
+  let w = f w in
+  let b = match b with None -> None | Some b -> Some (f b) in
+  { w; b }
 
-let map2 (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) p q =
+let map2 f p q =
+  let w = f p.w q.w in
   let b =
     match (p.b, q.b) with
     | Some pb, Some qb -> Some (f pb qb)
     | None, None -> None
     | Some _, None | None, Some _ -> invalid_arg "Linear.map2: bias mismatch"
   in
-  { w = f p.w q.w; b }
+  { w; b }
 
-let iter (f : 'a 'c. ('a, 'c) Nx.t -> unit) { w; b } =
+let iter f { w; b } =
   f w;
   match b with None -> () | Some b -> f b
 
-let astype dt { w; b } =
-  {
-    w = Nx.cast dt w;
-    b = (match b with None -> None | Some b -> Some (Nx.cast dt b));
-  }
+let fold f acc { w; b } =
+  let acc = f "w" acc w in
+  match b with None -> acc | Some b -> f "b" acc b
 
-let names p = match p.b with None -> [ "w" ] | Some _ -> [ "w"; "b" ]
+let fold2 f acc p q =
+  let acc = f "w" acc p.w q.w in
+  match (p.b, q.b) with
+  | Some pb, Some qb -> f "b" acc pb qb
+  | None, None -> acc
+  | Some _, None | None, Some _ -> invalid_arg "Linear.fold2: bias mismatch"
+
+let names p =
+  { w = "w"; b = (match p.b with None -> None | Some _ -> Some "b") }
 
 let make ?(w_init = Init.glorot_uniform) ?(bias_init = Init.zeros)
     ?(bias = true) ~inputs ~outputs dtype =

--- a/packages/kaun/lib/linear.mli
+++ b/packages/kaun/lib/linear.mli
@@ -10,7 +10,7 @@
     rate; filled with strings, the checkpoint names. Construct one with {!init}
     or {!make}, transform inputs with {!apply}, and compose layers into models
     by nesting records — the traversals give any such model a one-line
-    {!Nx.Ptree.Uniform} instance, and [Nx.Ptree.typed] turns that into the
+    {!Nx.Ptree.Uniform} instance, and [Nx.Ptree.instantiate] turns that into the
     {!Nx.Ptree.S} the transformations take:
 
     {[

--- a/packages/kaun/lib/linear.mli
+++ b/packages/kaun/lib/linear.mli
@@ -10,7 +10,7 @@
     rate; filled with strings, the checkpoint names. Construct one with {!init}
     or {!make}, transform inputs with {!apply}, and compose layers into models
     by nesting records — the traversals give any such model a one-line
-    {!Nx.Ptree.Uniform} instance, and [Nx.Ptree.instantiate] turns that into the
+    {!Nx.Ptree.Uniform} instance, and [Kaun.ptree] turns that into the
     {!Nx.Ptree.S} the transformations take:
 
     {[

--- a/packages/kaun/lib/linear.mli
+++ b/packages/kaun/lib/linear.mli
@@ -5,19 +5,24 @@
 
 (** Dense (fully connected) layers.
 
-    A linear layer is a plain record of parameters: a weight matrix and an
-    optional bias. Construct one with {!init} or {!make}, transform inputs with
-    {!apply}, and compose layers into models by putting records inside records —
-    the {!map}, {!map2}, {!iter} traversals and {!names} give any such model a
-    one-line {!Nx.Ptree.S} (and checkpoint-ready) instance:
+    A linear layer is a record of parameters with a payload hole. Filled with
+    tensors it is the layer itself; filled with floats, a per-leaf learning
+    rate; filled with strings, the checkpoint names. Construct one with {!init}
+    or {!make}, transform inputs with {!apply}, and compose layers into models
+    by nesting records — the traversals give any such model a one-line
+    {!Nx.Ptree.Uniform} instance, and [Nx.Ptree.typed] turns that into the
+    {!Nx.Ptree.S} the transformations take:
 
     {[
     module Mlp = struct
-      type t = { l1 : Linear.t; l2 : Linear.t }
+      type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-      let map (f : 'a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) { l1; l2 } =
-        { l1 = Linear.map f l1; l2 = Linear.map f l2 }
-      (* map2, iter, names: same one-liners over the fields. *)
+      let map f { l1; l2 } =
+        let l1 = Linear.map f l1 in
+        let l2 = Linear.map f l2 in
+        { l1; l2 }
+      (* map2, iter, fold, fold2, names: same one-liners over the fields,
+         or [@@deriving ptree]. *)
 
       let apply p x = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
     end
@@ -25,16 +30,14 @@
 
 (** {1:types Types} *)
 
-type 'b params = { w : (float, 'b) Nx.t; b : (float, 'b) Nx.t option }
-(** The type for linear-layer parameters with float dtype layout ['b].
+type 'a t = { w : 'a; b : 'a option }
+(** The type for linear-layer parameters over payload ['a].
 
-    [w] has shape [[| inputs; outputs |]] and [b], when present, shape
-    [[| outputs |]]. [b] is [None] for layers built without a bias
-    ({!make}[ ~bias:false]); such layers have no bias parameter at all, so
-    traversals skip it and {!apply} performs no shift. *)
-
-type t = Nx.float32_elt params
-(** The type for single-precision linear layers, the common case. *)
+    At tensor payloads — [(float, 'b) Nx.t t] — [w] has shape
+    [[| inputs; outputs |]] and [b], when present, shape [[| outputs |]]. [b]
+    is [None] for layers built without a bias ({!make}[ ~bias:false]); such
+    layers have no bias parameter at all, so traversals skip it and {!apply}
+    performs no shift. *)
 
 (** {1:constructors Constructors} *)
 
@@ -45,7 +48,7 @@ val make :
   inputs:int ->
   outputs:int ->
   (float, 'b) Nx.dtype ->
-  'b params
+  (float, 'b) Nx.t t
 (** [make ~inputs ~outputs dtype] is a fresh layer mapping [inputs] features to
     [outputs] features, with:
 
@@ -60,13 +63,13 @@ val make :
 
     Raises [Invalid_argument] if [inputs] or [outputs] is not positive. *)
 
-val init : inputs:int -> outputs:int -> t
+val init : inputs:int -> outputs:int -> Nx.float32_t t
 (** [init ~inputs ~outputs] is [make ~inputs ~outputs Nx.float32]:
     Glorot-uniform weights, zero bias. *)
 
 (** {1:applying Applying} *)
 
-val apply : 'b params -> (float, 'b) Nx.t -> (float, 'b) Nx.t
+val apply : (float, 'b) Nx.t t -> (float, 'b) Nx.t -> (float, 'b) Nx.t
 (** [apply p x] is [x @ p.w + p.b] (the shift is omitted when [p.b] is [None]).
     [x]'s last axis must have size [inputs]; leading axes are treated as batch
     axes, so the result has [x]'s shape with the last axis replaced by
@@ -76,32 +79,31 @@ val apply : 'b params -> (float, 'b) Nx.t -> (float, 'b) Nx.t
 
 (** {1:traversals Traversals}
 
-    Plain traversals over the parameter leaves, in the order [w] then [b]. They
-    satisfy the {!Nx.Ptree.S} contract at any fixed ['b]. *)
+    Payload traversals in the order [w] then [b], satisfying the
+    {!Nx.Ptree.Uniform} contract. Leaf paths are ["w"] and ["b"]. *)
 
-val map : ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t) -> 'b params -> 'b params
-(** [map f p] is [p] with [f] applied to every parameter leaf. *)
+val map : ('a -> 'b) -> 'a t -> 'b t
+(** [map f p] is [p] with [f] applied to every payload leaf.
+    [map (Nx.cast dt) p] converts a layer's precision; the cast is
+    differentiable through Rune. *)
 
-val map2 :
-  ('a 'c. ('a, 'c) Nx.t -> ('a, 'c) Nx.t -> ('a, 'c) Nx.t) ->
-  'b params ->
-  'b params ->
-  'b params
+val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 (** [map2 f p q] combines [p] and [q] leafwise with [f].
 
     Raises [Invalid_argument] if one of [p] and [q] has a bias and the other
     does not. *)
 
-val iter : ('a 'c. ('a, 'c) Nx.t -> unit) -> 'b params -> unit
-(** [iter f p] applies [f] to every parameter leaf of [p]. *)
+val iter : ('a -> unit) -> 'a t -> unit
+(** [iter f p] applies [f] to every payload leaf of [p]. *)
 
-val astype : (float, 'c) Nx.dtype -> 'b params -> 'c params
-(** [astype dt p] is [p] with every parameter leaf cast to [dt]. Differentiable
-    through Rune: gradients flow back at each original leaf's dtype, so an
-    astype of float32 parameters inside a loss function yields float32
-    gradients. *)
+val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+(** [fold f acc p] reduces [p] leafwise, threading each leaf's path. *)
 
-val names : 'b params -> string list
-(** [names p] is the checkpoint name of each parameter leaf of [p], in traversal
-    order: [["w"; "b"]], or [["w"]] when [p] has no bias. See
-    {!Checkpoint.Named}. *)
+val fold2 : (string -> 'acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
+(** [fold2 f acc p q] is like {!fold} across two structurally equal layers.
+
+    Raises [Invalid_argument] if one of [p] and [q] has a bias and the other
+    does not. *)
+
+val names : 'a t -> string t
+(** [names p] is [p] with every payload replaced by its path. *)

--- a/packages/kaun/test/test_attention.ml
+++ b/packages/kaun/test/test_attention.ml
@@ -9,7 +9,7 @@ open Kaun
 (* Float64 instances for gradient checking; the traversals are dtype-generic, so
    each instance is just a type pin. *)
 
-let attention64 = Nx.Ptree.typed (module Attention)
+let attention64 = Nx.Ptree.instantiate (module Attention)
 
 (* Raw q/k/v inputs as a parameter structure, to gradient-check the attention
    core with respect to its inputs. *)

--- a/packages/kaun/test/test_attention.ml
+++ b/packages/kaun/test/test_attention.ml
@@ -32,7 +32,8 @@ let grads_ok = function Ok () -> () | Error m -> fail m
 let shape_is ?msg expected t = equal ?msg (array int) expected (Nx.shape t)
 
 let values_are ?msg ~tol expected t =
-  equal ?msg (array (float tol)) expected (Nx.to_array t)
+  let ft = if tol = 0. then float_exact else float tol in
+  equal ?msg (array ft) expected (Nx.to_array t)
 
 (* Identity projections without bias: [apply] reduces to the attention core on
    [x] itself, so layer results can be checked analytically. *)
@@ -81,7 +82,7 @@ let test_core_mask_zeroes_weights () =
     (Attention.scaled_dot_product_attention ~mask q k v)
 
 let test_core_gradients () =
-  Nx.Rng.run ~seed:1 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 1) @@ fun () ->
   let p =
     {
       Qkv64.q = Nx.randn Nx.float64 [| 3; 2 |];
@@ -96,7 +97,7 @@ let test_core_gradients () =
   grads_ok (Rune.check_grads (module Qkv64) loss p)
 
 let test_core_masked_gradients () =
-  Nx.Rng.run ~seed:2 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 2) @@ fun () ->
   let p =
     {
       Qkv64.q = Nx.randn Nx.float64 [| 2; 2 |];
@@ -113,21 +114,21 @@ let test_core_masked_gradients () =
 
 let test_core_rejects_bad_shapes () =
   let t shape = Nx.zeros Nx.float32 shape in
-  raises_invalid_arg
-    "Attention.scaled_dot_product_attention: q, k and v must have at least 2 \
-     axes" (fun () ->
+  raises
+    (Invalid_argument "Attention.scaled_dot_product_attention: q, k and v must have at least 2 \
+     axes") (fun () ->
       Attention.scaled_dot_product_attention (t [| 3 |])
         (t [| 3; 2 |])
         (t [| 3; 2 |]));
-  raises_invalid_arg
-    "Attention.scaled_dot_product_attention: q has 2 features but k has 3"
+  raises
+    (Invalid_argument "Attention.scaled_dot_product_attention: q has 2 features but k has 3")
     (fun () ->
       Attention.scaled_dot_product_attention
         (t [| 1; 2 |])
         (t [| 4; 3 |])
         (t [| 4; 2 |]));
-  raises_invalid_arg
-    "Attention.scaled_dot_product_attention: k has 2 positions but v has 3"
+  raises
+    (Invalid_argument "Attention.scaled_dot_product_attention: k has 2 positions but v has 3")
     (fun () ->
       Attention.scaled_dot_product_attention
         (t [| 1; 2 |])
@@ -137,7 +138,7 @@ let test_core_rejects_bad_shapes () =
 (* Multi-head self-attention layer *)
 
 let test_init_shapes () =
-  Nx.Rng.run ~seed:3 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 3) @@ fun () ->
   let p = Attention.init ~embed_dim:8 in
   List.iter
     (fun (name, (l : Nx.float32_t Linear.t)) ->
@@ -153,7 +154,7 @@ let test_init_shapes () =
     ]
 
 let test_names () =
-  Nx.Rng.run ~seed:4 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 4) @@ fun () ->
   let paths p =
     List.rev (Attention.fold (fun path acc _ -> path :: acc) [] p)
   in
@@ -169,7 +170,7 @@ let test_names () =
     (paths no_bias)
 
 let test_apply_shapes () =
-  Nx.Rng.run ~seed:5 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 5) @@ fun () ->
   let p = Attention.init ~embed_dim:8 in
   let batched = Nx.zeros Nx.float32 [| 2; 5; 8 |] in
   shape_is ~msg:"batched input keeps its shape" [| 2; 5; 8 |]
@@ -215,7 +216,7 @@ let test_causal_first_position_is_itself () =
     [| 1.; 2. |] (Array.sub y 0 2)
 
 let test_causal_ignores_the_future () =
-  Nx.Rng.run ~seed:6 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 6) @@ fun () ->
   let p = Attention.init ~embed_dim:8 in
   let base = Array.init 32 (fun i -> sin (float_of_int i)) in
   let changed = Array.mapi (fun i a -> if i >= 24 then a +. 10.0 else a) base in
@@ -238,7 +239,7 @@ let test_causal_ignores_the_future () =
 let test_permutation_equivariance () =
   (* Self-attention has no notion of position: permuting the sequence permutes
      the output the same way. *)
-  Nx.Rng.run ~seed:7 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 7) @@ fun () ->
   let p = Attention.init ~embed_dim:4 in
   let base = Array.init 12 (fun i -> cos (float_of_int i)) in
   let perm = [| 2; 0; 1 |] in
@@ -254,7 +255,7 @@ let test_permutation_equivariance () =
     (permute perm y) yp
 
 let test_gradients () =
-  Nx.Rng.run ~seed:8 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 8) @@ fun () ->
   let x = Nx.randn Nx.float64 [| 3; 4 |] in
   let p = Attention.make ~embed_dim:4 Nx.float64 in
   let loss ?causal p =
@@ -270,7 +271,7 @@ let pos_at i = Nx.create Nx.int32 [| 1 |] [| Int32.of_int i |]
 let flat t = Nx.to_array (Nx.reshape [| -1 |] (Nx.contiguous t))
 
 let test_cached_prefill_matches_causal () =
-  Nx.Rng.run ~seed:20 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 20) @@ fun () ->
   let p = Attention.init ~embed_dim:8 in
   let x = Nx.randn Nx.float32 [| 1; 5; 8 |] in
   let full = Attention.apply ~num_heads:2 ~causal:true p x in
@@ -281,7 +282,7 @@ let test_cached_prefill_matches_causal () =
     (flat full) (flat y)
 
 let test_cached_decode_matches_causal () =
-  Nx.Rng.run ~seed:21 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 21) @@ fun () ->
   let p = Attention.init ~embed_dim:8 in
   let x = Nx.randn Nx.float32 [| 1; 5; 8 |] in
   let full = Attention.apply ~num_heads:2 ~causal:true p x in
@@ -307,7 +308,7 @@ let test_cached_decode_matches_causal () =
     (flat full) (flat y)
 
 let test_cached_update_is_functional () =
-  Nx.Rng.run ~seed:22 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 22) @@ fun () ->
   let p = Attention.init ~embed_dim:4 in
   let x = Nx.randn Nx.float32 [| 1; 2; 4 |] in
   let cache = Attention.Cache.make ~num_heads:2 ~head_dim:2 ~len:4 Nx.float32 in
@@ -315,7 +316,7 @@ let test_cached_update_is_functional () =
     Attention.apply_cached ~num_heads:2 ~pos:(pos_at 0) ~cache p x
   in
   equal ~msg:"argument cache still empty"
-    (array (float 0.0))
+    (array float_exact)
     (Array.make 16 0.0)
     (flat cache.Attention.Cache.keys);
   is_true ~msg:"returned cache holds the written keys"
@@ -324,7 +325,7 @@ let test_cached_update_is_functional () =
        (flat cache'.Attention.Cache.keys))
 
 let test_cached_write_past_len_is_dropped () =
-  Nx.Rng.run ~seed:23 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 23) @@ fun () ->
   let p = Attention.init ~embed_dim:4 in
   let x = Nx.randn Nx.float32 [| 1; 2; 4 |] in
   let cache = Attention.Cache.make ~num_heads:2 ~head_dim:2 ~len:2 Nx.float32 in
@@ -336,7 +337,7 @@ let test_cached_write_past_len_is_dropped () =
       (Nx.slice [ A; R (0, 1) ] x)
   in
   equal ~msg:"a write at pos = len leaves the cache unchanged"
-    (array (float 0.0))
+    (array float_exact)
     (flat cache.Attention.Cache.keys)
     (flat cache'.Attention.Cache.keys)
 
@@ -369,7 +370,7 @@ module Step = struct
 end
 
 let test_cached_step_jits_once () =
-  Nx.Rng.run ~seed:24 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 24) @@ fun () ->
   let p = Attention.init ~embed_dim:8 in
   let x = Nx.randn Nx.float32 [| 1; 4; 8 |] in
   let decode step_fn =
@@ -404,7 +405,7 @@ let test_cached_step_jits_once () =
   equal ~msg:"all four steps share one trace" int 1 !traces
 
 let test_cached_gradients () =
-  Nx.Rng.run ~seed:25 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 25) @@ fun () ->
   let x = Nx.randn Nx.float64 [| 1; 3; 4 |] in
   let p = Attention.make ~embed_dim:4 Nx.float64 in
   let loss p =
@@ -423,45 +424,45 @@ let test_cached_gradients () =
   grads_ok (Rune.check_grads attention64 loss p)
 
 let test_cached_rejects_bad_geometry () =
-  Nx.Rng.run ~seed:26 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 26) @@ fun () ->
   let p = Attention.init ~embed_dim:4 in
   let cache = Attention.Cache.make ~num_heads:2 ~head_dim:2 ~len:4 Nx.float32 in
   let apply ?(pos = pos_at 0) x =
     Attention.apply_cached ~num_heads:2 ~pos ~cache p x
   in
-  raises_invalid_arg
-    "Attention.Cache.make: batch, num_heads, head_dim and len must be \
-     positive, got batch=1 num_heads=2 head_dim=2 len=0" (fun () ->
+  raises
+    (Invalid_argument "Attention.Cache.make: batch, num_heads, head_dim and len must be \
+     positive, got batch=1 num_heads=2 head_dim=2 len=0") (fun () ->
       Attention.Cache.make ~num_heads:2 ~head_dim:2 ~len:0 Nx.float32);
-  raises_invalid_arg
-    "Attention.apply_cached: input must have shape [batch; seq; embed]"
+  raises
+    (Invalid_argument "Attention.apply_cached: input must have shape [batch; seq; embed]")
     (fun () -> apply (Nx.zeros Nx.float32 [| 2; 4 |]));
-  raises_invalid_arg
-    "Attention.apply_cached: cache has shape [1; 2; _; 2] but the input needs \
-     [2; 2; _; 2]" (fun () -> apply (Nx.zeros Nx.float32 [| 2; 1; 4 |]));
-  raises_invalid_arg "Attention.apply_cached: seq 5 exceeds the cache length 4"
+  raises
+    (Invalid_argument "Attention.apply_cached: cache has shape [1; 2; _; 2] but the input needs \
+     [2; 2; _; 2]") (fun () -> apply (Nx.zeros Nx.float32 [| 2; 1; 4 |]));
+  raises (Invalid_argument "Attention.apply_cached: seq 5 exceeds the cache length 4")
     (fun () -> apply (Nx.zeros Nx.float32 [| 1; 5; 4 |]));
-  raises_invalid_arg "Attention.apply_cached: pos must have a single element"
+  raises (Invalid_argument "Attention.apply_cached: pos must have a single element")
     (fun () ->
       apply
         ~pos:(Nx.create Nx.int32 [| 2 |] [| 0l; 1l |])
         (Nx.zeros Nx.float32 [| 1; 1; 4 |]))
 
 let test_rejects_bad_geometry () =
-  Nx.Rng.run ~seed:9 @@ fun () ->
-  raises_invalid_arg "Attention.make: embed_dim must be positive, got 0"
+  Nx.Rng.with_key (Nx.Rng.key 9) @@ fun () ->
+  raises (Invalid_argument "Attention.make: embed_dim must be positive, got 0")
     (fun () -> Attention.make ~embed_dim:0 Nx.float32);
   let p = Attention.init ~embed_dim:4 in
-  raises_invalid_arg
-    "Attention.apply: input must have at least sequence and feature axes"
+  raises
+    (Invalid_argument "Attention.apply: input must have at least sequence and feature axes")
     (fun () -> Attention.apply p (Nx.zeros Nx.float32 [| 4 |]));
-  raises_invalid_arg
-    "Attention.apply: last axis has size 3 but the layer attends over 4 \
-     features" (fun () -> Attention.apply p (Nx.zeros Nx.float32 [| 2; 3 |]));
-  raises_invalid_arg "Attention.apply: num_heads must be positive, got 0"
+  raises
+    (Invalid_argument "Attention.apply: last axis has size 3 but the layer attends over 4 \
+     features") (fun () -> Attention.apply p (Nx.zeros Nx.float32 [| 2; 3 |]));
+  raises (Invalid_argument "Attention.apply: num_heads must be positive, got 0")
     (fun () -> Attention.apply ~num_heads:0 p (Nx.zeros Nx.float32 [| 2; 4 |]));
-  raises_invalid_arg
-    "Attention.apply: num_heads (3) must divide the embedding dimension (4)"
+  raises
+    (Invalid_argument "Attention.apply: num_heads (3) must divide the embedding dimension (4)")
     (fun () -> Attention.apply ~num_heads:3 p (Nx.zeros Nx.float32 [| 2; 4 |]))
 
 let () =

--- a/packages/kaun/test/test_attention.ml
+++ b/packages/kaun/test/test_attention.ml
@@ -9,7 +9,7 @@ open Kaun
 (* Float64 instances for gradient checking; the traversals are dtype-generic, so
    each instance is just a type pin. *)
 
-let attention64 = Nx.Ptree.instantiate (module Attention)
+let attention64 = Kaun.ptree (module Attention)
 
 (* Raw q/k/v inputs as a parameter structure, to gradient-check the attention
    core with respect to its inputs. *)

--- a/packages/kaun/test/test_attention.ml
+++ b/packages/kaun/test/test_attention.ml
@@ -9,13 +9,7 @@ open Kaun
 (* Float64 instances for gradient checking; the traversals are dtype-generic, so
    each instance is just a type pin. *)
 
-module Attention64 = struct
-  type t = Nx.float64_elt Attention.params
-
-  let map = Attention.map
-  let map2 = Attention.map2
-  let iter = Attention.iter
-end
+let attention64 = Nx.Ptree.typed (module Attention)
 
 (* Raw q/k/v inputs as a parameter structure, to gradient-check the attention
    core with respect to its inputs. *)
@@ -38,8 +32,7 @@ let grads_ok = function Ok () -> () | Error m -> fail m
 let shape_is ?msg expected t = equal ?msg (array int) expected (Nx.shape t)
 
 let values_are ?msg ~tol expected t =
-  let ft = if tol = 0. then float_exact else float tol in
-  equal ?msg (array ft) expected (Nx.to_array t)
+  equal ?msg (array (float tol)) expected (Nx.to_array t)
 
 (* Identity projections without bias: [apply] reduces to the attention core on
    [x] itself, so layer results can be checked analytically. *)
@@ -88,7 +81,7 @@ let test_core_mask_zeroes_weights () =
     (Attention.scaled_dot_product_attention ~mask q k v)
 
 let test_core_gradients () =
-  Nx.Rng.with_key (Nx.Rng.key 1) @@ fun () ->
+  Nx.Rng.run ~seed:1 @@ fun () ->
   let p =
     {
       Qkv64.q = Nx.randn Nx.float64 [| 3; 2 |];
@@ -103,7 +96,7 @@ let test_core_gradients () =
   grads_ok (Rune.check_grads (module Qkv64) loss p)
 
 let test_core_masked_gradients () =
-  Nx.Rng.with_key (Nx.Rng.key 2) @@ fun () ->
+  Nx.Rng.run ~seed:2 @@ fun () ->
   let p =
     {
       Qkv64.q = Nx.randn Nx.float64 [| 2; 2 |];
@@ -120,24 +113,21 @@ let test_core_masked_gradients () =
 
 let test_core_rejects_bad_shapes () =
   let t shape = Nx.zeros Nx.float32 shape in
-  raises
-    (Invalid_argument
-       "Attention.scaled_dot_product_attention: q, k and v must have at least \
-        2 axes") (fun () ->
+  raises_invalid_arg
+    "Attention.scaled_dot_product_attention: q, k and v must have at least 2 \
+     axes" (fun () ->
       Attention.scaled_dot_product_attention (t [| 3 |])
         (t [| 3; 2 |])
         (t [| 3; 2 |]));
-  raises
-    (Invalid_argument
-       "Attention.scaled_dot_product_attention: q has 2 features but k has 3")
+  raises_invalid_arg
+    "Attention.scaled_dot_product_attention: q has 2 features but k has 3"
     (fun () ->
       Attention.scaled_dot_product_attention
         (t [| 1; 2 |])
         (t [| 4; 3 |])
         (t [| 4; 2 |]));
-  raises
-    (Invalid_argument
-       "Attention.scaled_dot_product_attention: k has 2 positions but v has 3")
+  raises_invalid_arg
+    "Attention.scaled_dot_product_attention: k has 2 positions but v has 3"
     (fun () ->
       Attention.scaled_dot_product_attention
         (t [| 1; 2 |])
@@ -147,10 +137,10 @@ let test_core_rejects_bad_shapes () =
 (* Multi-head self-attention layer *)
 
 let test_init_shapes () =
-  Nx.Rng.with_key (Nx.Rng.key 3) @@ fun () ->
+  Nx.Rng.run ~seed:3 @@ fun () ->
   let p = Attention.init ~embed_dim:8 in
   List.iter
-    (fun (name, (l : Linear.t)) ->
+    (fun (name, (l : Nx.float32_t Linear.t)) ->
       shape_is ~msg:(name ^ ".w shape") [| 8; 8 |] l.Linear.w;
       match l.Linear.b with
       | None -> fail (name ^ " should have a bias")
@@ -163,18 +153,23 @@ let test_init_shapes () =
     ]
 
 let test_names () =
-  Nx.Rng.with_key (Nx.Rng.key 4) @@ fun () ->
+  Nx.Rng.run ~seed:4 @@ fun () ->
+  let paths p =
+    List.rev (Attention.fold (fun path acc _ -> path :: acc) [] p)
+  in
   let p = Attention.init ~embed_dim:4 in
   equal ~msg:"with biases" (list string)
     [ "q.w"; "q.b"; "k.w"; "k.b"; "v.w"; "v.b"; "out.w"; "out.b" ]
-    (Attention.names p);
+    (paths p);
+  equal ~msg:"names agree with fold" (option string) (Some "q.b")
+    (Attention.names p).Attention.q.Linear.b;
   let no_bias = Attention.make ~bias:false ~embed_dim:4 Nx.float32 in
   equal ~msg:"without biases" (list string)
     [ "q.w"; "k.w"; "v.w"; "out.w" ]
-    (Attention.names no_bias)
+    (paths no_bias)
 
 let test_apply_shapes () =
-  Nx.Rng.with_key (Nx.Rng.key 5) @@ fun () ->
+  Nx.Rng.run ~seed:5 @@ fun () ->
   let p = Attention.init ~embed_dim:8 in
   let batched = Nx.zeros Nx.float32 [| 2; 5; 8 |] in
   shape_is ~msg:"batched input keeps its shape" [| 2; 5; 8 |]
@@ -220,7 +215,7 @@ let test_causal_first_position_is_itself () =
     [| 1.; 2. |] (Array.sub y 0 2)
 
 let test_causal_ignores_the_future () =
-  Nx.Rng.with_key (Nx.Rng.key 6) @@ fun () ->
+  Nx.Rng.run ~seed:6 @@ fun () ->
   let p = Attention.init ~embed_dim:8 in
   let base = Array.init 32 (fun i -> sin (float_of_int i)) in
   let changed = Array.mapi (fun i a -> if i >= 24 then a +. 10.0 else a) base in
@@ -243,7 +238,7 @@ let test_causal_ignores_the_future () =
 let test_permutation_equivariance () =
   (* Self-attention has no notion of position: permuting the sequence permutes
      the output the same way. *)
-  Nx.Rng.with_key (Nx.Rng.key 7) @@ fun () ->
+  Nx.Rng.run ~seed:7 @@ fun () ->
   let p = Attention.init ~embed_dim:4 in
   let base = Array.init 12 (fun i -> cos (float_of_int i)) in
   let perm = [| 2; 0; 1 |] in
@@ -259,15 +254,15 @@ let test_permutation_equivariance () =
     (permute perm y) yp
 
 let test_gradients () =
-  Nx.Rng.with_key (Nx.Rng.key 8) @@ fun () ->
+  Nx.Rng.run ~seed:8 @@ fun () ->
   let x = Nx.randn Nx.float64 [| 3; 4 |] in
   let p = Attention.make ~embed_dim:4 Nx.float64 in
   let loss ?causal p =
     let y = Attention.apply ~num_heads:2 ?causal p x in
     Nx.sum (Nx.mul y y)
   in
-  grads_ok (Rune.check_grads (module Attention64) (loss ?causal:None) p);
-  grads_ok (Rune.check_grads (module Attention64) (loss ~causal:true) p)
+  grads_ok (Rune.check_grads attention64 (loss ?causal:None) p);
+  grads_ok (Rune.check_grads attention64 (loss ~causal:true) p)
 
 (* Key-value cache decoding *)
 
@@ -275,7 +270,7 @@ let pos_at i = Nx.create Nx.int32 [| 1 |] [| Int32.of_int i |]
 let flat t = Nx.to_array (Nx.reshape [| -1 |] (Nx.contiguous t))
 
 let test_cached_prefill_matches_causal () =
-  Nx.Rng.with_key (Nx.Rng.key 20) @@ fun () ->
+  Nx.Rng.run ~seed:20 @@ fun () ->
   let p = Attention.init ~embed_dim:8 in
   let x = Nx.randn Nx.float32 [| 1; 5; 8 |] in
   let full = Attention.apply ~num_heads:2 ~causal:true p x in
@@ -286,7 +281,7 @@ let test_cached_prefill_matches_causal () =
     (flat full) (flat y)
 
 let test_cached_decode_matches_causal () =
-  Nx.Rng.with_key (Nx.Rng.key 21) @@ fun () ->
+  Nx.Rng.run ~seed:21 @@ fun () ->
   let p = Attention.init ~embed_dim:8 in
   let x = Nx.randn Nx.float32 [| 1; 5; 8 |] in
   let full = Attention.apply ~num_heads:2 ~causal:true p x in
@@ -312,7 +307,7 @@ let test_cached_decode_matches_causal () =
     (flat full) (flat y)
 
 let test_cached_update_is_functional () =
-  Nx.Rng.with_key (Nx.Rng.key 22) @@ fun () ->
+  Nx.Rng.run ~seed:22 @@ fun () ->
   let p = Attention.init ~embed_dim:4 in
   let x = Nx.randn Nx.float32 [| 1; 2; 4 |] in
   let cache = Attention.Cache.make ~num_heads:2 ~head_dim:2 ~len:4 Nx.float32 in
@@ -320,7 +315,7 @@ let test_cached_update_is_functional () =
     Attention.apply_cached ~num_heads:2 ~pos:(pos_at 0) ~cache p x
   in
   equal ~msg:"argument cache still empty"
-    (array float_exact)
+    (array (float 0.0))
     (Array.make 16 0.0)
     (flat cache.Attention.Cache.keys);
   is_true ~msg:"returned cache holds the written keys"
@@ -329,7 +324,7 @@ let test_cached_update_is_functional () =
        (flat cache'.Attention.Cache.keys))
 
 let test_cached_write_past_len_is_dropped () =
-  Nx.Rng.with_key (Nx.Rng.key 23) @@ fun () ->
+  Nx.Rng.run ~seed:23 @@ fun () ->
   let p = Attention.init ~embed_dim:4 in
   let x = Nx.randn Nx.float32 [| 1; 2; 4 |] in
   let cache = Attention.Cache.make ~num_heads:2 ~head_dim:2 ~len:2 Nx.float32 in
@@ -341,7 +336,7 @@ let test_cached_write_past_len_is_dropped () =
       (Nx.slice [ A; R (0, 1) ] x)
   in
   equal ~msg:"a write at pos = len leaves the cache unchanged"
-    (array float_exact)
+    (array (float 0.0))
     (flat cache.Attention.Cache.keys)
     (flat cache'.Attention.Cache.keys)
 
@@ -351,7 +346,7 @@ let test_cached_write_past_len_is_dropped () =
 type step = {
   pos : Nx.int32_t;
   x : Nx.float32_t;
-  cache : Nx.float32_elt Attention.Cache.t;
+  cache : Nx.float32_t Attention.Cache.t;
 }
 
 module Step = struct
@@ -374,7 +369,7 @@ module Step = struct
 end
 
 let test_cached_step_jits_once () =
-  Nx.Rng.with_key (Nx.Rng.key 24) @@ fun () ->
+  Nx.Rng.run ~seed:24 @@ fun () ->
   let p = Attention.init ~embed_dim:8 in
   let x = Nx.randn Nx.float32 [| 1; 4; 8 |] in
   let decode step_fn =
@@ -391,9 +386,9 @@ let test_cached_step_jits_once () =
     in
     Nx.concatenate ~axis:1 (List.rev ys)
   in
-  (* [Rune.jit2] runs the traced function itself only when it (re)traces, so the
-     counter observes compilations: every step has the same signature and must
-     replay the single trace. *)
+  (* [Rune.jit2] runs the traced function itself only when it (re)traces, so
+     the counter observes compilations: every step has the same signature and
+     must replay the single trace. *)
   let traces = ref 0 in
   let step { pos; x; cache } =
     incr traces;
@@ -409,14 +404,12 @@ let test_cached_step_jits_once () =
   equal ~msg:"all four steps share one trace" int 1 !traces
 
 let test_cached_gradients () =
-  Nx.Rng.with_key (Nx.Rng.key 25) @@ fun () ->
+  Nx.Rng.run ~seed:25 @@ fun () ->
   let x = Nx.randn Nx.float64 [| 1; 3; 4 |] in
   let p = Attention.make ~embed_dim:4 Nx.float64 in
   let loss p =
     (* Gradients must flow through the cache from prefill into the step. *)
-    let cache =
-      Attention.Cache.make ~num_heads:2 ~head_dim:2 ~len:3 Nx.float64
-    in
+    let cache = Attention.Cache.make ~num_heads:2 ~head_dim:2 ~len:3 Nx.float64 in
     let y1, cache =
       Attention.apply_cached ~num_heads:2 ~pos:(pos_at 0) ~cache p
         (Nx.slice [ A; R (0, 2) ] x)
@@ -427,58 +420,48 @@ let test_cached_gradients () =
     in
     Nx.add (Nx.sum (Nx.mul y1 y1)) (Nx.sum (Nx.mul y2 y2))
   in
-  grads_ok (Rune.check_grads (module Attention64) loss p)
+  grads_ok (Rune.check_grads attention64 loss p)
 
 let test_cached_rejects_bad_geometry () =
-  Nx.Rng.with_key (Nx.Rng.key 26) @@ fun () ->
+  Nx.Rng.run ~seed:26 @@ fun () ->
   let p = Attention.init ~embed_dim:4 in
   let cache = Attention.Cache.make ~num_heads:2 ~head_dim:2 ~len:4 Nx.float32 in
   let apply ?(pos = pos_at 0) x =
     Attention.apply_cached ~num_heads:2 ~pos ~cache p x
   in
-  raises
-    (Invalid_argument
-       "Attention.Cache.make: batch, num_heads, head_dim and len must be \
-        positive, got batch=1 num_heads=2 head_dim=2 len=0") (fun () ->
+  raises_invalid_arg
+    "Attention.Cache.make: batch, num_heads, head_dim and len must be \
+     positive, got batch=1 num_heads=2 head_dim=2 len=0" (fun () ->
       Attention.Cache.make ~num_heads:2 ~head_dim:2 ~len:0 Nx.float32);
-  raises
-    (Invalid_argument
-       "Attention.apply_cached: input must have shape [batch; seq; embed]")
+  raises_invalid_arg
+    "Attention.apply_cached: input must have shape [batch; seq; embed]"
     (fun () -> apply (Nx.zeros Nx.float32 [| 2; 4 |]));
-  raises
-    (Invalid_argument
-       "Attention.apply_cached: cache has shape [1; 2; _; 2] but the input \
-        needs [2; 2; _; 2]") (fun () ->
-      apply (Nx.zeros Nx.float32 [| 2; 1; 4 |]));
-  raises
-    (Invalid_argument "Attention.apply_cached: seq 5 exceeds the cache length 4")
+  raises_invalid_arg
+    "Attention.apply_cached: cache has shape [1; 2; _; 2] but the input needs \
+     [2; 2; _; 2]" (fun () -> apply (Nx.zeros Nx.float32 [| 2; 1; 4 |]));
+  raises_invalid_arg "Attention.apply_cached: seq 5 exceeds the cache length 4"
     (fun () -> apply (Nx.zeros Nx.float32 [| 1; 5; 4 |]));
-  raises
-    (Invalid_argument "Attention.apply_cached: pos must have a single element")
+  raises_invalid_arg "Attention.apply_cached: pos must have a single element"
     (fun () ->
       apply
         ~pos:(Nx.create Nx.int32 [| 2 |] [| 0l; 1l |])
         (Nx.zeros Nx.float32 [| 1; 1; 4 |]))
 
 let test_rejects_bad_geometry () =
-  Nx.Rng.with_key (Nx.Rng.key 9) @@ fun () ->
-  raises (Invalid_argument "Attention.make: embed_dim must be positive, got 0")
+  Nx.Rng.run ~seed:9 @@ fun () ->
+  raises_invalid_arg "Attention.make: embed_dim must be positive, got 0"
     (fun () -> Attention.make ~embed_dim:0 Nx.float32);
   let p = Attention.init ~embed_dim:4 in
-  raises
-    (Invalid_argument
-       "Attention.apply: input must have at least sequence and feature axes")
+  raises_invalid_arg
+    "Attention.apply: input must have at least sequence and feature axes"
     (fun () -> Attention.apply p (Nx.zeros Nx.float32 [| 4 |]));
-  raises
-    (Invalid_argument
-       "Attention.apply: last axis has size 3 but the layer attends over 4 \
-        features") (fun () ->
-      Attention.apply p (Nx.zeros Nx.float32 [| 2; 3 |]));
-  raises (Invalid_argument "Attention.apply: num_heads must be positive, got 0")
+  raises_invalid_arg
+    "Attention.apply: last axis has size 3 but the layer attends over 4 \
+     features" (fun () -> Attention.apply p (Nx.zeros Nx.float32 [| 2; 3 |]));
+  raises_invalid_arg "Attention.apply: num_heads must be positive, got 0"
     (fun () -> Attention.apply ~num_heads:0 p (Nx.zeros Nx.float32 [| 2; 4 |]));
-  raises
-    (Invalid_argument
-       "Attention.apply: num_heads (3) must divide the embedding dimension (4)")
+  raises_invalid_arg
+    "Attention.apply: num_heads (3) must divide the embedding dimension (4)"
     (fun () -> Attention.apply ~num_heads:3 p (Nx.zeros Nx.float32 [| 2; 4 |]))
 
 let () =

--- a/packages/kaun/test/test_checkpoint.ml
+++ b/packages/kaun/test/test_checkpoint.ml
@@ -100,7 +100,7 @@ module Lin = struct
   let names _ = { lw = "w"; lb = "b" }
 end
 
-let lin = Nx.Ptree.typed (module Lin)
+let lin = Nx.Ptree.instantiate (module Lin)
 
 (* Round-trip *)
 

--- a/packages/kaun/test/test_checkpoint.ml
+++ b/packages/kaun/test/test_checkpoint.ml
@@ -14,7 +14,7 @@ let to_arr t = Nx.to_array (Nx.reshape [| -1 |] (Nx.contiguous t))
 
 (* Checkpoints round-trip bit-exactly, so comparisons are exact. *)
 let check_arr ~msg expected actual =
-  equal ~msg (array float_exact) expected (to_arr actual)
+  equal ~msg (array (float 0.0)) expected (to_arr actual)
 
 (* Runs [f] with a fresh checkpoint file path in a temporary directory, removed
    afterwards even on failure. *)
@@ -28,70 +28,94 @@ let with_ckpt_file f =
       Sys.rmdir dir)
     (fun () -> f (Filename.concat dir "ckpt.safetensors"))
 
-(* A typed parameter record with mixed dtypes. *)
-
-type params = { w : Nx.float32_t; b : Nx.float32_t; scale : Nx.float64_t }
+(* A parameter record with mixed leaf dtypes, held at packed payloads. *)
 
 module Params = struct
-  type t = params
+  type 'a t = { w : 'a; b : 'a; scale : 'a }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { w; b; scale } =
-    { w = f w; b = f b; scale = f scale }
+  let map f { w; b; scale } =
+    let w = f w in
+    let b = f b in
+    let scale = f scale in
+    { w; b; scale }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
-    { w = f p.w q.w; b = f p.b q.b; scale = f p.scale q.scale }
+  let map2 f p q =
+    let w = f p.w q.w in
+    let b = f p.b q.b in
+    let scale = f p.scale q.scale in
+    { w; b; scale }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { w; b; scale } =
+  let iter f { w; b; scale } =
     f w;
     f b;
     f scale
 
-  let names _ = [ "w"; "b"; "scale" ]
+  let fold f acc { w; b; scale } = f "scale" (f "b" (f "w" acc w) b) scale
+
+  let fold2 f acc p q =
+    f "scale" (f "b" (f "w" acc p.w q.w) p.b q.b) p.scale q.scale
+
+  let names _ = { w = "w"; b = "b"; scale = "scale" }
 end
+
+let pack x = Rune.Ptree.P x
 
 let params () =
   {
-    w = vec32 [| 1.5; -2.0; 3.25 |];
-    b = vec32 [| 0.5 |];
-    scale = vec64 [| 2.0 |];
+    Params.w = pack (vec32 [| 1.5; -2.0; 3.25 |]);
+    b = pack (vec32 [| 0.5 |]);
+    scale = pack (vec64 [| 2.0 |]);
   }
 
-let fresh_params () = Params.map (fun leaf -> Nx.zeros_like leaf) (params ())
+let fresh_params () =
+  Params.map
+    (fun (Rune.Ptree.P leaf) -> Rune.Ptree.P (Nx.zeros_like leaf))
+    (params ())
 
-(* A float32 linear model, for the training stories. *)
+let unpack32 p = Rune.Ptree.unpack f32 p
+let unpack64 p = Rune.Ptree.unpack f64 p
 
-type lin = { lw : Nx.float32_t; lb : Nx.float32_t }
+(* A float32 linear model, for the training stories. Its leaf paths keep the
+   file names [w] and [b] whatever the record's field names. *)
 
 module Lin = struct
-  type t = lin
+  type 'a t = { lw : 'a; lb : 'a }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { lw; lb } =
-    { lw = f lw; lb = f lb }
+  let map f { lw; lb } =
+    let lw = f lw in
+    let lb = f lb in
+    { lw; lb }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
-    { lw = f p.lw q.lw; lb = f p.lb q.lb }
+  let map2 f p q =
+    let lw = f p.lw q.lw in
+    let lb = f p.lb q.lb in
+    { lw; lb }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { lw; lb } =
+  let iter f { lw; lb } =
     f lw;
     f lb
 
-  let names _ = [ "w"; "b" ]
+  let fold f acc { lw; lb } = f "b" (f "w" acc lw) lb
+  let fold2 f acc p q = f "b" (f "w" acc p.lw q.lw) p.lb q.lb
+  let names _ = { lw = "w"; lb = "b" }
 end
+
+let lin = Nx.Ptree.typed (module Lin)
 
 (* Round-trip *)
 
 let test_round_trip () =
   with_ckpt_file @@ fun path ->
-  Checkpoint.save path (Checkpoint.of_params (module Params) (params ()));
+  Checkpoint.save path (Checkpoint.of_packed (module Params) (params ()));
   let ckpt = Checkpoint.load path in
-  let p = Checkpoint.to_params (module Params) ~like:(fresh_params ()) ckpt in
-  check_arr ~msg:"w" [| 1.5; -2.0; 3.25 |] p.w;
-  check_arr ~msg:"b" [| 0.5 |] p.b;
-  check_arr ~msg:"scale" [| 2.0 |] p.scale
+  let p = Checkpoint.to_packed (module Params) ~like:(fresh_params ()) ckpt in
+  check_arr ~msg:"w" [| 1.5; -2.0; 3.25 |] (unpack32 p.Params.w);
+  check_arr ~msg:"b" [| 0.5 |] (unpack32 p.Params.b);
+  check_arr ~msg:"scale" [| 2.0 |] (unpack64 p.Params.scale)
 
 let test_round_trip_dtypes () =
   with_ckpt_file @@ fun path ->
-  Checkpoint.save path (Checkpoint.of_params (module Params) (params ()));
+  Checkpoint.save path (Checkpoint.of_packed (module Params) (params ()));
   let ckpt = Checkpoint.load path in
   let dtype_of name =
     match Checkpoint.get name ckpt with
@@ -100,7 +124,7 @@ let test_round_trip_dtypes () =
   equal ~msg:"w" string "float32" (dtype_of "w");
   equal ~msg:"scale" string "float64" (dtype_of "scale");
   (* Strict (no-cast) extraction succeeds, so dtypes survived the file. *)
-  let _ = Checkpoint.to_params (module Params) ~like:(fresh_params ()) ckpt in
+  let _ = Checkpoint.to_packed (module Params) ~like:(fresh_params ()) ckpt in
   ()
 
 let test_int_round_trip () =
@@ -113,13 +137,13 @@ let test_int_round_trip () =
 let xs = Nx.create f32 [| 4; 2 |] [| 0.0; 1.0; 1.0; 0.0; 1.0; 1.0; 0.5; -0.5 |]
 let ys = Nx.create f32 [| 4; 1 |] [| 1.0; -1.0; 0.5; 2.0 |]
 
-let loss (p : lin) =
-  let d = Nx.sub (Nx.add (Nx.matmul xs p.lw) p.lb) ys in
+let loss (p : Nx.float32_t Lin.t) =
+  let d = Nx.sub (Nx.add (Nx.matmul xs p.Lin.lw) p.Lin.lb) ys in
   Nx.mean (Nx.mul d d)
 
 let adam_train_step (p, st) =
-  let grads = Rune.grad (module Lin) loss p in
-  Vega.adam_step (module Lin) ~lr:0.05 st ~params:p ~grads
+  let grads = Rune.grad lin loss p in
+  Vega.adam_step lin ~lr:0.05 st ~params:p ~grads
 
 let rec train_adam_steps n s =
   if n = 0 then s else train_adam_steps (n - 1) (adam_train_step s)
@@ -127,9 +151,9 @@ let rec train_adam_steps n s =
 let test_resume_training () =
   with_ckpt_file @@ fun path ->
   let p0 =
-    { lw = Nx.create f32 [| 2; 1 |] [| 0.2; -0.1 |]; lb = vec32 [| 0.0 |] }
+    { Lin.lw = Nx.create f32 [| 2; 1 |] [| 0.2; -0.1 |]; lb = vec32 [| 0.0 |] }
   in
-  let p3, st3 = train_adam_steps 3 (p0, Vega.adam_init (module Lin) p0) in
+  let p3, st3 = train_adam_steps 3 (p0, Vega.adam_init lin p0) in
   Checkpoint.save path
     (Checkpoint.concat
        [
@@ -141,7 +165,7 @@ let test_resume_training () =
   let expected, _ = train_adam_steps 2 (p3, st3) in
   (* Restore into freshly initialized values and continue training. *)
   let ckpt = Checkpoint.load path in
-  let like = Vega.adam_init (module Lin) p0 in
+  let like = Vega.adam_init lin p0 in
   let p3' = Checkpoint.to_params (module Lin) ~prefix:"model" ~like:p0 ckpt in
   let st3' =
     {
@@ -157,17 +181,17 @@ let test_resume_training () =
     }
   in
   let resumed, _ = train_adam_steps 2 (p3', st3') in
-  check_arr ~msg:"w" (to_arr expected.lw) resumed.lw;
-  check_arr ~msg:"b" (to_arr expected.lb) resumed.lb;
+  check_arr ~msg:"w" (to_arr expected.Lin.lw) resumed.Lin.lw;
+  check_arr ~msg:"b" (to_arr expected.Lin.lb) resumed.Lin.lb;
   (* Control: dropping the optimizer state changes the trajectory, so the
      assertions above genuinely depend on restoring it. *)
-  let fresh, _ = train_adam_steps 2 (p3', Vega.adam_init (module Lin) p3') in
+  let fresh, _ = train_adam_steps 2 (p3', Vega.adam_init lin p3') in
   is_false ~msg:"fresh optimizer state diverges"
-    (to_arr fresh.lw = to_arr expected.lw)
+    (to_arr fresh.Lin.lw = to_arr expected.Lin.lw)
 
 let sgd_train_step (p, st) =
-  let grads = Rune.grad (module Lin) loss p in
-  Vega.sgd_step (module Lin) ~lr:0.05 ~momentum:0.9 st ~params:p ~grads
+  let grads = Rune.grad lin loss p in
+  Vega.sgd_step lin ~lr:0.05 ~momentum:0.9 st ~params:p ~grads
 
 let rec train_sgd_steps n s =
   if n = 0 then s else train_sgd_steps (n - 1) (sgd_train_step s)
@@ -175,9 +199,9 @@ let rec train_sgd_steps n s =
 let test_resume_sgd_momentum () =
   with_ckpt_file @@ fun path ->
   let p0 =
-    { lw = Nx.create f32 [| 2; 1 |] [| 0.2; -0.1 |]; lb = vec32 [| 0.0 |] }
+    { Lin.lw = Nx.create f32 [| 2; 1 |] [| 0.2; -0.1 |]; lb = vec32 [| 0.0 |] }
   in
-  let p3, st3 = train_sgd_steps 3 (p0, Vega.sgd_init (module Lin) p0) in
+  let p3, st3 = train_sgd_steps 3 (p0, Vega.sgd_init lin p0) in
   Checkpoint.save path
     (Checkpoint.concat
        [
@@ -189,7 +213,7 @@ let test_resume_sgd_momentum () =
   let expected, _ = train_sgd_steps 2 (p3, st3) in
   let ckpt = Checkpoint.load path in
   let p3' = Checkpoint.to_params (module Lin) ~prefix:"model" ~like:p0 ckpt in
-  let like = Vega.sgd_init (module Lin) p0 in
+  let like = Vega.sgd_init lin p0 in
   let st3' =
     {
       Vega.velocity =
@@ -199,10 +223,11 @@ let test_resume_sgd_momentum () =
     }
   in
   let resumed, _ = train_sgd_steps 2 (p3', st3') in
-  check_arr ~msg:"w" (to_arr expected.lw) resumed.lw;
-  check_arr ~msg:"b" (to_arr expected.lb) resumed.lb;
-  let fresh, _ = train_sgd_steps 2 (p3', Vega.sgd_init (module Lin) p3') in
-  is_false ~msg:"fresh momentum diverges" (to_arr fresh.lw = to_arr expected.lw)
+  check_arr ~msg:"w" (to_arr expected.Lin.lw) resumed.Lin.lw;
+  check_arr ~msg:"b" (to_arr expected.Lin.lb) resumed.Lin.lb;
+  let fresh, _ = train_sgd_steps 2 (p3', Vega.sgd_init lin p3') in
+  is_false ~msg:"fresh momentum diverges"
+    (to_arr fresh.Lin.lw = to_arr expected.Lin.lw)
 
 let test_load_pretrained () =
   with_ckpt_file @@ fun path ->
@@ -213,17 +238,17 @@ let test_load_pretrained () =
          Checkpoint.of_tensor "w" (Nx.create f32 [| 2; 1 |] [| 0.25; -0.75 |]);
          Checkpoint.of_tensor "b" (vec32 [| 0.125 |]);
        ]);
-  let fresh = { lw = Nx.zeros f32 [| 2; 1 |]; lb = Nx.zeros f32 [| 1 |] } in
+  let fresh = { Lin.lw = Nx.zeros f32 [| 2; 1 |]; lb = Nx.zeros f32 [| 1 |] } in
   let m =
     Checkpoint.to_params (module Lin) ~like:fresh (Checkpoint.load path)
   in
-  check_arr ~msg:"w" [| 0.25; -0.75 |] m.lw;
-  check_arr ~msg:"b" [| 0.125 |] m.lb
+  check_arr ~msg:"w" [| 0.25; -0.75 |] m.Lin.lw;
+  check_arr ~msg:"b" [| 0.125 |] m.Lin.lb
 
 (* Naming *)
 
 let test_prefix_names () =
-  let ckpt = Checkpoint.of_params (module Params) ~prefix:"model" (params ()) in
+  let ckpt = Checkpoint.of_packed (module Params) ~prefix:"model" (params ()) in
   equal (list string)
     [ "model.b"; "model.scale"; "model.w" ]
     (Checkpoint.names ckpt)
@@ -242,7 +267,7 @@ let test_ptree_paths () =
         ("head", T.tensor (vec64 [| 3.0 |]));
       ]
   in
-  let ckpt = Checkpoint.of_params (module Checkpoint.Ptree) tree in
+  let ckpt = Checkpoint.of_packed (module T.Tree) tree in
   equal ~msg:"paths" (list string)
     [ "head"; "layers.0.w"; "layers.1.w" ]
     (Checkpoint.names ckpt);
@@ -250,22 +275,41 @@ let test_ptree_paths () =
   Checkpoint.save path ckpt;
   let like = T.map (fun leaf -> Nx.zeros_like leaf) tree in
   let tree' =
-    Checkpoint.to_params (module Checkpoint.Ptree) ~like (Checkpoint.load path)
+    Checkpoint.to_packed (module T.Tree) ~like (Checkpoint.load path)
   in
   let leaf name =
-    match
-      Checkpoint.get name (Checkpoint.of_params (module Checkpoint.Ptree) tree')
-    with
+    match Checkpoint.get name (Checkpoint.of_packed (module T.Tree) tree') with
     | T.P x -> to_arr (Nx.cast f64 x)
   in
-  equal ~msg:"layers.1.w" (array float_exact) [| 2.0 |] (leaf "layers.1.w");
-  equal ~msg:"head" (array float_exact) [| 3.0 |] (leaf "head")
+  equal ~msg:"layers.1.w" (array (float 0.0)) [| 2.0 |] (leaf "layers.1.w");
+  equal ~msg:"head" (array (float 0.0)) [| 3.0 |] (leaf "head")
+
+(* A one-leaf structure whose payload sits at its own root: without a prefix
+   its name is empty. *)
+module Root = struct
+  type 'a t = 'a
+
+  let map f x = f x
+  let map2 f a b = f a b
+  let iter f x = f x
+  let fold f acc x = f "" acc x
+  let fold2 f acc a b = f "" acc a b
+  let names _ = ""
+end
+
+let test_root_leaf_prefix () =
+  let x = pack (vec32 [| 1.0 |]) in
+  let ckpt = Checkpoint.of_packed (module Root) ~prefix:"w" x in
+  equal ~msg:"prefix names the root" (list string) [ "w" ]
+    (Checkpoint.names ckpt);
+  raises_invalid_arg "Checkpoint.of_packed: empty tensor name" (fun () ->
+      Checkpoint.of_packed (module Root) x)
 
 let test_find_get () =
   let ckpt = Checkpoint.of_tensor "w" (vec32 [| 1.0 |]) in
   is_some ~msg:"find present" (Checkpoint.find "w" ckpt);
   is_none ~msg:"find absent" (Checkpoint.find "nope" ckpt);
-  raises (Invalid_argument "Checkpoint.get: no entry named \"nope\"") (fun () ->
+  raises_invalid_arg "Checkpoint.get: no entry named \"nope\"" (fun () ->
       Checkpoint.get "nope" ckpt)
 
 (* Error contracts *)
@@ -278,20 +322,22 @@ let test_missing_entry () =
         Checkpoint.of_tensor "scale" (vec64 [| 1.0 |]);
       ]
   in
-  raises (Invalid_argument "Checkpoint.to_params: missing entry \"b\"")
-    (fun () ->
-      Checkpoint.to_params (module Params) ~like:(fresh_params ()) ckpt)
+  raises_invalid_arg "Checkpoint.to_packed: missing entry \"b\"" (fun () ->
+      Checkpoint.to_packed (module Params) ~like:(fresh_params ()) ckpt)
 
 let test_extra_entries_ignored () =
   let ckpt =
     Checkpoint.concat
       [
-        Checkpoint.of_params (module Params) (params ());
+        Checkpoint.of_packed (module Params) (params ());
         Checkpoint.of_tensor "unrelated" (vec32 [| 9.0 |]);
       ]
   in
-  let p = Checkpoint.to_params (module Params) ~like:(fresh_params ()) ckpt in
-  check_arr ~msg:"w" [| 1.5; -2.0; 3.25 |] p.w
+  let p =
+    no_raise (fun () ->
+        Checkpoint.to_packed (module Params) ~like:(fresh_params ()) ckpt)
+  in
+  check_arr ~msg:"w" [| 1.5; -2.0; 3.25 |] (unpack32 p.Params.w)
 
 let test_shape_mismatch () =
   let ckpt =
@@ -302,11 +348,10 @@ let test_shape_mismatch () =
         Checkpoint.of_tensor "scale" (vec64 [| 1.0 |]);
       ]
   in
-  raises
-    (Invalid_argument
-       "Checkpoint.to_params: shape mismatch for \"b\": expected [1], got [2]")
+  raises_invalid_arg
+    "Checkpoint.to_packed: shape mismatch for \"b\": expected [1], got [2]"
     (fun () ->
-      Checkpoint.to_params (module Params) ~like:(fresh_params ()) ckpt)
+      Checkpoint.to_packed (module Params) ~like:(fresh_params ()) ckpt)
 
 let test_dtype_mismatch_and_cast () =
   let ckpt =
@@ -317,49 +362,41 @@ let test_dtype_mismatch_and_cast () =
         Checkpoint.of_tensor "scale" (vec32 [| 4.0 |]);
       ]
   in
-  raises
-    (Invalid_argument
-       "Checkpoint.to_params: dtype mismatch for \"scale\": expected float64, \
-        got float32 (pass ~cast:true to convert)") (fun () ->
-      Checkpoint.to_params (module Params) ~like:(fresh_params ()) ckpt);
+  raises_invalid_arg
+    "Checkpoint.to_packed: dtype mismatch for \"scale\": expected float64, got \
+     float32 (pass ~cast:true to convert)" (fun () ->
+      Checkpoint.to_packed (module Params) ~like:(fresh_params ()) ckpt);
   let p =
-    Checkpoint.to_params (module Params) ~cast:true ~like:(fresh_params ()) ckpt
+    Checkpoint.to_packed (module Params) ~cast:true ~like:(fresh_params ()) ckpt
   in
-  check_arr ~msg:"scale cast to float64" [| 4.0 |] p.scale
+  check_arr ~msg:"scale cast to float64" [| 4.0 |] (unpack64 p.Params.scale)
 
 let test_concat_duplicate () =
-  raises (Invalid_argument "Checkpoint.concat: duplicate name \"w\"") (fun () ->
+  raises_invalid_arg "Checkpoint.concat: duplicate name \"w\"" (fun () ->
       Checkpoint.concat
         [
           Checkpoint.of_tensor "w" (vec32 [| 1.0 |]);
           Checkpoint.of_tensor "w" (vec32 [| 2.0 |]);
         ])
 
-module Misnamed = struct
-  include Params
-
-  let names _ = [ "w" ]
-end
-
+(* A structure whose paths collide: the traversals are Params's, the paths are
+   not distinct. *)
 module Duplicated = struct
   include Params
 
-  let names _ = [ "w"; "w"; "scale" ]
+  let fold f acc { w; b; scale } = f "scale" (f "w" (f "w" acc w) b) scale
 end
 
-let test_invalid_names () =
-  raises
-    (Invalid_argument "Checkpoint.of_params: 1 name(s) for 3 tensor leaves")
-    (fun () -> Checkpoint.of_params (module Misnamed) (params ()));
-  raises
-    (Invalid_argument "Checkpoint.to_params: 1 name(s) for 3 tensor leaves")
-    (fun () ->
-      Checkpoint.to_params (module Misnamed) ~like:(params ()) Checkpoint.empty);
-  raises (Invalid_argument "Checkpoint.of_params: duplicate name \"w\"")
-    (fun () -> Checkpoint.of_params (module Duplicated) (params ()))
+let test_duplicate_names () =
+  raises_invalid_arg "Checkpoint.of_packed: duplicate name \"w\"" (fun () ->
+      Checkpoint.of_packed (module Duplicated) (params ()));
+  raises_invalid_arg "Checkpoint.to_packed: duplicate name \"w\"" (fun () ->
+      Checkpoint.to_packed
+        (module Duplicated)
+        ~like:(params ()) Checkpoint.empty)
 
 let test_empty_name () =
-  raises (Invalid_argument "Checkpoint.of_tensor: empty tensor name") (fun () ->
+  raises_invalid_arg "Checkpoint.of_tensor: empty tensor name" (fun () ->
       Checkpoint.of_tensor "" (vec32 [| 1.0 |]))
 
 let test_to_int_errors () =
@@ -370,14 +407,12 @@ let test_to_int_errors () =
         Checkpoint.of_tensor "v" (Nx.create Nx.int32 [| 2 |] [| 1l; 2l |]);
       ]
   in
-  raises (Invalid_argument "Checkpoint.to_int: no entry named \"step\"")
-    (fun () -> Checkpoint.to_int "step" ckpt);
-  raises
-    (Invalid_argument
-       "Checkpoint.to_int: \"w\" is not an int32 entry (dtype float32)")
-    (fun () -> Checkpoint.to_int "w" ckpt);
-  raises
-    (Invalid_argument "Checkpoint.to_int: \"v\" is not a scalar (shape [2])")
+  raises_invalid_arg "Checkpoint.to_int: no entry named \"step\"" (fun () ->
+      Checkpoint.to_int "step" ckpt);
+  raises_invalid_arg
+    "Checkpoint.to_int: \"w\" is not an int32 entry (dtype float32)" (fun () ->
+      Checkpoint.to_int "w" ckpt);
+  raises_invalid_arg "Checkpoint.to_int: \"v\" is not a scalar (shape [2])"
     (fun () -> Checkpoint.to_int "v" ckpt)
 
 let () =
@@ -402,6 +437,8 @@ let () =
         [
           test "prefix prepends dotted names" test_prefix_names;
           test "ptree leaves are named by their path" test_ptree_paths;
+          test "a root payload is named by the prefix alone"
+            test_root_leaf_prefix;
           test "find and get look entries up by name" test_find_get;
         ];
       group "errors"
@@ -411,7 +448,7 @@ let () =
           test "shape mismatch raises" test_shape_mismatch;
           test "dtype mismatch raises unless cast" test_dtype_mismatch_and_cast;
           test "concat rejects duplicate names" test_concat_duplicate;
-          test "invalid names lists are rejected" test_invalid_names;
+          test "duplicate leaf paths are rejected" test_duplicate_names;
           test "empty tensor names are rejected" test_empty_name;
           test "to_int rejects missing and non-scalar entries"
             test_to_int_errors;

--- a/packages/kaun/test/test_checkpoint.ml
+++ b/packages/kaun/test/test_checkpoint.ml
@@ -14,7 +14,7 @@ let to_arr t = Nx.to_array (Nx.reshape [| -1 |] (Nx.contiguous t))
 
 (* Checkpoints round-trip bit-exactly, so comparisons are exact. *)
 let check_arr ~msg expected actual =
-  equal ~msg (array (float 0.0)) expected (to_arr actual)
+  equal ~msg (array float_exact) expected (to_arr actual)
 
 (* Runs [f] with a fresh checkpoint file path in a temporary directory, removed
    afterwards even on failure. *)
@@ -281,8 +281,8 @@ let test_ptree_paths () =
     match Checkpoint.get name (Checkpoint.of_packed (module T.Tree) tree') with
     | T.P x -> to_arr (Nx.cast f64 x)
   in
-  equal ~msg:"layers.1.w" (array (float 0.0)) [| 2.0 |] (leaf "layers.1.w");
-  equal ~msg:"head" (array (float 0.0)) [| 3.0 |] (leaf "head")
+  equal ~msg:"layers.1.w" (array float_exact) [| 2.0 |] (leaf "layers.1.w");
+  equal ~msg:"head" (array float_exact) [| 3.0 |] (leaf "head")
 
 (* A one-leaf structure whose payload sits at its own root: without a prefix
    its name is empty. *)
@@ -302,14 +302,14 @@ let test_root_leaf_prefix () =
   let ckpt = Checkpoint.of_packed (module Root) ~prefix:"w" x in
   equal ~msg:"prefix names the root" (list string) [ "w" ]
     (Checkpoint.names ckpt);
-  raises_invalid_arg "Checkpoint.of_packed: empty tensor name" (fun () ->
+  raises (Invalid_argument "Checkpoint.of_packed: empty tensor name") (fun () ->
       Checkpoint.of_packed (module Root) x)
 
 let test_find_get () =
   let ckpt = Checkpoint.of_tensor "w" (vec32 [| 1.0 |]) in
   is_some ~msg:"find present" (Checkpoint.find "w" ckpt);
   is_none ~msg:"find absent" (Checkpoint.find "nope" ckpt);
-  raises_invalid_arg "Checkpoint.get: no entry named \"nope\"" (fun () ->
+  raises (Invalid_argument "Checkpoint.get: no entry named \"nope\"") (fun () ->
       Checkpoint.get "nope" ckpt)
 
 (* Error contracts *)
@@ -322,7 +322,7 @@ let test_missing_entry () =
         Checkpoint.of_tensor "scale" (vec64 [| 1.0 |]);
       ]
   in
-  raises_invalid_arg "Checkpoint.to_packed: missing entry \"b\"" (fun () ->
+  raises (Invalid_argument "Checkpoint.to_packed: missing entry \"b\"") (fun () ->
       Checkpoint.to_packed (module Params) ~like:(fresh_params ()) ckpt)
 
 let test_extra_entries_ignored () =
@@ -333,10 +333,7 @@ let test_extra_entries_ignored () =
         Checkpoint.of_tensor "unrelated" (vec32 [| 9.0 |]);
       ]
   in
-  let p =
-    no_raise (fun () ->
-        Checkpoint.to_packed (module Params) ~like:(fresh_params ()) ckpt)
-  in
+  let p = Checkpoint.to_packed (module Params) ~like:(fresh_params ()) ckpt in
   check_arr ~msg:"w" [| 1.5; -2.0; 3.25 |] (unpack32 p.Params.w)
 
 let test_shape_mismatch () =
@@ -348,8 +345,8 @@ let test_shape_mismatch () =
         Checkpoint.of_tensor "scale" (vec64 [| 1.0 |]);
       ]
   in
-  raises_invalid_arg
-    "Checkpoint.to_packed: shape mismatch for \"b\": expected [1], got [2]"
+  raises
+    (Invalid_argument "Checkpoint.to_packed: shape mismatch for \"b\": expected [1], got [2]")
     (fun () ->
       Checkpoint.to_packed (module Params) ~like:(fresh_params ()) ckpt)
 
@@ -362,9 +359,9 @@ let test_dtype_mismatch_and_cast () =
         Checkpoint.of_tensor "scale" (vec32 [| 4.0 |]);
       ]
   in
-  raises_invalid_arg
-    "Checkpoint.to_packed: dtype mismatch for \"scale\": expected float64, got \
-     float32 (pass ~cast:true to convert)" (fun () ->
+  raises
+    (Invalid_argument "Checkpoint.to_packed: dtype mismatch for \"scale\": expected float64, got \
+     float32 (pass ~cast:true to convert)") (fun () ->
       Checkpoint.to_packed (module Params) ~like:(fresh_params ()) ckpt);
   let p =
     Checkpoint.to_packed (module Params) ~cast:true ~like:(fresh_params ()) ckpt
@@ -372,7 +369,7 @@ let test_dtype_mismatch_and_cast () =
   check_arr ~msg:"scale cast to float64" [| 4.0 |] (unpack64 p.Params.scale)
 
 let test_concat_duplicate () =
-  raises_invalid_arg "Checkpoint.concat: duplicate name \"w\"" (fun () ->
+  raises (Invalid_argument "Checkpoint.concat: duplicate name \"w\"") (fun () ->
       Checkpoint.concat
         [
           Checkpoint.of_tensor "w" (vec32 [| 1.0 |]);
@@ -388,15 +385,15 @@ module Duplicated = struct
 end
 
 let test_duplicate_names () =
-  raises_invalid_arg "Checkpoint.of_packed: duplicate name \"w\"" (fun () ->
+  raises (Invalid_argument "Checkpoint.of_packed: duplicate name \"w\"") (fun () ->
       Checkpoint.of_packed (module Duplicated) (params ()));
-  raises_invalid_arg "Checkpoint.to_packed: duplicate name \"w\"" (fun () ->
+  raises (Invalid_argument "Checkpoint.to_packed: duplicate name \"w\"") (fun () ->
       Checkpoint.to_packed
         (module Duplicated)
         ~like:(params ()) Checkpoint.empty)
 
 let test_empty_name () =
-  raises_invalid_arg "Checkpoint.of_tensor: empty tensor name" (fun () ->
+  raises (Invalid_argument "Checkpoint.of_tensor: empty tensor name") (fun () ->
       Checkpoint.of_tensor "" (vec32 [| 1.0 |]))
 
 let test_to_int_errors () =
@@ -407,12 +404,12 @@ let test_to_int_errors () =
         Checkpoint.of_tensor "v" (Nx.create Nx.int32 [| 2 |] [| 1l; 2l |]);
       ]
   in
-  raises_invalid_arg "Checkpoint.to_int: no entry named \"step\"" (fun () ->
+  raises (Invalid_argument "Checkpoint.to_int: no entry named \"step\"") (fun () ->
       Checkpoint.to_int "step" ckpt);
-  raises_invalid_arg
-    "Checkpoint.to_int: \"w\" is not an int32 entry (dtype float32)" (fun () ->
+  raises
+    (Invalid_argument "Checkpoint.to_int: \"w\" is not an int32 entry (dtype float32)") (fun () ->
       Checkpoint.to_int "w" ckpt);
-  raises_invalid_arg "Checkpoint.to_int: \"v\" is not a scalar (shape [2])"
+  raises (Invalid_argument "Checkpoint.to_int: \"v\" is not a scalar (shape [2])")
     (fun () -> Checkpoint.to_int "v" ckpt)
 
 let () =

--- a/packages/kaun/test/test_checkpoint.ml
+++ b/packages/kaun/test/test_checkpoint.ml
@@ -100,7 +100,7 @@ module Lin = struct
   let names _ = { lw = "w"; lb = "b" }
 end
 
-let lin = Nx.Ptree.instantiate (module Lin)
+let lin = Kaun.ptree (module Lin)
 
 (* Round-trip *)
 

--- a/packages/kaun/test/test_conv.ml
+++ b/packages/kaun/test/test_conv.ml
@@ -10,7 +10,7 @@ open Kaun
    so the instance is just a type pin. Tensor64 treats a bare tensor as a
    one-leaf parameter tree, for gradients with respect to an input. *)
 
-let conv64 = Nx.Ptree.typed (module Conv)
+let conv64 = Nx.Ptree.instantiate (module Conv)
 
 module Tensor64 = struct
   type t = (float, Nx.float64_elt) Nx.t

--- a/packages/kaun/test/test_conv.ml
+++ b/packages/kaun/test/test_conv.ml
@@ -10,13 +10,7 @@ open Kaun
    so the instance is just a type pin. Tensor64 treats a bare tensor as a
    one-leaf parameter tree, for gradients with respect to an input. *)
 
-module Conv64 = struct
-  type t = Nx.float64_elt Conv.params
-
-  let map = Conv.map
-  let map2 = Conv.map2
-  let iter = Conv.iter
-end
+let conv64 = Nx.Ptree.typed (module Conv)
 
 module Tensor64 = struct
   type t = (float, Nx.float64_elt) Nx.t
@@ -140,12 +134,14 @@ let test_conv_no_bias () =
       Nx.float32
   in
   is_true ~msg:"no bias parameter" (p.Conv.b = None);
-  equal ~msg:"names without bias" (list string) [ "w" ] (Conv.names p)
+  let paths = List.rev (Conv.fold (fun path acc _ -> path :: acc) [] p) in
+  equal ~msg:"paths without bias" (list string) [ "w" ] paths
 
 let test_conv_names () =
   Nx.Rng.with_key (Nx.Rng.key 4) @@ fun () ->
   let p = Conv.init ~in_channels:2 ~out_channels:2 ~kernel_size:(2, 2) in
-  equal ~msg:"with bias" (list string) [ "w"; "b" ] (Conv.names p)
+  let paths = List.rev (Conv.fold (fun path acc _ -> path :: acc) [] p) in
+  equal ~msg:"with bias" (list string) [ "w"; "b" ] paths
 
 let test_conv_gradients () =
   Nx.Rng.with_key (Nx.Rng.key 5) @@ fun () ->
@@ -157,7 +153,7 @@ let test_conv_gradients () =
   let p =
     Conv.make ~in_channels:2 ~out_channels:2 ~kernel_size:(2, 2) Nx.float64
   in
-  grads_ok (Rune.check_grads (module Conv64) loss p);
+  grads_ok (Rune.check_grads conv64 loss p);
   let no_bias =
     Conv.make ~bias:false ~in_channels:2 ~out_channels:2 ~kernel_size:(3, 3)
       Nx.float64
@@ -166,7 +162,7 @@ let test_conv_gradients () =
     let y = Conv.apply ~stride:(2, 2) ~padding:`Same p x in
     Nx.sum (Nx.mul y y)
   in
-  grads_ok (Rune.check_grads (module Conv64) strided_loss no_bias)
+  grads_ok (Rune.check_grads conv64 strided_loss no_bias)
 
 let test_conv_input_gradients () =
   Nx.Rng.with_key (Nx.Rng.key 6) @@ fun () ->

--- a/packages/kaun/test/test_conv.ml
+++ b/packages/kaun/test/test_conv.ml
@@ -10,7 +10,7 @@ open Kaun
    so the instance is just a type pin. Tensor64 treats a bare tensor as a
    one-leaf parameter tree, for gradients with respect to an input. *)
 
-let conv64 = Nx.Ptree.instantiate (module Conv)
+let conv64 = Kaun.ptree (module Conv)
 
 module Tensor64 = struct
   type t = (float, Nx.float64_elt) Nx.t

--- a/packages/kaun/test/test_half.ml
+++ b/packages/kaun/test/test_half.ml
@@ -192,7 +192,7 @@ let test_batch_norm_island () =
 
 (* ───── The astype-sandwich gradient ───── *)
 
-let linear32 = Nx.Ptree.instantiate (module Linear)
+let linear32 = Kaun.ptree (module Linear)
 
 let test_sandwich_grad (type b) name (dt : (float, b) Nx.dtype) ~tol () =
   ignore name;

--- a/packages/kaun/test/test_half.ml
+++ b/packages/kaun/test/test_half.ml
@@ -192,7 +192,7 @@ let test_batch_norm_island () =
 
 (* ───── The astype-sandwich gradient ───── *)
 
-let linear32 = Nx.Ptree.typed (module Linear)
+let linear32 = Nx.Ptree.instantiate (module Linear)
 
 let test_sandwich_grad (type b) name (dt : (float, b) Nx.dtype) ~tol () =
   ignore name;

--- a/packages/kaun/test/test_half.ml
+++ b/packages/kaun/test/test_half.ml
@@ -3,7 +3,8 @@
   SPDX-License-Identifier: ISC
   ---------------------------------------------------------------------------*)
 
-(* Mixed precision through the kaun layers: per-layer [astype], the float32
+(* Mixed precision through the kaun layers: per-layer [map (Nx.cast dt)], the
+   float32
    islands (attention scores and normalization statistics), the astype-sandwich
    gradient, and a jitted float16 training loop with Vega's loss scaling.
 
@@ -31,34 +32,34 @@ let dtype_is ?msg dt t = is_true ?msg (Nx_core.Dtype.equal (Nx.dtype t) dt)
    range. *)
 let grid n = Array.init n (fun i -> 0.25 *. float_of_int ((i mod 13) - 6))
 
-(* ───── astype ───── *)
+(* ───── cast ───── *)
 
 let linear_params () =
   { Linear.w = mat f32 3 2 (grid 6); b = Some (vec f32 [| 0.5; -0.25 |]) }
 
-let test_astype_dtypes () =
-  let lin = Linear.astype f16 (linear_params ()) in
+let test_cast_dtypes () =
+  let lin = Linear.map (Nx.cast f16) (linear_params ()) in
   dtype_is ~msg:"linear w" f16 lin.Linear.w;
   dtype_is ~msg:"linear b" f16 (Option.get lin.Linear.b);
-  let emb = Embedding.astype f16 { Embedding.table = mat f32 4 3 (grid 12) } in
+  let emb = Embedding.map (Nx.cast f16) { Embedding.table = mat f32 4 3 (grid 12) } in
   dtype_is ~msg:"embedding table" f16 emb.Embedding.table;
-  let ln = Layer_norm.astype f16 (Layer_norm.init ~dim:4) in
+  let ln = Layer_norm.map (Nx.cast f16) (Layer_norm.init ~dim:4) in
   dtype_is ~msg:"layer norm gamma" f16 ln.Layer_norm.gamma;
-  let attn = Attention.astype f16 (Attention.init ~embed_dim:4) in
+  let attn = Attention.map (Nx.cast f16) (Attention.init ~embed_dim:4) in
   dtype_is ~msg:"attention q.w" f16 attn.Attention.q.Linear.w;
   let bn, stats = Batch_norm.init ~features:3 in
-  dtype_is ~msg:"batch norm gamma" f16 (Batch_norm.astype f16 bn).gamma;
+  dtype_is ~msg:"batch norm gamma" f16 (Batch_norm.map (Nx.cast f16) bn).gamma;
   dtype_is ~msg:"batch norm stats mean" f16
-    (Batch_norm.Stats.astype f16 stats).mean;
+    (Batch_norm.Stats.map (Nx.cast f16) stats).mean;
   let conv = Conv.init ~in_channels:1 ~out_channels:2 ~kernel_size:(2, 2) in
-  dtype_is ~msg:"conv w" f16 (Conv.astype f16 conv).Conv.w;
+  dtype_is ~msg:"conv w" f16 (Conv.map (Nx.cast f16) conv).Conv.w;
   let cache = Attention.Cache.make ~num_heads:2 ~head_dim:2 ~len:3 Nx.float32 in
-  dtype_is ~msg:"cache keys" f16 (Attention.Cache.astype f16 cache).keys
+  dtype_is ~msg:"cache keys" f16 (Attention.Cache.map (Nx.cast f16) cache).keys
 
-let test_astype_round_trip () =
-  (* Grid values are exact at both halves: astype down and back is lossless. *)
+let test_cast_round_trip () =
+  (* Grid values are exact at both halves: cast down and back is lossless. *)
   let p = linear_params () in
-  let back dt = Linear.astype f32 (Linear.astype dt p) in
+  let back dt = Linear.map (Nx.cast f32) (Linear.map (Nx.cast dt) p) in
   close ~msg:"float16 w" ~tol:0.0 p.Linear.w (back f16).Linear.w;
   close ~msg:"bfloat16 w" ~tol:0.0 p.Linear.w (back bf16).Linear.w
 
@@ -68,7 +69,7 @@ let test_linear_apply (type b) name (dt : (float, b) Nx.dtype) ~tol () =
   let p = linear_params () in
   let x = mat f32 4 3 (grid 12) in
   let expected = Linear.apply p x in
-  let actual = Linear.apply (Linear.astype dt p) (Nx.cast dt x) in
+  let actual = Linear.apply (Linear.map (Nx.cast dt) p) (Nx.cast dt x) in
   dtype_is ~msg:"output dtype" dt actual;
   close ~tol expected actual
 
@@ -77,7 +78,7 @@ let test_embedding_apply () =
   let ids = vec Nx.int32 [| 0l; 3l; 4l |] in
   (* A gather rounds nothing: exact at float16. *)
   close ~msg:"float16 gather is exact" ~tol:0.0 (Embedding.apply p ids)
-    (Embedding.apply (Embedding.astype f16 p) ids)
+    (Embedding.apply (Embedding.map (Nx.cast f16) p) ids)
 
 let test_conv_apply () =
   let p =
@@ -88,7 +89,7 @@ let test_conv_apply () =
   in
   let x = Nx.create f32 [| 1; 1; 4; 4 |] (grid 16) in
   close ~msg:"float16 conv" ~tol:0.02 (Conv.apply p x)
-    (Conv.apply (Conv.astype f16 p) (Nx.cast f16 x))
+    (Conv.apply (Conv.map (Nx.cast f16) p) (Nx.cast f16 x))
 
 (* ───── float32 islands ───── *)
 
@@ -109,7 +110,7 @@ let test_layer_norm_island (type b) name (dt : (float, b) Nx.dtype) ~tol () =
      reference is the float32 computation on the same rounded values. *)
   let xh = Nx.cast dt x in
   let expected = Layer_norm.apply p (Nx.cast f32 xh) in
-  let actual = Layer_norm.apply (Layer_norm.astype dt p) xh in
+  let actual = Layer_norm.apply (Layer_norm.map (Nx.cast dt) p) xh in
   is_true ~msg:"all finite" (Nx.item [] (Nx.all (Nx.isfinite actual)));
   close ~tol expected actual
 
@@ -147,7 +148,7 @@ let test_attention_apply_half () =
   let x = mat f32 3 dim (grid 12) in
   let expected = Attention.apply ~num_heads:2 ~causal:true p x in
   let actual =
-    Attention.apply ~num_heads:2 ~causal:true (Attention.astype f16 p)
+    Attention.apply ~num_heads:2 ~causal:true (Attention.map (Nx.cast f16) p)
       (Nx.cast f16 x)
   in
   close ~msg:"multi-head causal at float16" ~tol:0.01 expected actual
@@ -173,8 +174,8 @@ let test_batch_norm_island () =
   let p, stats = Batch_norm.init ~features:3 in
   let expected, estats = Batch_norm.apply p stats ~training:true x in
   let actual, astats =
-    Batch_norm.apply (Batch_norm.astype f16 p)
-      (Batch_norm.Stats.astype f16 stats)
+    Batch_norm.apply (Batch_norm.map (Nx.cast f16) p)
+      (Batch_norm.Stats.map (Nx.cast f16) stats)
       ~training:true (Nx.cast f16 x)
   in
   is_true ~msg:"all finite" (Nx.item [] (Nx.all (Nx.isfinite actual)));
@@ -183,21 +184,15 @@ let test_batch_norm_island () =
     astats.Batch_norm.Stats.mean;
   let expected_eval, _ = Batch_norm.apply p estats ~training:false x in
   let actual_eval, _ =
-    Batch_norm.apply (Batch_norm.astype f16 p)
-      (Batch_norm.Stats.astype f16 estats)
+    Batch_norm.apply (Batch_norm.map (Nx.cast f16) p)
+      (Batch_norm.Stats.map (Nx.cast f16) estats)
       ~training:false (Nx.cast f16 x)
   in
   close ~msg:"eval normalization" ~tol:0.05 expected_eval actual_eval
 
 (* ───── The astype-sandwich gradient ───── *)
 
-module Linear32 = struct
-  type t = Linear.t
-
-  let map = Linear.map
-  let map2 = Linear.map2
-  let iter = Linear.iter
-end
+let linear32 = Nx.Ptree.typed (module Linear)
 
 let test_sandwich_grad (type b) name (dt : (float, b) Nx.dtype) ~tol () =
   ignore name;
@@ -206,12 +201,12 @@ let test_sandwich_grad (type b) name (dt : (float, b) Nx.dtype) ~tol () =
   let loss compute p =
     Nx.cast f32
       (Nx.mean
-         (Nx.tanh (Linear.apply (Linear.astype compute p) (Nx.cast compute x))))
+         (Nx.tanh (Linear.apply (Linear.map (Nx.cast compute) p) (Nx.cast compute x))))
   in
-  let v, grads = Rune.value_and_grad (module Linear32) (loss dt) p in
+  let v, grads = Rune.value_and_grad linear32 (loss dt) p in
   (* [grads : Linear.t]: float32 by type; the cast VJP makes it so at run time,
      and the values must track the all-float32 gradient. *)
-  let v32, grads32 = Rune.value_and_grad (module Linear32) (loss f32) p in
+  let v32, grads32 = Rune.value_and_grad linear32 (loss f32) p in
   close ~msg:"loss" ~tol v32 v;
   close ~msg:"dw" ~tol grads32.Linear.w grads.Linear.w;
   close ~msg:"db" ~tol (Option.get grads32.Linear.b) (Option.get grads.Linear.b)
@@ -330,10 +325,10 @@ let test_f16_train_loss_scaled () =
 
 let tests =
   [
-    group "astype"
+    group "cast"
       [
-        test "casts every leaf of every layer" test_astype_dtypes;
-        test "round-trips exact values" test_astype_round_trip;
+        test "casts every leaf of every layer" test_cast_dtypes;
+        test "round-trips exact values" test_cast_round_trip;
       ];
     group "dtype-generic apply"
       [
@@ -355,7 +350,7 @@ let tests =
         test "attention apply float16" test_attention_apply_half;
         test "batch norm float16" test_batch_norm_island;
       ];
-    group "astype sandwich"
+    group "cast sandwich"
       [
         test "float16 grads are float32 and track the reference"
           (test_sandwich_grad "float16" f16 ~tol:0.005);

--- a/packages/kaun/test/test_kaun.ml
+++ b/packages/kaun/test/test_kaun.ml
@@ -26,6 +26,20 @@ module Mlp = struct
     Linear.iter f l1;
     Linear.iter f l2
 
+  let fold f acc { l1; l2 } =
+    let acc = Linear.fold (fun p -> f ("l1." ^ p)) acc l1 in
+    Linear.fold (fun p -> f ("l2." ^ p)) acc l2
+
+  let fold2 f acc p q =
+    let acc = Linear.fold2 (fun s -> f ("l1." ^ s)) acc p.l1 q.l1 in
+    Linear.fold2 (fun s -> f ("l2." ^ s)) acc p.l2 q.l2
+
+  let names p =
+    {
+      l1 = Linear.map (( ^ ) "l1.") (Linear.names p.l1);
+      l2 = Linear.map (( ^ ) "l2.") (Linear.names p.l2);
+    }
+
   let apply p x = Linear.apply p.l2 (Nx.tanh (Linear.apply p.l1 x))
 end
 

--- a/packages/kaun/test/test_kaun.ml
+++ b/packages/kaun/test/test_kaun.ml
@@ -29,7 +29,7 @@ module Mlp = struct
   let apply p x = Linear.apply p.l2 (Nx.tanh (Linear.apply p.l1 x))
 end
 
-let mlp = Nx.Ptree.typed (module Mlp)
+let mlp = Nx.Ptree.instantiate (module Mlp)
 
 let xor_x =
   lazy (Nx.create Nx.float32 [| 4; 2 |] [| 0.; 0.; 0.; 1.; 1.; 0.; 1.; 1. |])

--- a/packages/kaun/test/test_kaun.ml
+++ b/packages/kaun/test/test_kaun.ml
@@ -43,7 +43,7 @@ module Mlp = struct
   let apply p x = Linear.apply p.l2 (Nx.tanh (Linear.apply p.l1 x))
 end
 
-let mlp = Nx.Ptree.instantiate (module Mlp)
+let mlp = Kaun.ptree (module Mlp)
 
 let xor_x =
   lazy (Nx.create Nx.float32 [| 4; 2 |] [| 0.; 0.; 0.; 1.; 1.; 0.; 1.; 1. |])

--- a/packages/kaun/test/test_kaun.ml
+++ b/packages/kaun/test/test_kaun.ml
@@ -10,20 +10,26 @@ open Windtrap
 open Kaun
 
 module Mlp = struct
-  type t = { l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; l2 } =
-    { l1 = Linear.map f l1; l2 = Linear.map f l2 }
+  let map f { l1; l2 } =
+    let l1 = Linear.map f l1 in
+    let l2 = Linear.map f l2 in
+    { l1; l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
-    { l1 = Linear.map2 f p.l1 q.l1; l2 = Linear.map2 f p.l2 q.l2 }
+  let map2 f p q =
+    let l1 = Linear.map2 f p.l1 q.l1 in
+    let l2 = Linear.map2 f p.l2 q.l2 in
+    { l1; l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; l2 } =
+  let iter f { l1; l2 } =
     Linear.iter f l1;
     Linear.iter f l2
 
   let apply p x = Linear.apply p.l2 (Nx.tanh (Linear.apply p.l1 x))
 end
+
+let mlp = Nx.Ptree.typed (module Mlp)
 
 let xor_x =
   lazy (Nx.create Nx.float32 [| 4; 2 |] [| 0.; 0.; 0.; 1.; 1.; 0.; 1.; 1. |])
@@ -41,13 +47,13 @@ let test_xor_trains () =
   in
   let loss p = Loss.sigmoid_bce (Mlp.apply p x) y in
   let step (params, ostate) =
-    let l, grads = Rune.value_and_grad (module Mlp) loss params in
+    let l, grads = Rune.value_and_grad mlp loss params in
     let params, ostate =
-      Vega.adam_step (module Mlp) ~lr:0.05 ostate ~params ~grads
+      Vega.adam_step mlp ~lr:0.05 ostate ~params ~grads
     in
     ((params, ostate), Nx.item [] l)
   in
-  let state = ref (params, Vega.adam_init (module Mlp) params) in
+  let state = ref (params, Vega.adam_init mlp params) in
   let last = ref Float.infinity in
   for _ = 1 to 500 do
     let s, l = step !state in
@@ -75,12 +81,12 @@ let test_sgd_decreases_loss () =
   in
   let loss p = Loss.mse (Mlp.apply p x) y in
   let l0 = Nx.item [] (loss params) in
-  let state = ref (params, Vega.sgd_init (module Mlp) params) in
+  let state = ref (params, Vega.sgd_init mlp params) in
   for _ = 1 to 100 do
     let params, ostate = !state in
-    let _, grads = Rune.value_and_grad (module Mlp) loss params in
+    let _, grads = Rune.value_and_grad mlp loss params in
     state :=
-      Vega.sgd_step (module Mlp) ~lr:0.1 ~momentum:0.9 ostate ~params ~grads
+      Vega.sgd_step mlp ~lr:0.1 ~momentum:0.9 ostate ~params ~grads
   done;
   let l1 = Nx.item [] (loss (fst !state)) in
   is_true ~msg:"sgd decreases the loss" (l1 < l0 *. 0.5)

--- a/packages/kaun/test/test_kaun.ml
+++ b/packages/kaun/test/test_kaun.ml
@@ -26,20 +26,6 @@ module Mlp = struct
     Linear.iter f l1;
     Linear.iter f l2
 
-  let fold f acc { l1; l2 } =
-    let acc = Linear.fold (fun p -> f ("l1." ^ p)) acc l1 in
-    Linear.fold (fun p -> f ("l2." ^ p)) acc l2
-
-  let fold2 f acc p q =
-    let acc = Linear.fold2 (fun s -> f ("l1." ^ s)) acc p.l1 q.l1 in
-    Linear.fold2 (fun s -> f ("l2." ^ s)) acc p.l2 q.l2
-
-  let names p =
-    {
-      l1 = Linear.map (( ^ ) "l1.") (Linear.names p.l1);
-      l2 = Linear.map (( ^ ) "l2.") (Linear.names p.l2);
-    }
-
   let apply p x = Linear.apply p.l2 (Nx.tanh (Linear.apply p.l1 x))
 end
 

--- a/packages/kaun/test/test_layers.ml
+++ b/packages/kaun/test/test_layers.ml
@@ -27,9 +27,9 @@ module _ :
 (* Float64 instances for gradient checking; the layer traversals are
    dtype-generic, so each instance is just a type pin. *)
 
-let linear64 = Nx.Ptree.instantiate (module Linear)
-let embedding64 = Nx.Ptree.instantiate (module Embedding)
-let layer_norm64 = Nx.Ptree.instantiate (module Layer_norm)
+let linear64 = Kaun.ptree (module Linear)
+let embedding64 = Kaun.ptree (module Embedding)
+let layer_norm64 = Kaun.ptree (module Layer_norm)
 
 let grads_ok = function Ok () -> () | Error m -> fail m
 let shape_is ?msg expected t = equal ?msg (array int) expected (Nx.shape t)

--- a/packages/kaun/test/test_layers.ml
+++ b/packages/kaun/test/test_layers.ml
@@ -6,32 +6,30 @@
 open Windtrap
 open Kaun
 
+(* Each layer's traversals satisfy the Uniform contract, so a layer is a valid
+   [@@deriving ptree] delegate by construction. *)
+module _ : Nx.Ptree.Uniform with type 'a t = 'a Linear.t = Linear
+module _ : Nx.Ptree.Uniform with type 'a t = 'a Conv.t = Conv
+module _ : Nx.Ptree.Uniform with type 'a t = 'a Embedding.t = Embedding
+module _ : Nx.Ptree.Uniform with type 'a t = 'a Layer_norm.t = Layer_norm
+module _ : Nx.Ptree.Uniform with type 'a t = 'a Batch_norm.t = Batch_norm
+
+module _ :
+  Nx.Ptree.Uniform with type 'a t = 'a Batch_norm.Stats.t =
+  Batch_norm.Stats
+
+module _ : Nx.Ptree.Uniform with type 'a t = 'a Attention.t = Attention
+
+module _ :
+  Nx.Ptree.Uniform with type 'a t = 'a Attention.Cache.t =
+  Attention.Cache
+
 (* Float64 instances for gradient checking; the layer traversals are
    dtype-generic, so each instance is just a type pin. *)
 
-module Linear64 = struct
-  type t = Nx.float64_elt Linear.params
-
-  let map = Linear.map
-  let map2 = Linear.map2
-  let iter = Linear.iter
-end
-
-module Embedding64 = struct
-  type t = Nx.float64_elt Embedding.params
-
-  let map = Embedding.map
-  let map2 = Embedding.map2
-  let iter = Embedding.iter
-end
-
-module Layer_norm64 = struct
-  type t = Nx.float64_elt Layer_norm.params
-
-  let map = Layer_norm.map
-  let map2 = Layer_norm.map2
-  let iter = Layer_norm.iter
-end
+let linear64 = Nx.Ptree.typed (module Linear)
+let embedding64 = Nx.Ptree.typed (module Embedding)
+let layer_norm64 = Nx.Ptree.typed (module Layer_norm)
 
 let grads_ok = function Ok () -> () | Error m -> fail m
 let shape_is ?msg expected t = equal ?msg (array int) expected (Nx.shape t)
@@ -89,9 +87,12 @@ let test_linear_custom_inits () =
 let test_linear_names () =
   Nx.Rng.with_key (Nx.Rng.key 4) @@ fun () ->
   let with_bias = Linear.init ~inputs:2 ~outputs:2 in
-  equal ~msg:"with bias" (list string) [ "w"; "b" ] (Linear.names with_bias);
+  let paths p = List.rev (Linear.fold (fun path acc _ -> path :: acc) [] p) in
+  equal ~msg:"with bias" (list string) [ "w"; "b" ] (paths with_bias);
+  equal ~msg:"names agree with fold" (option string) (Some "b")
+    (Linear.names with_bias).Linear.b;
   let no_bias = Linear.make ~bias:false ~inputs:2 ~outputs:2 Nx.float32 in
-  equal ~msg:"without bias" (list string) [ "w" ] (Linear.names no_bias)
+  equal ~msg:"without bias" (list string) [ "w" ] (paths no_bias)
 
 let test_linear_gradients () =
   Nx.Rng.with_key (Nx.Rng.key 5) @@ fun () ->
@@ -101,9 +102,9 @@ let test_linear_gradients () =
     Nx.sum (Nx.mul y y)
   in
   let p = Linear.make ~inputs:3 ~outputs:2 Nx.float64 in
-  grads_ok (Rune.check_grads (module Linear64) loss p);
+  grads_ok (Rune.check_grads linear64 loss p);
   let no_bias = Linear.make ~bias:false ~inputs:3 ~outputs:2 Nx.float64 in
-  grads_ok (Rune.check_grads (module Linear64) loss no_bias)
+  grads_ok (Rune.check_grads linear64 loss no_bias)
 
 let test_linear_map2_bias_mismatch () =
   Nx.Rng.with_key (Nx.Rng.key 6) @@ fun () ->
@@ -135,7 +136,7 @@ let test_embedding_init_shape () =
   Nx.Rng.with_key (Nx.Rng.key 7) @@ fun () ->
   let p = Embedding.init ~vocab:7 ~dim:4 in
   shape_is ~msg:"table shape" [| 7; 4 |] p.Embedding.table;
-  equal ~msg:"names" (list string) [ "table" ] (Embedding.names p)
+  equal ~msg:"names" string "table" (Embedding.names p).Embedding.table
 
 let test_embedding_gathers_rows () =
   let p = embedding_4x3 () in
@@ -161,7 +162,7 @@ let test_embedding_duplicate_id_gradient () =
   let p = Embedding.make ~vocab:3 ~dim:2 Nx.float64 in
   let ids = Nx.create Nx.int32 [| 3 |] [| 0l; 2l; 0l |] in
   let loss p = Nx.sum (Embedding.apply p ids) in
-  let g = Rune.grad (module Embedding64) loss p in
+  let g = Rune.grad embedding64 loss p in
   (* Row 0 is gathered twice, row 1 never, row 2 once. *)
   values_are ~msg:"gradient counts occurrences" ~tol:1e-12
     [| 2.; 2.; 0.; 0.; 1.; 1. |]
@@ -175,7 +176,7 @@ let test_embedding_gradients () =
     let y = Embedding.apply p ids in
     Nx.sum (Nx.mul y y)
   in
-  grads_ok (Rune.check_grads (module Embedding64) loss p)
+  grads_ok (Rune.check_grads embedding64 loss p)
 
 let test_embedding_rejects_out_of_bounds () =
   let p = embedding_4x3 () in
@@ -197,7 +198,8 @@ let test_layer_norm_init_shapes () =
   shape_is ~msg:"beta shape" [| 6 |] p.Layer_norm.beta;
   values_are ~msg:"gamma is ones" ~tol:0.0 (Array.make 6 1.0) p.Layer_norm.gamma;
   values_are ~msg:"beta is zeros" ~tol:0.0 (Array.make 6 0.0) p.Layer_norm.beta;
-  equal ~msg:"names" (list string) [ "gamma"; "beta" ] (Layer_norm.names p)
+  let paths = List.rev (Layer_norm.fold (fun path acc _ -> path :: acc) [] p) in
+  equal ~msg:"names" (list string) [ "gamma"; "beta" ] paths
 
 let test_layer_norm_analytic () =
   (* Per row: mean 1, variance 1, so x normalizes to [-1; 1] (up to eps), then
@@ -254,7 +256,7 @@ let test_layer_norm_gradients () =
     let y = Layer_norm.apply p x in
     Nx.sum (Nx.mul y y)
   in
-  grads_ok (Rune.check_grads (module Layer_norm64) loss p)
+  grads_ok (Rune.check_grads layer_norm64 loss p)
 
 let test_layer_norm_rejects_bad_input () =
   let p = Layer_norm.init ~dim:4 in

--- a/packages/kaun/test/test_layers.ml
+++ b/packages/kaun/test/test_layers.ml
@@ -27,9 +27,9 @@ module _ :
 (* Float64 instances for gradient checking; the layer traversals are
    dtype-generic, so each instance is just a type pin. *)
 
-let linear64 = Nx.Ptree.typed (module Linear)
-let embedding64 = Nx.Ptree.typed (module Embedding)
-let layer_norm64 = Nx.Ptree.typed (module Layer_norm)
+let linear64 = Nx.Ptree.instantiate (module Linear)
+let embedding64 = Nx.Ptree.instantiate (module Embedding)
+let layer_norm64 = Nx.Ptree.instantiate (module Layer_norm)
 
 let grads_ok = function Ok () -> () | Error m -> fail m
 let shape_is ?msg expected t = equal ?msg (array int) expected (Nx.shape t)

--- a/packages/kaun/test/test_pmap_dp.ml
+++ b/packages/kaun/test/test_pmap_dp.ml
@@ -25,7 +25,11 @@ let lr = 0.05
 (* The model: pre-norm causal self-attention with a residual, then a linear head
    over the vocabulary. *)
 
-type model = { ln : Layer_norm.t; attn : Attention.t; head : Linear.t }
+type model = {
+  ln : Nx.float32_t Layer_norm.t;
+  attn : Nx.float32_t Attention.t;
+  head : Nx.float32_t Linear.t;
+}
 
 module Model = struct
   type t = model

--- a/packages/kaun/test/test_stateful.ml
+++ b/packages/kaun/test/test_stateful.ml
@@ -108,10 +108,11 @@ let test_bn_grads_flow_to_params () =
     let y, _ = Batch_norm.apply p stats ~training:true x in
     Nx.sum (Nx.mul y y)
   in
-  (match Rune.check_grads ~tol:0.05 (module Batch_norm) f params with
+  let bn = Nx.Ptree.typed (module Batch_norm) in
+  (match Rune.check_grads ~tol:0.05 bn f params with
   | Ok () -> ()
   | Error msg -> failf "gradient check failed: %s" msg);
-  let grads = Rune.grad (module Batch_norm) f params in
+  let grads = Rune.grad bn f params in
   is_true ~msg:"gamma gradient is non-zero"
     (Array.exists
        (fun g -> Float.abs g > 1e-3)
@@ -164,19 +165,21 @@ let test_bn_init_validates () =
 (* The full training-step round trip: a model mixing stateless and stateful
    layers, stats threaded through value_and_grad_aux's aux channel. *)
 module Model = struct
-  type t = { lin : Linear.t; bn : Batch_norm.t; out : Linear.t }
+  type 'a t = { lin : 'a Linear.t; bn : 'a Batch_norm.t; out : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { lin; bn; out } =
-    { lin = Linear.map f lin; bn = Batch_norm.map f bn; out = Linear.map f out }
+  let map f { lin; bn; out } =
+    let lin = Linear.map f lin in
+    let bn = Batch_norm.map f bn in
+    let out = Linear.map f out in
+    { lin; bn; out }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
-    {
-      lin = Linear.map2 f p.lin q.lin;
-      bn = Batch_norm.map2 f p.bn q.bn;
-      out = Linear.map2 f p.out q.out;
-    }
+  let map2 f p q =
+    let lin = Linear.map2 f p.lin q.lin in
+    let bn = Batch_norm.map2 f p.bn q.bn in
+    let out = Linear.map2 f p.out q.out in
+    { lin; bn; out }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { lin; bn; out } =
+  let iter f { lin; bn; out } =
     Linear.iter f lin;
     Batch_norm.iter f bn;
     Linear.iter f out
@@ -187,6 +190,8 @@ module Model = struct
     let h = Nx.tanh h in
     (Linear.apply p.out h, stats)
 end
+
+let model = Nx.Ptree.typed (module Model)
 
 let test_bn_train_step_roundtrip () =
   Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->
@@ -206,14 +211,14 @@ let test_bn_train_step_roundtrip () =
       (Loss.mse pred y, stats')
     in
     let loss, grads, stats' =
-      Rune.value_and_grad_aux (module Model) objective params
+      Rune.value_and_grad_aux model objective params
     in
     let params, ostate =
-      Vega.adam_step (module Model) ~lr:0.02 ostate ~params ~grads
+      Vega.adam_step model ~lr:0.02 ostate ~params ~grads
     in
     ((params, stats', ostate), Nx.item [] loss)
   in
-  let state = ref (params, stats, Vega.adam_init (module Model) params) in
+  let state = ref (params, stats, Vega.adam_init model params) in
   let first = snd (step !state) in
   let last = ref first in
   for _ = 1 to 300 do

--- a/packages/kaun/test/test_stateful.ml
+++ b/packages/kaun/test/test_stateful.ml
@@ -184,6 +184,23 @@ module Model = struct
     Batch_norm.iter f bn;
     Linear.iter f out
 
+  let fold f acc { lin; bn; out } =
+    let acc = Linear.fold (fun p -> f ("lin." ^ p)) acc lin in
+    let acc = Batch_norm.fold (fun p -> f ("bn." ^ p)) acc bn in
+    Linear.fold (fun p -> f ("out." ^ p)) acc out
+
+  let fold2 f acc p q =
+    let acc = Linear.fold2 (fun s -> f ("lin." ^ s)) acc p.lin q.lin in
+    let acc = Batch_norm.fold2 (fun s -> f ("bn." ^ s)) acc p.bn q.bn in
+    Linear.fold2 (fun s -> f ("out." ^ s)) acc p.out q.out
+
+  let names p =
+    {
+      lin = Linear.map (( ^ ) "lin.") (Linear.names p.lin);
+      bn = Batch_norm.map (( ^ ) "bn.") (Batch_norm.names p.bn);
+      out = Linear.map (( ^ ) "out.") (Linear.names p.out);
+    }
+
   let forward p stats ~training x =
     let h = Linear.apply p.lin x in
     let h, stats = Batch_norm.apply p.bn stats ~training h in

--- a/packages/kaun/test/test_stateful.ml
+++ b/packages/kaun/test/test_stateful.ml
@@ -108,7 +108,7 @@ let test_bn_grads_flow_to_params () =
     let y, _ = Batch_norm.apply p stats ~training:true x in
     Nx.sum (Nx.mul y y)
   in
-  let bn = Nx.Ptree.instantiate (module Batch_norm) in
+  let bn = Kaun.ptree (module Batch_norm) in
   (match Rune.check_grads ~tol:0.05 bn f params with
   | Ok () -> ()
   | Error msg -> failf "gradient check failed: %s" msg);
@@ -208,7 +208,7 @@ module Model = struct
     (Linear.apply p.out h, stats)
 end
 
-let model = Nx.Ptree.instantiate (module Model)
+let model = Kaun.ptree (module Model)
 
 let test_bn_train_step_roundtrip () =
   Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->

--- a/packages/kaun/test/test_stateful.ml
+++ b/packages/kaun/test/test_stateful.ml
@@ -184,23 +184,6 @@ module Model = struct
     Batch_norm.iter f bn;
     Linear.iter f out
 
-  let fold f acc { lin; bn; out } =
-    let acc = Linear.fold (fun p -> f ("lin." ^ p)) acc lin in
-    let acc = Batch_norm.fold (fun p -> f ("bn." ^ p)) acc bn in
-    Linear.fold (fun p -> f ("out." ^ p)) acc out
-
-  let fold2 f acc p q =
-    let acc = Linear.fold2 (fun s -> f ("lin." ^ s)) acc p.lin q.lin in
-    let acc = Batch_norm.fold2 (fun s -> f ("bn." ^ s)) acc p.bn q.bn in
-    Linear.fold2 (fun s -> f ("out." ^ s)) acc p.out q.out
-
-  let names p =
-    {
-      lin = Linear.map (( ^ ) "lin.") (Linear.names p.lin);
-      bn = Batch_norm.map (( ^ ) "bn.") (Batch_norm.names p.bn);
-      out = Linear.map (( ^ ) "out.") (Linear.names p.out);
-    }
-
   let forward p stats ~training x =
     let h = Linear.apply p.lin x in
     let h, stats = Batch_norm.apply p.bn stats ~training h in

--- a/packages/kaun/test/test_stateful.ml
+++ b/packages/kaun/test/test_stateful.ml
@@ -108,7 +108,7 @@ let test_bn_grads_flow_to_params () =
     let y, _ = Batch_norm.apply p stats ~training:true x in
     Nx.sum (Nx.mul y y)
   in
-  let bn = Nx.Ptree.typed (module Batch_norm) in
+  let bn = Nx.Ptree.instantiate (module Batch_norm) in
   (match Rune.check_grads ~tol:0.05 bn f params with
   | Ok () -> ()
   | Error msg -> failf "gradient check failed: %s" msg);
@@ -191,7 +191,7 @@ module Model = struct
     (Linear.apply p.out h, stats)
 end
 
-let model = Nx.Ptree.typed (module Model)
+let model = Nx.Ptree.instantiate (module Model)
 
 let test_bn_train_step_roundtrip () =
   Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->

--- a/packages/munin/examples/x-kaun-mnist-jit/main.ml
+++ b/packages/munin/examples/x-kaun-mnist-jit/main.ml
@@ -96,7 +96,7 @@ module Cnn = struct
     Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
 
-let cnn = Nx.Ptree.instantiate (module Cnn)
+let cnn = Kaun.ptree (module Cnn)
 
 (* The jitted step's input: the batch joins the parameters as leaves — values
    that change between calls must be inputs, never captures. *)

--- a/packages/munin/examples/x-kaun-mnist-jit/main.ml
+++ b/packages/munin/examples/x-kaun-mnist-jit/main.ml
@@ -96,7 +96,7 @@ module Cnn = struct
     Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
 
-let cnn = Nx.Ptree.typed (module Cnn)
+let cnn = Nx.Ptree.instantiate (module Cnn)
 
 (* The jitted step's input: the batch joins the parameters as leaves — values
    that change between calls must be inputs, never captures. *)

--- a/packages/munin/examples/x-kaun-mnist-jit/main.ml
+++ b/packages/munin/examples/x-kaun-mnist-jit/main.ml
@@ -45,38 +45,47 @@ let speclist =
    (the Nx.Ptree.S contract plus checkpoint names). *)
 
 module Cnn = struct
-  type t = { c1 : Conv.t; c2 : Conv.t; l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { c1 : 'a Conv.t; c2 : 'a Conv.t; l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { c1; c2; l1; l2 } =
-    {
-      c1 = Conv.map f c1;
-      c2 = Conv.map f c2;
-      l1 = Linear.map f l1;
-      l2 = Linear.map f l2;
-    }
+  let map f { c1; c2; l1; l2 } =
+    let c1 = Conv.map f c1 in
+    let c2 = Conv.map f c2 in
+    let l1 = Linear.map f l1 in
+    let l2 = Linear.map f l2 in
+    { c1; c2; l1; l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
-    {
-      c1 = Conv.map2 f p.c1 q.c1;
-      c2 = Conv.map2 f p.c2 q.c2;
-      l1 = Linear.map2 f p.l1 q.l1;
-      l2 = Linear.map2 f p.l2 q.l2;
-    }
+  let map2 f p q =
+    let c1 = Conv.map2 f p.c1 q.c1 in
+    let c2 = Conv.map2 f p.c2 q.c2 in
+    let l1 = Linear.map2 f p.l1 q.l1 in
+    let l2 = Linear.map2 f p.l2 q.l2 in
+    { c1; c2; l1; l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { c1; c2; l1; l2 } =
+  let iter f { c1; c2; l1; l2 } =
     Conv.iter f c1;
     Conv.iter f c2;
     Linear.iter f l1;
     Linear.iter f l2
 
-  let names { c1; c2; l1; l2 } =
-    List.concat
-      [
-        List.map (( ^ ) "c1.") (Conv.names c1);
-        List.map (( ^ ) "c2.") (Conv.names c2);
-        List.map (( ^ ) "l1.") (Linear.names l1);
-        List.map (( ^ ) "l2.") (Linear.names l2);
-      ]
+  let fold f acc { c1; c2; l1; l2 } =
+    let acc = Conv.fold (fun p -> f ("c1." ^ p)) acc c1 in
+    let acc = Conv.fold (fun p -> f ("c2." ^ p)) acc c2 in
+    let acc = Linear.fold (fun p -> f ("l1." ^ p)) acc l1 in
+    Linear.fold (fun p -> f ("l2." ^ p)) acc l2
+
+  let fold2 f acc p q =
+    let acc = Conv.fold2 (fun s -> f ("c1." ^ s)) acc p.c1 q.c1 in
+    let acc = Conv.fold2 (fun s -> f ("c2." ^ s)) acc p.c2 q.c2 in
+    let acc = Linear.fold2 (fun s -> f ("l1." ^ s)) acc p.l1 q.l1 in
+    Linear.fold2 (fun s -> f ("l2." ^ s)) acc p.l2 q.l2
+
+  let names p =
+    {
+      c1 = Conv.map (( ^ ) "c1.") (Conv.names p.c1);
+      c2 = Conv.map (( ^ ) "c2.") (Conv.names p.c2);
+      l1 = Linear.map (( ^ ) "l1.") (Linear.names p.l1);
+      l2 = Linear.map (( ^ ) "l2.") (Linear.names p.l2);
+    }
 
   let apply p x =
     let x = Fn.relu (Conv.apply ~padding:`Same p.c1 x) in
@@ -87,11 +96,13 @@ module Cnn = struct
     Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
 
+let cnn = Nx.Ptree.typed (module Cnn)
+
 (* The jitted step's input: the batch joins the parameters as leaves — values
    that change between calls must be inputs, never captures. *)
 module Step_in = struct
   type t = {
-    params : Cnn.t;
+    params : Nx.float32_t Cnn.t;
     x : (float, Nx.float32_elt) Nx.t;
     y : (int32, Nx.int32_elt) Nx.t;
   }
@@ -109,7 +120,7 @@ module Step_in = struct
 end
 
 module Step_out = struct
-  type t = { params : Cnn.t; loss : (float, Nx.float32_elt) Nx.t }
+  type t = { params : Nx.float32_t Cnn.t; loss : (float, Nx.float32_elt) Nx.t }
 
   let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) t =
     { params = Cnn.map f t.params; loss = f t.loss }
@@ -123,7 +134,7 @@ module Step_out = struct
 end
 
 module Eval_in = struct
-  type t = { params : Cnn.t; x : (float, Nx.float32_elt) Nx.t }
+  type t = { params : Nx.float32_t Cnn.t; x : (float, Nx.float32_elt) Nx.t }
 
   let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) t =
     { params = Cnn.map f t.params; x = f t.x }
@@ -153,7 +164,7 @@ let () =
         l2 = Linear.init ~inputs:128 ~outputs:10;
       }
   in
-  let state = Vega.sgd_init (module Cnn) !params in
+  let state = Vega.sgd_init cnn !params in
   let n_params =
     let n = ref 0 in
     let count : 'a 'b. ('a, 'b) Nx.t -> unit = fun t -> n := !n + Nx.numel t in
@@ -204,8 +215,8 @@ let () =
      so training never round-trips them through the host. *)
   let train_step { Step_in.params; x; y } =
     let loss_fn p = Loss.softmax_cross_entropy_sparse (Cnn.apply p x) y in
-    let loss, grads = Rune.value_and_grad (module Cnn) loss_fn params in
-    let params, _ = Vega.sgd_step (module Cnn) ~lr:!lr state ~params ~grads in
+    let loss, grads = Rune.value_and_grad cnn loss_fn params in
+    let params, _ = Vega.sgd_step cnn ~lr:!lr state ~params ~grads in
     { Step_out.params; loss }
   in
   let step =

--- a/packages/munin/examples/x-kaun-mnist/main.ml
+++ b/packages/munin/examples/x-kaun-mnist/main.ml
@@ -21,38 +21,47 @@ let lr = 0.001
    (the Nx.Ptree.S contract plus checkpoint names). *)
 
 module Cnn = struct
-  type t = { c1 : Conv.t; c2 : Conv.t; l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { c1 : 'a Conv.t; c2 : 'a Conv.t; l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { c1; c2; l1; l2 } =
-    {
-      c1 = Conv.map f c1;
-      c2 = Conv.map f c2;
-      l1 = Linear.map f l1;
-      l2 = Linear.map f l2;
-    }
+  let map f { c1; c2; l1; l2 } =
+    let c1 = Conv.map f c1 in
+    let c2 = Conv.map f c2 in
+    let l1 = Linear.map f l1 in
+    let l2 = Linear.map f l2 in
+    { c1; c2; l1; l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
-    {
-      c1 = Conv.map2 f p.c1 q.c1;
-      c2 = Conv.map2 f p.c2 q.c2;
-      l1 = Linear.map2 f p.l1 q.l1;
-      l2 = Linear.map2 f p.l2 q.l2;
-    }
+  let map2 f p q =
+    let c1 = Conv.map2 f p.c1 q.c1 in
+    let c2 = Conv.map2 f p.c2 q.c2 in
+    let l1 = Linear.map2 f p.l1 q.l1 in
+    let l2 = Linear.map2 f p.l2 q.l2 in
+    { c1; c2; l1; l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { c1; c2; l1; l2 } =
+  let iter f { c1; c2; l1; l2 } =
     Conv.iter f c1;
     Conv.iter f c2;
     Linear.iter f l1;
     Linear.iter f l2
 
-  let names { c1; c2; l1; l2 } =
-    List.concat
-      [
-        List.map (( ^ ) "c1.") (Conv.names c1);
-        List.map (( ^ ) "c2.") (Conv.names c2);
-        List.map (( ^ ) "l1.") (Linear.names l1);
-        List.map (( ^ ) "l2.") (Linear.names l2);
-      ]
+  let fold f acc { c1; c2; l1; l2 } =
+    let acc = Conv.fold (fun p -> f ("c1." ^ p)) acc c1 in
+    let acc = Conv.fold (fun p -> f ("c2." ^ p)) acc c2 in
+    let acc = Linear.fold (fun p -> f ("l1." ^ p)) acc l1 in
+    Linear.fold (fun p -> f ("l2." ^ p)) acc l2
+
+  let fold2 f acc p q =
+    let acc = Conv.fold2 (fun s -> f ("c1." ^ s)) acc p.c1 q.c1 in
+    let acc = Conv.fold2 (fun s -> f ("c2." ^ s)) acc p.c2 q.c2 in
+    let acc = Linear.fold2 (fun s -> f ("l1." ^ s)) acc p.l1 q.l1 in
+    Linear.fold2 (fun s -> f ("l2." ^ s)) acc p.l2 q.l2
+
+  let names p =
+    {
+      c1 = Conv.map (( ^ ) "c1.") (Conv.names p.c1);
+      c2 = Conv.map (( ^ ) "c2.") (Conv.names p.c2);
+      l1 = Linear.map (( ^ ) "l1.") (Linear.names p.l1);
+      l2 = Linear.map (( ^ ) "l2.") (Linear.names p.l2);
+    }
 
   let apply p x =
     let x = Fn.relu (Conv.apply ~padding:`Same p.c1 x) in
@@ -62,6 +71,8 @@ module Cnn = struct
     let x = Nx.reshape [| (Nx.shape x).(0); 32 * 7 * 7 |] x in
     Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
+
+let cnn = Nx.Ptree.typed (module Cnn)
 
 let () =
   Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->
@@ -104,14 +115,14 @@ let () =
         l2 = Linear.init ~inputs:128 ~outputs:10;
       }
   in
-  let ostate = ref (Vega.adam_init (module Cnn) !params) in
+  let ostate = ref (Vega.adam_init cnn !params) in
 
   (* Training step: value_and_grad + one Adam update. *)
   let train_step (x, y) =
     let loss_fn p = Loss.softmax_cross_entropy_sparse (Cnn.apply p x) y in
-    let l, grads = Rune.value_and_grad (module Cnn) loss_fn !params in
+    let l, grads = Rune.value_and_grad cnn loss_fn !params in
     let params', ostate' =
-      Vega.adam_step (module Cnn) ~lr !ostate ~params:!params ~grads
+      Vega.adam_step cnn ~lr !ostate ~params:!params ~grads
     in
     params := params';
     ostate := ostate';

--- a/packages/munin/examples/x-kaun-mnist/main.ml
+++ b/packages/munin/examples/x-kaun-mnist/main.ml
@@ -72,7 +72,7 @@ module Cnn = struct
     Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
 
-let cnn = Nx.Ptree.typed (module Cnn)
+let cnn = Nx.Ptree.instantiate (module Cnn)
 
 let () =
   Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->

--- a/packages/munin/examples/x-kaun-mnist/main.ml
+++ b/packages/munin/examples/x-kaun-mnist/main.ml
@@ -72,7 +72,7 @@ module Cnn = struct
     Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
 
-let cnn = Nx.Ptree.instantiate (module Cnn)
+let cnn = Kaun.ptree (module Cnn)
 
 let () =
   Nx.Rng.with_key (Nx.Rng.key 42) @@ fun () ->

--- a/packages/nx/examples/08-signal-processing/README.md
+++ b/packages/nx/examples/08-signal-processing/README.md
@@ -28,7 +28,7 @@ dune exec nx/examples/08-signal-processing/main.exe
 | `magnitude dtype z`           | Element-wise modulus of a complex spectrum        |
 | `linspace dtype start stop n` | Evenly spaced time samples                        |
 | `sin t`                       | Element-wise sine                                 |
-| `Rng.normal ~key dtype shape` | Gaussian noise                                    |
+| `randn dtype shape`           | Gaussian noise from the ambient `Rng` scope       |
 | `Nx.Infix` (`+`, `*`, `*$`)   | Clean arithmetic on arrays                        |
 
 ## Output Walkthrough

--- a/packages/nx/lib/ptree.ml
+++ b/packages/nx/lib/ptree.ml
@@ -29,6 +29,8 @@ module type Uniform = sig
 
   val fold2 :
     (string -> 'acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
+
+  val names : 'a t -> string t
 end
 
 module Make (U : Uniform) = struct

--- a/packages/nx/lib/ptree.ml
+++ b/packages/nx/lib/ptree.ml
@@ -19,7 +19,7 @@ end
 
 type tensor = P : ('a, 'b) Nx_effect.t -> tensor
 
-module type Gtree = sig
+module type Uniform = sig
   type 'a t
 
   val map : ('a -> 'b) -> 'a t -> 'b t
@@ -31,7 +31,7 @@ module type Gtree = sig
     (string -> 'acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
 end
 
-module Tensor_tree (U : Gtree) = struct
+module Make (U : Uniform) = struct
   type t = tensor U.t
 
   let map (f : 'a 'b. ('a, 'b) Nx_effect.t -> ('a, 'b) Nx_effect.t) (t : t) : t
@@ -49,7 +49,7 @@ module Tensor_tree (U : Gtree) = struct
           Nx_core.Dtype.equal_witness (Nx_effect.dtype x) (Nx_effect.dtype y)
         with
         | Some Type.Equal -> P (f x y)
-        | None -> invalid_arg "Ptree.Tensor_tree.map2: leaf dtype mismatch")
+        | None -> invalid_arg "Ptree.Make.map2: leaf dtype mismatch")
       a b
 
   let iter (f : 'a 'b. ('a, 'b) Nx_effect.t -> unit) (t : t) : unit =

--- a/packages/nx/lib/ptree.ml
+++ b/packages/nx/lib/ptree.ml
@@ -19,12 +19,17 @@ end
 
 type tensor = P : ('a, 'b) Nx_effect.t -> tensor
 
-module type Uniform = sig
+module type Traverse = sig
   type 'a t
 
   val map : ('a -> 'b) -> 'a t -> 'b t
   val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
   val iter : ('a -> unit) -> 'a t -> unit
+end
+
+module type Uniform = sig
+  include Traverse
+
   val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
 
   val fold2 :
@@ -33,7 +38,7 @@ module type Uniform = sig
   val names : 'a t -> string t
 end
 
-module Make (U : Uniform) = struct
+module Make (U : Traverse) = struct
   type t = tensor U.t
 
   let map (f : 'a 'b. ('a, 'b) Nx_effect.t -> ('a, 'b) Nx_effect.t) (t : t) : t
@@ -58,7 +63,7 @@ module Make (U : Uniform) = struct
     U.iter (fun (P x) -> f x) t
 end
 
-let typed (type a b) (module U : Uniform) :
+let typed (type a b) (module U : Traverse) :
     (module S with type t = (a, b) Nx_effect.t U.t) =
   (module struct
     type t = (a, b) Nx_effect.t U.t

--- a/packages/nx/lib/ptree.ml
+++ b/packages/nx/lib/ptree.ml
@@ -19,17 +19,12 @@ end
 
 type tensor = P : ('a, 'b) Nx_effect.t -> tensor
 
-module type Traverse = sig
+module type Uniform = sig
   type 'a t
 
   val map : ('a -> 'b) -> 'a t -> 'b t
   val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
   val iter : ('a -> unit) -> 'a t -> unit
-end
-
-module type Uniform = sig
-  include Traverse
-
   val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
 
   val fold2 :
@@ -38,7 +33,7 @@ module type Uniform = sig
   val names : 'a t -> string t
 end
 
-module Make (U : Traverse) = struct
+module Make (U : Uniform) = struct
   type t = tensor U.t
 
   let map (f : 'a 'b. ('a, 'b) Nx_effect.t -> ('a, 'b) Nx_effect.t) (t : t) : t
@@ -63,7 +58,7 @@ module Make (U : Traverse) = struct
     U.iter (fun (P x) -> f x) t
 end
 
-let instantiate (type a b) (module U : Traverse) :
+let instantiate (type a b) (module U : Uniform) :
     (module S with type t = (a, b) Nx_effect.t U.t) =
   (module struct
     type t = (a, b) Nx_effect.t U.t

--- a/packages/nx/lib/ptree.ml
+++ b/packages/nx/lib/ptree.ml
@@ -19,12 +19,17 @@ end
 
 type tensor = P : ('a, 'b) Nx_effect.t -> tensor
 
-module type Uniform = sig
+module type Traverse = sig
   type 'a t
 
   val map : ('a -> 'b) -> 'a t -> 'b t
   val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
   val iter : ('a -> unit) -> 'a t -> unit
+end
+
+module type Uniform = sig
+  include Traverse
+
   val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
 
   val fold2 :
@@ -33,7 +38,7 @@ module type Uniform = sig
   val names : 'a t -> string t
 end
 
-module Make (U : Uniform) = struct
+module Make (U : Traverse) = struct
   type t = tensor U.t
 
   let map (f : 'a 'b. ('a, 'b) Nx_effect.t -> ('a, 'b) Nx_effect.t) (t : t) : t
@@ -58,7 +63,7 @@ module Make (U : Uniform) = struct
     U.iter (fun (P x) -> f x) t
 end
 
-let instantiate (type a b) (module U : Uniform) :
+let instantiate (type a b) (module U : Traverse) :
     (module S with type t = (a, b) Nx_effect.t U.t) =
   (module struct
     type t = (a, b) Nx_effect.t U.t

--- a/packages/nx/lib/ptree.ml
+++ b/packages/nx/lib/ptree.ml
@@ -91,50 +91,97 @@ let unpack ?(at = "") (type a b) (dt : (a, b) Nx_core.Dtype.t) (p : tensor) :
           in
           invalid_arg msg)
 
-type t = Tensor of tensor | List of t list | Dict of (string * t) list
+module Tree = struct
+  type 'a t = Leaf of 'a | List of 'a t list | Dict of (string * 'a t) list
 
-let tensor x = Tensor (P x)
-let list ts = List ts
-let dict kvs = Dict kvs
+  let rec map f = function
+    | Leaf x -> Leaf (f x)
+    | List ts -> List (List.map (map f) ts)
+    | Dict kvs -> Dict (List.map (fun (k, v) -> (k, map f v)) kvs)
 
-let rec map (f : 'a 'b. ('a, 'b) Nx_effect.t -> ('a, 'b) Nx_effect.t) (t : t) :
-    t =
-  match t with
-  | Tensor (P x) -> Tensor (P (f x))
-  | List ts -> List (List.map (map f) ts)
-  | Dict kvs -> Dict (List.map (fun (k, v) -> (k, map f v)) kvs)
+  let rec map2 f a b =
+    match (a, b) with
+    | Leaf x, Leaf y -> Leaf (f x y)
+    | List xs, List ys ->
+        if List.length xs <> List.length ys then
+          invalid_arg "Ptree.Tree.map2: list length mismatch"
+        else List (List.map2 (map2 f) xs ys)
+    | Dict xs, Dict ys ->
+        if List.length xs <> List.length ys then
+          invalid_arg "Ptree.Tree.map2: dict size mismatch"
+        else
+          Dict
+            (List.map2
+               (fun (k1, v1) (k2, v2) ->
+                 if not (String.equal k1 k2) then
+                   invalid_arg "Ptree.Tree.map2: dict key mismatch"
+                 else (k1, map2 f v1 v2))
+               xs ys)
+    | _ -> invalid_arg "Ptree.Tree.map2: structure mismatch"
 
-let rec map2
-    (f :
-      'a 'b.
-      ('a, 'b) Nx_effect.t -> ('a, 'b) Nx_effect.t -> ('a, 'b) Nx_effect.t)
-    (a : t) (b : t) : t =
-  match (a, b) with
-  | Tensor (P x), Tensor (P y) -> (
-      match
-        Nx_core.Dtype.equal_witness (Nx_effect.dtype x) (Nx_effect.dtype y)
-      with
-      | Some Type.Equal -> Tensor (P (f x y))
-      | None -> invalid_arg "Ptree.map2: leaf dtype mismatch")
-  | List xs, List ys ->
-      if List.length xs <> List.length ys then
-        invalid_arg "Ptree.map2: list length mismatch"
-      else List (List.map2 (map2 f) xs ys)
-  | Dict xs, Dict ys ->
-      if List.length xs <> List.length ys then
-        invalid_arg "Ptree.map2: dict size mismatch"
-      else
-        Dict
-          (List.map2
-             (fun (k1, v1) (k2, v2) ->
-               if not (String.equal k1 k2) then
-                 invalid_arg "Ptree.map2: dict key mismatch"
-               else (k1, map2 f v1 v2))
-             xs ys)
-  | _ -> invalid_arg "Ptree.map2: structure mismatch"
+  let rec iter f = function
+    | Leaf x -> f x
+    | List ts -> List.iter (iter f) ts
+    | Dict kvs -> List.iter (fun (_, v) -> iter f v) kvs
 
-let rec iter (f : 'a 'b. ('a, 'b) Nx_effect.t -> unit) (t : t) : unit =
-  match t with
-  | Tensor (P x) -> f x
-  | List ts -> List.iter (iter f) ts
-  | Dict kvs -> List.iter (fun (_, v) -> iter f v) kvs
+  let join prefix seg = if prefix = "" then seg else prefix ^ "." ^ seg
+
+  let fold f acc t =
+    let rec go prefix acc = function
+      | Leaf x -> f prefix acc x
+      | List ts ->
+          snd
+            (List.fold_left
+               (fun (i, acc) v ->
+                 (i + 1, go (join prefix (string_of_int i)) acc v))
+               (0, acc) ts)
+      | Dict kvs ->
+          List.fold_left (fun acc (k, v) -> go (join prefix k) acc v) acc kvs
+    in
+    go "" acc t
+
+  let fold2 f acc a b =
+    let rec go prefix acc a b =
+      match (a, b) with
+      | Leaf x, Leaf y -> f prefix acc x y
+      | List xs, List ys ->
+          if List.length xs <> List.length ys then
+            invalid_arg "Ptree.Tree.fold2: list length mismatch"
+          else
+            snd
+              (List.fold_left2
+                 (fun (i, acc) x y ->
+                   (i + 1, go (join prefix (string_of_int i)) acc x y))
+                 (0, acc) xs ys)
+      | Dict xs, Dict ys ->
+          if List.length xs <> List.length ys then
+            invalid_arg "Ptree.Tree.fold2: dict size mismatch"
+          else
+            List.fold_left2
+              (fun acc (k1, v1) (k2, v2) ->
+                if not (String.equal k1 k2) then
+                  invalid_arg "Ptree.Tree.fold2: dict key mismatch"
+                else go (join prefix k1) acc v1 v2)
+              acc xs ys
+      | _ -> invalid_arg "Ptree.Tree.fold2: structure mismatch"
+    in
+    go "" acc a b
+
+  let names t =
+    let rec go prefix = function
+      | Leaf _ -> Leaf prefix
+      | List ts ->
+          List (List.mapi (fun i v -> go (join prefix (string_of_int i)) v) ts)
+      | Dict kvs ->
+          Dict (List.map (fun (k, v) -> (k, go (join prefix k) v)) kvs)
+    in
+    go "" t
+end
+
+type t = tensor Tree.t
+
+let tensor x = Tree.Leaf (P x)
+let list ts = Tree.List ts
+let dict kvs = Tree.Dict kvs
+
+include (Make (Tree) : S with type t := t)

--- a/packages/nx/lib/ptree.ml
+++ b/packages/nx/lib/ptree.ml
@@ -63,7 +63,7 @@ module Make (U : Traverse) = struct
     U.iter (fun (P x) -> f x) t
 end
 
-let typed (type a b) (module U : Traverse) :
+let instantiate (type a b) (module U : Traverse) :
     (module S with type t = (a, b) Nx_effect.t U.t) =
   (module struct
     type t = (a, b) Nx_effect.t U.t

--- a/packages/nx/lib/ptree.ml
+++ b/packages/nx/lib/ptree.ml
@@ -58,6 +58,26 @@ module Make (U : Uniform) = struct
     U.iter (fun (P x) -> f x) t
 end
 
+let typed (type a b) (module U : Uniform) :
+    (module S with type t = (a, b) Nx_effect.t U.t) =
+  (module struct
+    type t = (a, b) Nx_effect.t U.t
+
+    let map (f : 'p 'q. ('p, 'q) Nx_effect.t -> ('p, 'q) Nx_effect.t) (t : t) :
+        t =
+      U.map (fun x -> f x) t
+
+    let map2
+        (f :
+          'p 'q.
+          ('p, 'q) Nx_effect.t -> ('p, 'q) Nx_effect.t -> ('p, 'q) Nx_effect.t)
+        (a : t) (b : t) : t =
+      U.map2 (fun x y -> f x y) a b
+
+    let iter (f : 'p 'q. ('p, 'q) Nx_effect.t -> unit) (t : t) : unit =
+      U.iter (fun x -> f x) t
+  end)
+
 let unpack ?(at = "") (type a b) (dt : (a, b) Nx_core.Dtype.t) (p : tensor) :
     (a, b) Nx_effect.t =
   match p with

--- a/packages/nx/lib/ptree.ml
+++ b/packages/nx/lib/ptree.ml
@@ -18,6 +18,57 @@ module type S = sig
 end
 
 type tensor = P : ('a, 'b) Nx_effect.t -> tensor
+
+module type Gtree = sig
+  type 'a t
+
+  val map : ('a -> 'b) -> 'a t -> 'b t
+  val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+  val iter : ('a -> unit) -> 'a t -> unit
+  val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+
+  val fold2 :
+    (string -> 'acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
+end
+
+module Tensor_tree (U : Gtree) = struct
+  type t = tensor U.t
+
+  let map (f : 'a 'b. ('a, 'b) Nx_effect.t -> ('a, 'b) Nx_effect.t) (t : t) : t
+      =
+    U.map (fun (P x) -> P (f x)) t
+
+  let map2
+      (f :
+        'a 'b.
+        ('a, 'b) Nx_effect.t -> ('a, 'b) Nx_effect.t -> ('a, 'b) Nx_effect.t)
+      (a : t) (b : t) : t =
+    U.map2
+      (fun (P x) (P y) ->
+        match
+          Nx_core.Dtype.equal_witness (Nx_effect.dtype x) (Nx_effect.dtype y)
+        with
+        | Some Type.Equal -> P (f x y)
+        | None -> invalid_arg "Ptree.Tensor_tree.map2: leaf dtype mismatch")
+      a b
+
+  let iter (f : 'a 'b. ('a, 'b) Nx_effect.t -> unit) (t : t) : unit =
+    U.iter (fun (P x) -> f x) t
+end
+
+let unpack ?(at = "") (type a b) (dt : (a, b) Nx_core.Dtype.t) (p : tensor) :
+    (a, b) Nx_effect.t =
+  match p with
+  | P x -> (
+      match Nx_core.Dtype.equal_witness (Nx_effect.dtype x) dt with
+      | Some Type.Equal -> x
+      | None ->
+          let msg =
+            if at = "" then "Ptree.unpack: dtype mismatch"
+            else "Ptree.unpack: dtype mismatch at " ^ at
+          in
+          invalid_arg msg)
+
 type t = Tensor of tensor | List of t list | Dict of (string * t) list
 
 let tensor x = Tensor (P x)

--- a/packages/nx/lib/ptree.mli
+++ b/packages/nx/lib/ptree.mli
@@ -112,6 +112,18 @@ end
     is [tensor U.t], and its traversals check leafwise that dtypes agree. *)
 module Make (U : Uniform) : S with type t = tensor U.t
 
+val typed :
+  (module U : Uniform) -> (module S with type t = ('a, 'b) Nx_effect.t U.t)
+(** [typed (module U)] is the parameter tree over [U] at a single tensor type:
+    the structure instantiated at typed leaves, satisfying {!S} with no packing.
+    Bind it once per structure and pass it wherever a first-class {!S} module is
+    expected:
+
+    {[
+      let mlp = Nx.Ptree.typed (module Mlp) in
+      let grads = grad mlp loss params
+    ]} *)
+
 val unpack :
   ?at:string -> ('a, 'b) Nx_core.Dtype.t -> tensor -> ('a, 'b) Nx_effect.t
 (** [unpack ?at dt p] unpacks the packed tensor [p] and returns it with the

--- a/packages/nx/lib/ptree.mli
+++ b/packages/nx/lib/ptree.mli
@@ -62,11 +62,15 @@ type tensor =
       the structure of [t].
     - [map2 f a b] applies [f] to corresponding payloads of [a] and [b], which
       must be structurally equal.
-    - [iter f t] applies [f] to every payload of [t] exactly once, in a stable
-      order.
-    - [fold f acc t] visits every payload in stable order; the [string] argument
-      is the path to the current position.
-    - [fold2] is like [fold] but across two structurally equal trees. *)
+    - [iter f t] applies [f] to every payload of [t] exactly once.
+    - [fold f acc t] visits every payload; the [string] argument is the path to
+      the current position.
+    - [fold2] is like [fold] but across two structurally equal trees.
+    - [names t] is [t] with every payload replaced by its path, so
+      [names (map f t)] is [names t].
+    - Every traversal visits the payloads of a value in the same order: [map],
+      [iter], [fold], and [names] agree on the payload sequence, and [map2] and
+      [fold2] visit corresponding pairs in that order. *)
 module type Uniform = sig
   type 'a t
   (** The structure type, parameterised by the uniform payload type. *)
@@ -98,6 +102,10 @@ module type Uniform = sig
   (** [fold2 f acc a b] is like {!fold} but across two structurally equal trees.
 
       Raises [Invalid_argument] if [a] and [b] are not structurally equal. *)
+
+  val names : 'a t -> string t
+  (** [names t] is [t] with every payload replaced by its path (see {!fold} for
+      the path convention). *)
 end
 
 (** [Make (U)] is the parameter tree over [U] with packed tensor leaves: its [t]

--- a/packages/nx/lib/ptree.mli
+++ b/packages/nx/lib/ptree.mli
@@ -9,7 +9,8 @@
     autodiff transformations, structural optimizers and checkpointing all
     operate on any structure implementing it — typically a record of tensors
     with hand-written one-line traversals. The concrete {!type:t} is the stock
-    instance for structures only known at runtime. *)
+    instance for structures only known at runtime, and {!module-Make} derives an
+    instance from any payload-generic structure ({!module-type:Uniform}). *)
 
 (** Structures whose tensor leaves can be traversed.
 
@@ -44,14 +45,17 @@ type tensor =
   | P : ('a, 'b) Nx_effect.t -> tensor
       (** A packed tensor. The wrapper hides dtype and layout parameters. *)
 
-(** Uniform homomorphic structures.
+(** Structures with a uniform payload.
 
-    A [('a, Gtree).t] is a structure whose payload positions are all of type
-    ['a] — the "higher-kinded data" (HKD) shape that enables polymorphic
-    traversals like [map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t].
+    An ['a t] satisfying {!module-type:Uniform} is a structure whose payload
+    positions all have type ['a]. Instantiating the payload turns one
+    declaration into a family of trees — the model itself and any
+    parameter-shaped data (masks, symmetries, per-leaf learning rates) — with
+    type-changing traversals like
+    [map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t] connecting them.
 
-    The classic {!module-type:S} is the rank-2 bridge over packed tensor leaves;
-    {!module-Tensor_tree} converts any {!Gtree} into an {!S}.
+    {!module-type:S} is the same structure specialised to packed tensor leaves;
+    {!module-Make} converts any {!module-type:Uniform} into an {!S}.
 
     Implementations must satisfy:
     - [map f t] applies [f] to every payload of [t] exactly once and preserves
@@ -61,9 +65,9 @@ type tensor =
     - [iter f t] applies [f] to every payload of [t] exactly once, in a stable
       order.
     - [fold f acc t] visits every payload in stable order; the [string] argument
-      is the dotted path to the current position.
-    - [fold2] is like {!fold} but across two structurally equal trees. *)
-module type Gtree = sig
+      is the path to the current position.
+    - [fold2] is like [fold] but across two structurally equal trees. *)
+module type Uniform = sig
   type 'a t
   (** The structure type, parameterised by the uniform payload type. *)
 
@@ -79,13 +83,15 @@ module type Gtree = sig
   (** [iter f t] applies [f] to every payload leaf of [t]. *)
 
   val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
-  (** [fold f acc t] reduces [t] to an accumulator, threading a dotted path to
-      each payload leaf. The path convention (stable for JIT caching):
+  (** [fold f acc t] reduces [t] to an accumulator, threading the path of each
+      payload leaf. A path is the dot-joined sequence of record field names and
+      container indices from the root to the leaf, matching the checkpoint
+      naming convention:
 
-      - Root starts at [""].
-      - Record field [w] appends [".w"] under the parent path.
-      - List / array at index [i] appends [".i"].
-      - Option [Some x] keeps the path unchanged; [None] skips. *)
+      - A record field contributes its name, a list or array element its
+        zero-based index; segments are joined with ["."] (e.g. ["layers.0.w"]).
+      - [Some x] contributes nothing; [None] skips the payload.
+      - A payload at the root has the empty path. *)
 
   val fold2 :
     (string -> 'acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
@@ -94,10 +100,9 @@ module type Gtree = sig
       Raises [Invalid_argument] if [a] and [b] are not structurally equal. *)
 end
 
-(** [Tensor_tree (U)] bridges a uniform {!Gtree} to the rank-2 {!S} interface by
-    packing every payload leaf as {!tensor}. The resulting [t] is [tensor U.t].
-*)
-module Tensor_tree (U : Gtree) : S with type t = tensor U.t
+(** [Make (U)] is the parameter tree over [U] with packed tensor leaves: its [t]
+    is [tensor U.t], and its traversals check leafwise that dtypes agree. *)
+module Make (U : Uniform) : S with type t = tensor U.t
 
 val unpack :
   ?at:string -> ('a, 'b) Nx_core.Dtype.t -> tensor -> ('a, 'b) Nx_effect.t

--- a/packages/nx/lib/ptree.mli
+++ b/packages/nx/lib/ptree.mli
@@ -55,8 +55,8 @@ type tensor =
     [map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t] connecting them.
 
     {!module-type:S} is the same structure specialised to packed tensor leaves;
-    {!module-Make} and {!val-typed} convert any {!module-type:Traverse} into an
-    {!S}. {!module-type:Uniform} extends the core with leaf paths.
+    {!module-Make} and {!val-instantiate} convert any {!module-type:Traverse}
+    into an {!S}. {!module-type:Uniform} extends the core with leaf paths.
 
     Implementations must satisfy:
     - [map f t] applies [f] to every payload of [t] exactly once and preserves
@@ -123,17 +123,21 @@ end
     is [tensor U.t], and its traversals check leafwise that dtypes agree. *)
 module Make (U : Traverse) : S with type t = tensor U.t
 
-val typed :
+val instantiate :
   (module U : Traverse) -> (module S with type t = ('a, 'b) Nx_effect.t U.t)
-(** [typed (module U)] is the parameter tree over [U] at a single tensor type:
-    the structure instantiated at typed leaves, satisfying {!S} with no packing.
-    Bind it once per structure and pass it wherever a first-class {!S} module is
-    expected:
+(** [instantiate (module U)] fills a payload-generic structure's hole at a
+    single tensor type: the result satisfies {!S} with typed leaves and no
+    packing. Bind it once per model and pass the value to the transformations:
 
     {[
-      let mlp = Nx.Ptree.typed (module Mlp) in
+      let mlp = Nx.Ptree.instantiate (module Mlp) in
       let grads = grad mlp loss params
-    ]} *)
+    ]}
+
+    Transformations only walk tensor leaves, so they take this instantiated
+    walker. Checkpointing also names leaves, and names come from the
+    structure's shape, so it takes the structure's module itself (see
+    [Kaun.Checkpoint]). *)
 
 val unpack :
   ?at:string -> ('a, 'b) Nx_core.Dtype.t -> tensor -> ('a, 'b) Nx_effect.t

--- a/packages/nx/lib/ptree.mli
+++ b/packages/nx/lib/ptree.mli
@@ -45,9 +45,9 @@ type tensor =
   | P : ('a, 'b) Nx_effect.t -> tensor
       (** A packed tensor. The wrapper hides dtype and layout parameters. *)
 
-(** Structures with a uniform payload.
+(** Structures with a uniform payload: the traversal core.
 
-    An ['a t] satisfying {!module-type:Uniform} is a structure whose payload
+    An ['a t] satisfying {!module-type:Traverse} is a structure whose payload
     positions all have type ['a]. Instantiating the payload turns one
     declaration into a family of trees — the model itself and any
     parameter-shaped data (masks, symmetries, per-leaf learning rates) — with
@@ -55,7 +55,8 @@ type tensor =
     [map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t] connecting them.
 
     {!module-type:S} is the same structure specialised to packed tensor leaves;
-    {!module-Make} converts any {!module-type:Uniform} into an {!S}.
+    {!module-Make} and {!val-typed} convert any {!module-type:Traverse} into an
+    {!S}. {!module-type:Uniform} extends the core with leaf paths.
 
     Implementations must satisfy:
     - [map f t] applies [f] to every payload of [t] exactly once and preserves
@@ -63,15 +64,10 @@ type tensor =
     - [map2 f a b] applies [f] to corresponding payloads of [a] and [b], which
       must be structurally equal.
     - [iter f t] applies [f] to every payload of [t] exactly once.
-    - [fold f acc t] visits every payload; the [string] argument is the path to
-      the current position.
-    - [fold2] is like [fold] but across two structurally equal trees.
-    - [names t] is [t] with every payload replaced by its path, so
-      [names (map f t)] is [names t].
-    - Every traversal visits the payloads of a value in the same order: [map],
-      [iter], [fold], and [names] agree on the payload sequence, and [map2] and
-      [fold2] visit corresponding pairs in that order. *)
-module type Uniform = sig
+    - Every traversal visits the payloads of a value in the same order: [map]
+      and [iter] agree on the payload sequence, and [map2] visits corresponding
+      pairs in that order. *)
+module type Traverse = sig
   type 'a t
   (** The structure type, parameterised by the uniform payload type. *)
 
@@ -85,6 +81,21 @@ module type Uniform = sig
 
   val iter : ('a -> unit) -> 'a t -> unit
   (** [iter f t] applies [f] to every payload leaf of [t]. *)
+end
+
+(** Structures with a uniform payload and leaf paths.
+
+    {!module-type:Uniform} extends {!module-type:Traverse} with path-threading
+    reductions; it is the contract checkpointing consumes and the one
+    [\[@@deriving ptree\]] derives for payload-generic types. Additional laws:
+    - [fold f acc t] visits every payload in the traversal order; the [string]
+      argument is the path to the current position.
+    - [fold2] is like [fold] but across two structurally equal trees.
+    - [names t] is [t] with every payload replaced by its path, so
+      [names (map f t)] is [names t] and [fold] pairs with any traversal
+      positionally. *)
+module type Uniform = sig
+  include Traverse
 
   val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
   (** [fold f acc t] reduces [t] to an accumulator, threading the path of each
@@ -110,10 +121,10 @@ end
 
 (** [Make (U)] is the parameter tree over [U] with packed tensor leaves: its [t]
     is [tensor U.t], and its traversals check leafwise that dtypes agree. *)
-module Make (U : Uniform) : S with type t = tensor U.t
+module Make (U : Traverse) : S with type t = tensor U.t
 
 val typed :
-  (module U : Uniform) -> (module S with type t = ('a, 'b) Nx_effect.t U.t)
+  (module U : Traverse) -> (module S with type t = ('a, 'b) Nx_effect.t U.t)
 (** [typed (module U)] is the parameter tree over [U] at a single tensor type:
     the structure instantiated at typed leaves, satisfying {!S} with no packing.
     Bind it once per structure and pass it wherever a first-class {!S} module is

--- a/packages/nx/lib/ptree.mli
+++ b/packages/nx/lib/ptree.mli
@@ -45,18 +45,20 @@ type tensor =
   | P : ('a, 'b) Nx_effect.t -> tensor
       (** A packed tensor. The wrapper hides dtype and layout parameters. *)
 
-(** Structures with a uniform payload: the traversal core.
+(** Structures with a uniform payload.
 
-    An ['a t] satisfying {!module-type:Traverse} is a structure whose payload
+    An ['a t] satisfying {!module-type:Uniform} is a structure whose payload
     positions all have type ['a]. Instantiating the payload turns one
     declaration into a family of trees — the model itself and any
     parameter-shaped data (masks, symmetries, per-leaf learning rates) — with
     type-changing traversals like
-    [map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t] connecting them.
+    [map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t] connecting them. It is
+    the contract checkpointing consumes and the one [\[@@deriving ptree\]]
+    derives for payload-generic types.
 
     {!module-type:S} is the same structure specialised to packed tensor leaves;
-    {!module-Make} and {!val-instantiate} convert any {!module-type:Traverse}
-    into an {!S}. {!module-type:Uniform} extends the core with leaf paths.
+    {!module-Make} and {!val-instantiate} convert any {!module-type:Uniform}
+    into an {!S}.
 
     Implementations must satisfy:
     - [map f t] applies [f] to every payload of [t] exactly once and preserves
@@ -66,8 +68,14 @@ type tensor =
     - [iter f t] applies [f] to every payload of [t] exactly once.
     - Every traversal visits the payloads of a value in the same order: [map]
       and [iter] agree on the payload sequence, and [map2] visits corresponding
-      pairs in that order. *)
-module type Traverse = sig
+      pairs in that order.
+    - [fold f acc t] visits every payload in the traversal order; the [string]
+      argument is the path to the current position.
+    - [fold2] is like [fold] but across two structurally equal trees.
+    - [names t] is [t] with every payload replaced by its path, so
+      [names (map f t)] is [names t] and [fold] pairs with any traversal
+      positionally. *)
+module type Uniform = sig
   type 'a t
   (** The structure type, parameterised by the uniform payload type. *)
 
@@ -81,21 +89,6 @@ module type Traverse = sig
 
   val iter : ('a -> unit) -> 'a t -> unit
   (** [iter f t] applies [f] to every payload leaf of [t]. *)
-end
-
-(** Structures with a uniform payload and leaf paths.
-
-    {!module-type:Uniform} extends {!module-type:Traverse} with path-threading
-    reductions; it is the contract checkpointing consumes and the one
-    [\[@@deriving ptree\]] derives for payload-generic types. Additional laws:
-    - [fold f acc t] visits every payload in the traversal order; the [string]
-      argument is the path to the current position.
-    - [fold2] is like [fold] but across two structurally equal trees.
-    - [names t] is [t] with every payload replaced by its path, so
-      [names (map f t)] is [names t] and [fold] pairs with any traversal
-      positionally. *)
-module type Uniform = sig
-  include Traverse
 
   val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
   (** [fold f acc t] reduces [t] to an accumulator, threading the path of each
@@ -121,10 +114,10 @@ end
 
 (** [Make (U)] is the parameter tree over [U] with packed tensor leaves: its [t]
     is [tensor U.t], and its traversals check leafwise that dtypes agree. *)
-module Make (U : Traverse) : S with type t = tensor U.t
+module Make (U : Uniform) : S with type t = tensor U.t
 
 val instantiate :
-  (module U : Traverse) -> (module S with type t = ('a, 'b) Nx_effect.t U.t)
+  (module U : Uniform) -> (module S with type t = ('a, 'b) Nx_effect.t U.t)
 (** [instantiate (module U)] fills a payload-generic structure's hole at a
     single tensor type: the result satisfies {!S} with typed leaves and no
     packing. Bind it once per model and pass the value to the transformations:

--- a/packages/nx/lib/ptree.mli
+++ b/packages/nx/lib/ptree.mli
@@ -45,20 +45,18 @@ type tensor =
   | P : ('a, 'b) Nx_effect.t -> tensor
       (** A packed tensor. The wrapper hides dtype and layout parameters. *)
 
-(** Structures with a uniform payload.
+(** Structures with a uniform payload: the traversal core.
 
-    An ['a t] satisfying {!module-type:Uniform} is a structure whose payload
+    An ['a t] satisfying {!module-type:Traverse} is a structure whose payload
     positions all have type ['a]. Instantiating the payload turns one
     declaration into a family of trees — the model itself and any
     parameter-shaped data (masks, symmetries, per-leaf learning rates) — with
     type-changing traversals like
-    [map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t] connecting them. It is
-    the contract checkpointing consumes and the one [\[@@deriving ptree\]]
-    derives for payload-generic types.
+    [map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t] connecting them.
 
     {!module-type:S} is the same structure specialised to packed tensor leaves;
-    {!module-Make} and {!val-instantiate} convert any {!module-type:Uniform}
-    into an {!S}.
+    {!module-Make} and {!val-instantiate} convert any {!module-type:Traverse}
+    into an {!S}. {!module-type:Uniform} extends the core with leaf paths.
 
     Implementations must satisfy:
     - [map f t] applies [f] to every payload of [t] exactly once and preserves
@@ -68,14 +66,8 @@ type tensor =
     - [iter f t] applies [f] to every payload of [t] exactly once.
     - Every traversal visits the payloads of a value in the same order: [map]
       and [iter] agree on the payload sequence, and [map2] visits corresponding
-      pairs in that order.
-    - [fold f acc t] visits every payload in the traversal order; the [string]
-      argument is the path to the current position.
-    - [fold2] is like [fold] but across two structurally equal trees.
-    - [names t] is [t] with every payload replaced by its path, so
-      [names (map f t)] is [names t] and [fold] pairs with any traversal
-      positionally. *)
-module type Uniform = sig
+      pairs in that order. *)
+module type Traverse = sig
   type 'a t
   (** The structure type, parameterised by the uniform payload type. *)
 
@@ -89,6 +81,21 @@ module type Uniform = sig
 
   val iter : ('a -> unit) -> 'a t -> unit
   (** [iter f t] applies [f] to every payload leaf of [t]. *)
+end
+
+(** Structures with a uniform payload and leaf paths.
+
+    {!module-type:Uniform} extends {!module-type:Traverse} with path-threading
+    reductions; it is the contract checkpointing consumes and the one
+    [\[@@deriving ptree\]] derives for payload-generic types. Additional laws:
+    - [fold f acc t] visits every payload in the traversal order; the [string]
+      argument is the path to the current position.
+    - [fold2] is like [fold] but across two structurally equal trees.
+    - [names t] is [t] with every payload replaced by its path, so
+      [names (map f t)] is [names t] and [fold] pairs with any traversal
+      positionally. *)
+module type Uniform = sig
+  include Traverse
 
   val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
   (** [fold f acc t] reduces [t] to an accumulator, threading the path of each
@@ -114,10 +121,10 @@ end
 
 (** [Make (U)] is the parameter tree over [U] with packed tensor leaves: its [t]
     is [tensor U.t], and its traversals check leafwise that dtypes agree. *)
-module Make (U : Uniform) : S with type t = tensor U.t
+module Make (U : Traverse) : S with type t = tensor U.t
 
 val instantiate :
-  (module U : Uniform) -> (module S with type t = ('a, 'b) Nx_effect.t U.t)
+  (module U : Traverse) -> (module S with type t = ('a, 'b) Nx_effect.t U.t)
 (** [instantiate (module U)] fills a payload-generic structure's hole at a
     single tensor type: the result satisfies {!S} with typed leaves and no
     packing. Bind it once per model and pass the value to the transformations:

--- a/packages/nx/lib/ptree.mli
+++ b/packages/nx/lib/ptree.mli
@@ -44,6 +44,68 @@ type tensor =
   | P : ('a, 'b) Nx_effect.t -> tensor
       (** A packed tensor. The wrapper hides dtype and layout parameters. *)
 
+(** Uniform homomorphic structures.
+
+    A [('a, Gtree).t] is a structure whose payload positions are all of type
+    ['a] — the "higher-kinded data" (HKD) shape that enables polymorphic
+    traversals like [map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t].
+
+    The classic {!module-type:S} is the rank-2 bridge over packed tensor leaves;
+    {!module-Tensor_tree} converts any {!Gtree} into an {!S}.
+
+    Implementations must satisfy:
+    - [map f t] applies [f] to every payload of [t] exactly once and preserves
+      the structure of [t].
+    - [map2 f a b] applies [f] to corresponding payloads of [a] and [b], which
+      must be structurally equal.
+    - [iter f t] applies [f] to every payload of [t] exactly once, in a stable
+      order.
+    - [fold f acc t] visits every payload in stable order; the [string] argument
+      is the dotted path to the current position.
+    - [fold2] is like {!fold} but across two structurally equal trees. *)
+module type Gtree = sig
+  type 'a t
+  (** The structure type, parameterised by the uniform payload type. *)
+
+  val map : ('a -> 'b) -> 'a t -> 'b t
+  (** [map f t] is [t] with [f] applied to every payload leaf. *)
+
+  val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+  (** [map2 f a b] is [a] and [b] combined leafwise with [f].
+
+      Raises [Invalid_argument] if [a] and [b] are not structurally equal. *)
+
+  val iter : ('a -> unit) -> 'a t -> unit
+  (** [iter f t] applies [f] to every payload leaf of [t]. *)
+
+  val fold : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+  (** [fold f acc t] reduces [t] to an accumulator, threading a dotted path to
+      each payload leaf. The path convention (stable for JIT caching):
+
+      - Root starts at [""].
+      - Record field [w] appends [".w"] under the parent path.
+      - List / array at index [i] appends [".i"].
+      - Option [Some x] keeps the path unchanged; [None] skips. *)
+
+  val fold2 :
+    (string -> 'acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
+  (** [fold2 f acc a b] is like {!fold} but across two structurally equal trees.
+
+      Raises [Invalid_argument] if [a] and [b] are not structurally equal. *)
+end
+
+(** [Tensor_tree (U)] bridges a uniform {!Gtree} to the rank-2 {!S} interface by
+    packing every payload leaf as {!tensor}. The resulting [t] is [tensor U.t].
+*)
+module Tensor_tree (U : Gtree) : S with type t = tensor U.t
+
+val unpack :
+  ?at:string -> ('a, 'b) Nx_core.Dtype.t -> tensor -> ('a, 'b) Nx_effect.t
+(** [unpack ?at dt p] unpacks the packed tensor [p] and returns it with the
+    dtype [dt]; raises [Invalid_argument] if the dtype does not match. The
+    optional [~at] string, if non-empty, is included in the error message as the
+    location of the mismatch. *)
+
 (** The stock dynamic parameter tree; itself satisfies {!S}. *)
 type t =
   | Tensor of tensor  (** A tensor leaf. *)

--- a/packages/nx/lib/ptree.mli
+++ b/packages/nx/lib/ptree.mli
@@ -131,20 +131,30 @@ val unpack :
     optional [~at] string, if non-empty, is included in the error message as the
     location of the mismatch. *)
 
-(** The stock dynamic parameter tree; itself satisfies {!S}. *)
-type t =
-  | Tensor of tensor  (** A tensor leaf. *)
-  | List of t list  (** An ordered list branch. *)
-  | Dict of (string * t) list  (** A dict branch. Keys are strings. *)
+(** The stock dynamic tree: ordered lists and string-keyed dicts, generic in
+    the payload. It satisfies {!module-type:Uniform}, with zero-based list
+    positions and dict keys as path segments. *)
+module Tree : sig
+  type 'a t =
+    | Leaf of 'a  (** A payload leaf. *)
+    | List of 'a t list  (** An ordered list branch. *)
+    | Dict of (string * 'a t) list  (** A dict branch. Keys are strings. *)
+
+  include Uniform with type 'a t := 'a t
+end
+
+type t = tensor Tree.t
+(** The stock dynamic parameter tree — {!Tree} with packed tensor leaves;
+    itself satisfies {!S}. *)
 
 val tensor : ('a, 'b) Nx_effect.t -> t
-(** [tensor x] is [Tensor (P x)]. *)
+(** [tensor x] is [Tree.Leaf (P x)]. *)
 
 val list : t list -> t
-(** [list ts] is [List ts]. *)
+(** [list ts] is [Tree.List ts]. *)
 
 val dict : (string * t) list -> t
-(** [dict kvs] is [Dict kvs]. *)
+(** [dict kvs] is [Tree.Dict kvs]. *)
 
 val map : ('a 'b. ('a, 'b) Nx_effect.t -> ('a, 'b) Nx_effect.t) -> t -> t
 (** [map f t] is [t] with [f] applied to every tensor leaf. *)

--- a/packages/nx/test/dune
+++ b/packages/nx/test/dune
@@ -19,7 +19,7 @@
   test_nx_rng
   test_nx_splat
   test_nx_stft
-  test_ptree_gtree)
+  test_ptree_uniform)
  (package nx)
  (modules
   :standard

--- a/packages/nx/test/dune
+++ b/packages/nx/test/dune
@@ -27,26 +27,14 @@
   backend_contract
   test_backend_contract
   test_nx_support
-  test_nx_io
-  test_oxcaml_backend)
+  test_nx_io)
  (libraries nx.buffer nx nx.core nx.effect windtrap test_nx_support))
 
 (test
  (name test_backend_contract)
  (package nx)
  (modules backend_contract test_backend_contract)
- (libraries nx.buffer nx.c nx.core windtrap))
-
-(test
- (name test_oxcaml_backend)
- (package nx)
- (modules test_oxcaml_backend)
- (action
-  (run
-   %{test}
-   %{dep:../lib/core/backend_intf.ml}
-   %{dep:../lib/backend/nx_backend.mli}
-   %{dep:../../nx-oxcaml/lib/nx_backend.ml})))
+ (libraries nx.buffer nx.c nx.core windtrap windtrap.prop))
 
 (test
  (name test_nx_io)

--- a/packages/nx/test/dune
+++ b/packages/nx/test/dune
@@ -18,7 +18,8 @@
   test_nx_ops
   test_nx_rng
   test_nx_splat
-  test_nx_stft)
+  test_nx_stft
+  test_ptree_gtree)
  (package nx)
  (modules
   :standard

--- a/packages/nx/test/dune
+++ b/packages/nx/test/dune
@@ -27,14 +27,26 @@
   backend_contract
   test_backend_contract
   test_nx_support
-  test_nx_io)
+  test_nx_io
+  test_oxcaml_backend)
  (libraries nx.buffer nx nx.core nx.effect windtrap test_nx_support))
 
 (test
  (name test_backend_contract)
  (package nx)
  (modules backend_contract test_backend_contract)
- (libraries nx.buffer nx.c nx.core windtrap windtrap.prop))
+ (libraries nx.buffer nx.c nx.core windtrap))
+
+(test
+ (name test_oxcaml_backend)
+ (package nx)
+ (modules test_oxcaml_backend)
+ (action
+  (run
+   %{test}
+   %{dep:../lib/core/backend_intf.ml}
+   %{dep:../lib/backend/nx_backend.mli}
+   %{dep:../../nx-oxcaml/lib/nx_backend.ml})))
 
 (test
  (name test_nx_io)

--- a/packages/nx/test/test_ptree_gtree.ml
+++ b/packages/nx/test/test_ptree_gtree.ml
@@ -1,0 +1,153 @@
+(*---------------------------------------------------------------------------
+  Copyright (c) 2026 The Raven authors. All rights reserved.
+  SPDX-License-Identifier: ISC
+  ---------------------------------------------------------------------------*)
+
+(* Gtree → Ptree.S bridge via Tensor_tree: hand-written gtree, no ppx. *)
+
+open Windtrap
+
+(* ——— helpers ——— *)
+
+(* as_f32 : refine an existentially-typed tensor to concrete float32 through a
+   dtype witness check. This is the standard pattern for consuming existential
+   tensors from packed leaves. *)
+let as_f32 (type a b) (x : (a, b) Nx.t) : Nx.float32_t =
+  match Nx_core.Dtype.equal_witness (Nx.dtype x) Nx.float32 with
+  | Some Type.Equal -> x
+  | None -> failwith "expected a float32 leaf"
+
+let raw (t : Nx.float32_t) = Nx.to_array (Nx.reshape [| -1 |] (Nx.contiguous t))
+
+let check ~msg (expected : float array) (actual : float array) =
+  equal ~msg int (Array.length expected) (Array.length actual);
+  Array.iteri
+    (fun i e ->
+      equal ~msg:(Printf.sprintf "%s[%d]" msg i) (float 1e-5) e actual.(i))
+    expected
+
+let f32 = Nx.float32
+let vec32 xs = Nx.create f32 [| Array.length xs |] xs
+let pack x = Nx.Ptree.P x
+
+(* ——— hand-written gtree ——— *)
+
+module U = struct
+  type 'a t = { w : 'a; b : 'a }
+
+  let map (f : 'a -> 'b) { w; b } = { w = f w; b = f b }
+  let map2 (f : 'a -> 'b -> 'c) a b = { w = f a.w b.w; b = f a.b b.b }
+
+  let iter (f : 'a -> unit) { w; b } =
+    f w;
+    f b
+
+  let fold (f : string -> 'acc -> 'a -> 'acc) acc { w; b } =
+    f "b" (f "w" acc w) b
+
+  let fold2 (f : string -> 'acc -> 'a -> 'b -> 'acc) acc a b =
+    f "b" (f "w" acc a.w b.w) a.b b.b
+end
+
+(* ——— Tensor_tree bridge ——— *)
+
+module T = Nx.Ptree.Tensor_tree (U)
+module Check : Nx.Ptree.S = T
+
+let params () =
+  { U.w = pack (vec32 [| 1.0; -2.0; 3.0 |]); b = pack (vec32 [| 0.5 |]) }
+
+(* ——— tests ——— *)
+
+let test_map_preserves_structure () =
+  let t : T.t = params () in
+  let r = T.map (fun x -> Nx.mul x x) t in
+  match r with
+  | { U.w = Nx.Ptree.P w; b = Nx.Ptree.P b } ->
+      check ~msg:"w" [| 1.0; 4.0; 9.0 |] (raw (as_f32 w));
+      check ~msg:"b" [| 0.25 |] (raw (as_f32 b))
+
+let test_map2_combines_leafwise () =
+  let a = params () and b = params () in
+  let r = T.map2 (fun x y -> Nx.add x y) a b in
+  match r with
+  | { U.w = Nx.Ptree.P w; _ } ->
+      check ~msg:"w" [| 2.0; -4.0; 6.0 |] (raw (as_f32 w))
+
+let test_iter_visits_every_leaf () =
+  let count = ref 0 in
+  T.iter (fun _ -> incr count) (params ());
+  equal ~msg:"leaves" int 2 !count
+
+let test_gtree_fold_paths () =
+  let visited = ref [] in
+  let _ =
+    U.fold
+      (fun path acc _ ->
+        visited := path :: !visited;
+        acc)
+      0 (params ())
+  in
+  let paths = List.rev !visited in
+  equal ~msg:"count" int 2 (List.length paths);
+  equal ~msg:"first path" string "w" (List.nth paths 0);
+  equal ~msg:"second path" string "b" (List.nth paths 1)
+
+let test_gtree_fold2 () =
+  let merged =
+    U.fold2 (fun path acc _ _ -> path :: acc) [] (params ()) (params ())
+  in
+  let merged = List.rev merged in
+  equal ~msg:"merged count" int 2 (List.length merged)
+
+let test_map2_dtype_mismatch () =
+  let b =
+    {
+      U.w = pack (Nx.create Nx.float64 [| 1 |] [| 1.0 |]);
+      b = pack (vec32 [| 0.5 |]);
+    }
+  in
+  raises_match
+    (fun e -> match e with Invalid_argument _ -> true | _ -> false)
+    (fun () -> ignore (T.map2 (fun x _ -> x) (params ()) b))
+
+let test_unpack_ok () =
+  let x = vec32 [| 1.0; 2.0 |] in
+  check ~msg:"unpack" [| 1.0; 2.0 |] (raw (Nx.Ptree.unpack f32 (pack x)))
+
+let test_unpack_mismatch () =
+  let p = pack (vec32 [| 1.0 |]) in
+  raises_match
+    (fun e -> match e with Invalid_argument _ -> true | _ -> false)
+    (fun () -> ignore (Nx.Ptree.unpack Nx.float64 p))
+
+let test_unpack_at_path () =
+  let p = pack (vec32 [| 1.0 |]) in
+  raises_match
+    (fun e ->
+      match e with
+      | Invalid_argument msg when String.length msg > 0 -> true
+      | _ -> false)
+    (fun () -> ignore (Nx.Ptree.unpack ~at:"model.layer.w" Nx.float64 p))
+
+let tests =
+  [
+    group "Tensor_tree bridge"
+      [
+        test "map preserves structure" test_map_preserves_structure;
+        test "map2 combines leafwise" test_map2_combines_leafwise;
+        test "iter visits every leaf" test_iter_visits_every_leaf;
+      ];
+    group "Gtree fold"
+      [ test "fold paths" test_gtree_fold_paths; test "fold2" test_gtree_fold2 ];
+    group "structure errors"
+      [ test "map2 rejects dtype mismatch" test_map2_dtype_mismatch ];
+    group "unpack"
+      [
+        test "unpack succeeds on matching dtype" test_unpack_ok;
+        test "unpack raises on mismatching dtype" test_unpack_mismatch;
+        test "unpack ~at includes path in message" test_unpack_at_path;
+      ];
+  ]
+
+let () = run "nx ptree gtree" tests

--- a/packages/nx/test/test_ptree_uniform.ml
+++ b/packages/nx/test/test_ptree_uniform.ml
@@ -120,6 +120,21 @@ let test_map2_dtype_mismatch () =
     (fun e -> match e with Invalid_argument _ -> true | _ -> false)
     (fun () -> ignore (T.map2 (fun x _ -> x) (params ()) b))
 
+let test_typed_instance () =
+  let module TP =
+    (val Nx.Ptree.typed (module U)
+        : Nx.Ptree.S with type t = Nx.float32_t U.t)
+  in
+  let p = { U.w = vec32 [| 1.0; -2.0 |]; b = vec32 [| 3.0 |] } in
+  let r = TP.map (fun x -> Nx.mul x x) p in
+  check ~msg:"typed map w" [| 1.0; 4.0 |] (raw r.U.w);
+  check ~msg:"typed map b" [| 9.0 |] (raw r.U.b);
+  let s = TP.map2 (fun x y -> Nx.add x y) p p in
+  check ~msg:"typed map2 w" [| 2.0; -4.0 |] (raw s.U.w);
+  let count = ref 0 in
+  TP.iter (fun _ -> incr count) p;
+  equal ~msg:"typed iter leaves" int 2 !count
+
 let test_unpack_ok () =
   let x = vec32 [| 1.0; 2.0 |] in
   check ~msg:"unpack" [| 1.0; 2.0 |] (raw (Nx.Ptree.unpack f32 (pack x)))
@@ -155,6 +170,8 @@ let tests =
       ];
     group "structure errors"
       [ test "map2 rejects dtype mismatch" test_map2_dtype_mismatch ];
+    group "typed instance"
+      [ test "typed traverses with typed leaves" test_typed_instance ];
     group "unpack"
       [
         test "unpack succeeds on matching dtype" test_unpack_ok;

--- a/packages/nx/test/test_ptree_uniform.ml
+++ b/packages/nx/test/test_ptree_uniform.ml
@@ -122,7 +122,7 @@ let test_map2_dtype_mismatch () =
 
 let test_typed_instance () =
   let module TP =
-    (val Nx.Ptree.typed (module U)
+    (val Nx.Ptree.instantiate (module U)
         : Nx.Ptree.S with type t = Nx.float32_t U.t)
   in
   let p = { U.w = vec32 [| 1.0; -2.0 |]; b = vec32 [| 3.0 |] } in

--- a/packages/nx/test/test_ptree_uniform.ml
+++ b/packages/nx/test/test_ptree_uniform.ml
@@ -135,6 +135,26 @@ let test_typed_instance () =
   TP.iter (fun _ -> incr count) p;
   equal ~msg:"typed iter leaves" int 2 !count
 
+let test_tree_paths () =
+  let t =
+    Nx.Ptree.dict
+      [
+        ( "layers",
+          Nx.Ptree.list
+            [
+              Nx.Ptree.tensor (vec32 [| 1.0 |]);
+              Nx.Ptree.tensor (vec32 [| 2.0 |]);
+            ] );
+        ("head", Nx.Ptree.tensor (vec32 [| 3.0 |]));
+      ]
+  in
+  let expected = [ "layers.0"; "layers.1"; "head" ] in
+  let paths = List.rev (Nx.Ptree.Tree.fold (fun p acc _ -> p :: acc) [] t) in
+  equal ~msg:"tree paths" (list string) expected paths;
+  let names = Nx.Ptree.Tree.names t in
+  equal ~msg:"tree names agrees with fold" (list string) expected
+    (List.rev (Nx.Ptree.Tree.fold (fun _ acc p -> p :: acc) [] names))
+
 let test_unpack_ok () =
   let x = vec32 [| 1.0; 2.0 |] in
   check ~msg:"unpack" [| 1.0; 2.0 |] (raw (Nx.Ptree.unpack f32 (pack x)))
@@ -172,6 +192,8 @@ let tests =
       [ test "map2 rejects dtype mismatch" test_map2_dtype_mismatch ];
     group "typed instance"
       [ test "typed traverses with typed leaves" test_typed_instance ];
+    group "stock tree"
+      [ test "list and dict positions become paths" test_tree_paths ];
     group "unpack"
       [
         test "unpack succeeds on matching dtype" test_unpack_ok;

--- a/packages/nx/test/test_ptree_uniform.ml
+++ b/packages/nx/test/test_ptree_uniform.ml
@@ -3,7 +3,8 @@
   SPDX-License-Identifier: ISC
   ---------------------------------------------------------------------------*)
 
-(* Uniform → Ptree.S bridge via Ptree.Make: hand-written uniform structure, no ppx. *)
+(* Uniform → Ptree.S bridge via Ptree.Make: hand-written uniform structure, no
+   ppx. *)
 
 open Windtrap
 
@@ -139,7 +140,10 @@ let tests =
         test "iter visits every leaf" test_iter_visits_every_leaf;
       ];
     group "Uniform fold"
-      [ test "fold paths" test_uniform_fold_paths; test "fold2" test_uniform_fold2 ];
+      [
+        test "fold paths" test_uniform_fold_paths;
+        test "fold2" test_uniform_fold2;
+      ];
     group "structure errors"
       [ test "map2 rejects dtype mismatch" test_map2_dtype_mismatch ];
     group "unpack"

--- a/packages/nx/test/test_ptree_uniform.ml
+++ b/packages/nx/test/test_ptree_uniform.ml
@@ -48,6 +48,8 @@ module U = struct
 
   let fold2 (f : string -> 'acc -> 'a -> 'b -> 'acc) acc a b =
     f "b" (f "w" acc a.w b.w) a.b b.b
+
+  let names _ = { w = "w"; b = "b" }
 end
 
 (* ——— Ptree.S bridge ——— *)
@@ -101,6 +103,12 @@ let test_uniform_fold2 () =
   let merged = List.rev merged in
   equal ~msg:"merged count" int 2 (List.length merged)
 
+let test_uniform_names () =
+  let names = U.names (params ()) in
+  let paths = List.rev (U.fold (fun path acc _ -> path :: acc) [] names) in
+  equal ~msg:"names agrees with fold's paths" (list string) [ "w"; "b" ] paths;
+  equal ~msg:"each payload carries its own path" string "w" names.U.w
+
 let test_map2_dtype_mismatch () =
   let b =
     {
@@ -143,6 +151,7 @@ let tests =
       [
         test "fold paths" test_uniform_fold_paths;
         test "fold2" test_uniform_fold2;
+        test "names is the tree of paths" test_uniform_names;
       ];
     group "structure errors"
       [ test "map2 rejects dtype mismatch" test_map2_dtype_mismatch ];

--- a/packages/nx/test/test_ptree_uniform.ml
+++ b/packages/nx/test/test_ptree_uniform.ml
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: ISC
   ---------------------------------------------------------------------------*)
 
-(* Gtree → Ptree.S bridge via Tensor_tree: hand-written gtree, no ppx. *)
+(* Uniform → Ptree.S bridge via Ptree.Make: hand-written uniform structure, no ppx. *)
 
 open Windtrap
 
@@ -30,7 +30,7 @@ let f32 = Nx.float32
 let vec32 xs = Nx.create f32 [| Array.length xs |] xs
 let pack x = Nx.Ptree.P x
 
-(* ——— hand-written gtree ——— *)
+(* ——— hand-written uniform structure ——— *)
 
 module U = struct
   type 'a t = { w : 'a; b : 'a }
@@ -49,9 +49,9 @@ module U = struct
     f "b" (f "w" acc a.w b.w) a.b b.b
 end
 
-(* ——— Tensor_tree bridge ——— *)
+(* ——— Ptree.S bridge ——— *)
 
-module T = Nx.Ptree.Tensor_tree (U)
+module T = Nx.Ptree.Make (U)
 module Check : Nx.Ptree.S = T
 
 let params () =
@@ -79,7 +79,7 @@ let test_iter_visits_every_leaf () =
   T.iter (fun _ -> incr count) (params ());
   equal ~msg:"leaves" int 2 !count
 
-let test_gtree_fold_paths () =
+let test_uniform_fold_paths () =
   let visited = ref [] in
   let _ =
     U.fold
@@ -93,7 +93,7 @@ let test_gtree_fold_paths () =
   equal ~msg:"first path" string "w" (List.nth paths 0);
   equal ~msg:"second path" string "b" (List.nth paths 1)
 
-let test_gtree_fold2 () =
+let test_uniform_fold2 () =
   let merged =
     U.fold2 (fun path acc _ _ -> path :: acc) [] (params ()) (params ())
   in
@@ -132,14 +132,14 @@ let test_unpack_at_path () =
 
 let tests =
   [
-    group "Tensor_tree bridge"
+    group "Ptree.S bridge"
       [
         test "map preserves structure" test_map_preserves_structure;
         test "map2 combines leafwise" test_map2_combines_leafwise;
         test "iter visits every leaf" test_iter_visits_every_leaf;
       ];
-    group "Gtree fold"
-      [ test "fold paths" test_gtree_fold_paths; test "fold2" test_gtree_fold2 ];
+    group "Uniform fold"
+      [ test "fold paths" test_uniform_fold_paths; test "fold2" test_uniform_fold2 ];
     group "structure errors"
       [ test "map2 rejects dtype mismatch" test_map2_dtype_mismatch ];
     group "unpack"
@@ -150,4 +150,4 @@ let tests =
       ];
   ]
 
-let () = run "nx ptree gtree" tests
+let () = run "nx ptree uniform" tests

--- a/packages/ppx_ptree/README.md
+++ b/packages/ppx_ptree/README.md
@@ -52,6 +52,100 @@ the public `Nx.t` type:
 
 The PPX adds no runtime dependency.
 
+## Deriving uniform gtree traversals
+
+`[@@deriving gtree]` generates rank-1, type-changing traversals for
+*higher-kinded data* — structures whose payload positions all share a single
+type parameter:
+
+```ocaml
+type 'a t = { w : 'a; b : 'a; name : string }
+[@@deriving gtree]
+```
+
+This produces `map`, `map2`, `iter`, `fold`, `fold2`, and `names` directly on
+`'a t`. The `fold` and `fold2` operations receive a dotted path string at
+each leaf, built from field names and container indices:
+
+```ocaml
+val fold  : (string -> 'a -> 'acc -> 'acc) -> 'a t -> 'acc -> 'acc
+val fold2 : (string -> 'a -> 'b -> 'acc -> 'acc) -> 'a t -> 'b t -> 'acc -> 'acc
+```
+
+Path convention (stable for JIT caching):
+
+- Root starts at `""`.
+- Record field `w` appends `".w"`.
+- List/array item at index `i` appends `".i"`.
+- Tuple positions use `".0"`, `".1"`, etc.
+
+Payload positions are fields (or nested positions) where the type parameter
+`'a` occurs directly — not inside an `Nx.t` leaf. Fields without `'a` are
+static metadata, following the same semantics as `[@ptree.ignore]`: preserved
+by `map`, left-biased by `map2`, skipped by `iter`/`fold`/`fold2`.
+
+### Nesting
+
+A field `'a Sub.t` delegates to `Sub.map`, `Sub.fold`, etc. — `Sub` must also
+derive `[@@deriving gtree]`.
+
+### Names
+
+`val names : string t` is a constant tree of dotted paths, derived when the
+structure is statically known (no payload `option`/`list`/`array`). Omitted
+otherwise.
+
+### Bridge to Ptree.S
+
+A gtree instantiated with `Nx.Ptree.tensor` as its payload satisfies
+`Nx.Ptree.S` via the `Nx.Ptree.Tensor_tree` functor:
+
+```ocaml
+type 'a params = { w : 'a; b : 'a }
+[@@deriving gtree]
+
+type t = Nx.Ptree.tensor params
+
+module T = Nx.Ptree.Tensor_tree (struct
+  type 'a t = 'a params
+  let map = map
+  let map2 = map2
+  let iter = iter
+end)
+
+let loss (p : T.t) = ...
+let g = Rune.grad (module T) loss params
+```
+
+(The `[@@deriving ptree, gtree]` combination on a static record automates the
+packing — see mirror mode below.)
+
+### Mirror mode (static records)
+
+When applied to a concrete record without a type parameter,
+`[@@deriving ptree, gtree]` generates:
+
+- `module Gtree` — the uniform mirror type `'a t` + all six traversals
+- `val to_gtree : t -> Nx.Ptree.tensor Gtree.t` — packs tensor leaves
+- `val of_gtree : Nx.Ptree.tensor Gtree.t -> t` — unpacks with dtype checks
+  (only when all leaf dtypes are concrete, e.g. `Nx.float32_t`)
+
+```ocaml
+type t = { w : Nx.float32_t; b : Nx.float16_t }
+[@@deriving ptree, gtree]
+
+(* Gtree traversals on the uniform view: *)
+let symmetrize (params : t) (syms : Symmetry.t Params.Gtree.t) : t =
+  let u = to_gtree params in
+  let zipped = Params.Gtree.map2 (fun (Nx.Ptree.P x) sym ->
+    Nx.Ptree.P (Symmetry.project sym x)) u syms
+  in
+  of_gtree zipped
+```
+
+Also works for nested models where each sub-module derives `[@@deriving ptree, gtree]`:
+a field `linear : Linear.t` maps to `'a Linear.Gtree.t` in the mirror.
+
 ## Example
 
 The [Rune linear-regression example](examples/01-rune-linear-regression/)

--- a/packages/ppx_ptree/README.md
+++ b/packages/ppx_ptree/README.md
@@ -105,8 +105,9 @@ Paths compose: a leaf the delegate reports as `"w"` under a field `head` becomes
 
 ### Bridge to Ptree.S
 
-A uniform type instantiated at `Nx.Ptree.tensor` satisfies `Nx.Ptree.S` via
-the `Nx.Ptree.Make` functor:
+`Nx.Ptree.instantiate` fills a uniform type's payload at a single tensor
+type, yielding the `Nx.Ptree.S` walker the transformations take (in kaun,
+`Kaun.ptree` is the same function):
 
 ```ocaml
 module Params = struct
@@ -114,13 +115,15 @@ module Params = struct
   [@@deriving ptree]
 end
 
-module P = Nx.Ptree.Make (Params)
+let p = Nx.Ptree.instantiate (module Params)
 
-let g = Rune.grad (module P) loss params
+let g = Rune.grad p loss params
 ```
 
-`P.t` is `Nx.Ptree.tensor Params.t`, so the leaves are packed; recover a typed
-tensor from one with `Nx.Ptree.unpack`.
+For mixed leaf dtypes, the `Nx.Ptree.Make` functor packs the leaves instead:
+`Nx.Ptree.Make (Params)` satisfies `Nx.Ptree.S` with `t` equal to
+`Nx.Ptree.tensor Params.t`; recover a typed tensor from one with
+`Nx.Ptree.unpack`.
 
 ### Mirror mode (concrete records)
 

--- a/packages/ppx_ptree/README.md
+++ b/packages/ppx_ptree/README.md
@@ -16,6 +16,10 @@ name generates suffixed functions, such as `map_state`, `map2_state`, and
 `iter_state`. This lets one declaration group contain helper structures while
 reserving the unsuffixed names for one primary `t` or `params` type.
 
+The same attribute on a payload-generic type — one type parameter, occurring
+outside tensor leaves — derives the rank-1 uniform traversals instead; see
+[Uniform types](#uniform-payload-generic-types) below.
+
 ## Supported shapes
 
 Tensor leaves may use `('a, 'b) Nx.t`, `Nx_effect.t`, or any of Nx's concrete
@@ -52,99 +56,99 @@ the public `Nx.t` type:
 
 The PPX adds no runtime dependency.
 
-## Deriving uniform gtree traversals
+## Uniform (payload-generic) types
 
-`[@@deriving gtree]` generates rank-1, type-changing traversals for
-*higher-kinded data* — structures whose payload positions all share a single
-type parameter:
-
-```ocaml
-type 'a t = { w : 'a; b : 'a; name : string }
-[@@deriving gtree]
-```
-
-This produces `map`, `map2`, `iter`, `fold`, `fold2`, and `names` directly on
-`'a t`. The `fold` and `fold2` operations receive a dotted path string at
-each leaf, built from field names and container indices:
+When a type has exactly one type parameter and that parameter occurs outside
+tensor leaves, `[@@deriving ptree]` derives rank-1, type-changing traversals
+instead — the `Nx.Ptree.Uniform` shape:
 
 ```ocaml
-val fold  : (string -> 'a -> 'acc -> 'acc) -> 'a t -> 'acc -> 'acc
-val fold2 : (string -> 'a -> 'b -> 'acc -> 'acc) -> 'a t -> 'b t -> 'acc -> 'acc
+type 'a t = { w : 'a; b : 'a option; name : string }
+[@@deriving ptree]
 ```
 
-Path convention (stable for JIT caching):
+This produces `map`, `map2`, `iter`, `fold`, `fold2`, and `names`:
 
-- Root starts at `""`.
-- Record field `w` appends `".w"`.
-- List/array item at index `i` appends `".i"`.
-- Tuple positions use `".0"`, `".1"`, etc.
+```ocaml
+val map   : ('a -> 'b) -> 'a t -> 'b t
+val map2  : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+val iter  : ('a -> unit) -> 'a t -> unit
+val fold  : (string -> 'acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+val fold2 : (string -> 'acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
+val names : 'a t -> string t
+```
 
-Payload positions are fields (or nested positions) where the type parameter
-`'a` occurs directly — not inside an `Nx.t` leaf. Fields without `'a` are
-static metadata, following the same semantics as `[@ptree.ignore]`: preserved
-by `map`, left-biased by `map2`, skipped by `iter`/`fold`/`fold2`.
+`fold` and `fold2` pass each payload leaf's path to the callback, and `names`
+is the tree of those paths, computed from a value so optional and variable-size
+containers resolve. A path is the dot-joined sequence of record field names and
+container indices from the root — `"w"`, `"layers.0"`, `"pair.1"` — matching
+the checkpoint naming convention; `Some` contributes no segment, and a payload
+at the root has the empty path.
+
+Payload positions are the positions where `'a` occurs directly — not inside an
+`Nx.t` leaf. Fields without `'a` are static metadata: preserved by `map`,
+left-biased by `map2`, skipped by `iter`/`fold`/`fold2`, copied by `names`.
+The `[@ptree.*]` attributes do not apply to payload positions of uniform
+types; a field whose bare `'a` carries an attribute keeps its rank-2 meaning
+for mode selection, so records like `{ tag : 'tag [@ptree.ignore]; ... }`
+continue to derive the classic traversals.
 
 ### Nesting
 
-A field `'a Sub.t` delegates to `Sub.map`, `Sub.fold`, etc. — `Sub` must also
-derive `[@@deriving gtree]`.
-
-### Names
-
-`val names : string t` is a constant tree of dotted paths, derived when the
-structure is statically known (no payload `option`/`list`/`array`). Omitted
-otherwise.
+A field `'a sub` (a sibling type in the same declaration group) or `'a Sub.t`
+delegates to the sibling's or `Sub`'s uniform traversals. Delegated types must
+be applied to the payload parameter alone.
 
 ### Bridge to Ptree.S
 
-A gtree instantiated with `Nx.Ptree.tensor` as its payload satisfies
-`Nx.Ptree.S` via the `Nx.Ptree.Tensor_tree` functor:
+A uniform type instantiated at `Nx.Ptree.tensor` satisfies `Nx.Ptree.S` via
+the `Nx.Ptree.Make` functor:
 
 ```ocaml
 type 'a params = { w : 'a; b : 'a }
-[@@deriving gtree]
+[@@deriving ptree]
 
-type t = Nx.Ptree.tensor params
-
-module T = Nx.Ptree.Tensor_tree (struct
+module P = Nx.Ptree.Make (struct
   type 'a t = 'a params
   let map = map
   let map2 = map2
   let iter = iter
 end)
 
-let loss (p : T.t) = ...
-let g = Rune.grad (module T) loss params
+let g = Rune.grad (module P) loss params
 ```
 
-(The `[@@deriving ptree, gtree]` combination on a static record automates the
-packing — see mirror mode below.)
+### Mirror mode (concrete records)
 
-### Mirror mode (static records)
+`[@@deriving ptree ~mirror]` on a concrete type additionally generates a
+uniform mirror alongside the rank-2 traversals:
 
-When applied to a concrete record without a type parameter,
-`[@@deriving ptree, gtree]` generates:
-
-- `module Gtree` — the uniform mirror type `'a t` + all six traversals
-- `val to_gtree : t -> Nx.Ptree.tensor Gtree.t` — packs tensor leaves
-- `val of_gtree : Nx.Ptree.tensor Gtree.t -> t` — unpacks with dtype checks
-  (only when all leaf dtypes are concrete, e.g. `Nx.float32_t`)
+- `module Uniform` — the payload-generic mirror `'m t` with all six uniform
+  traversals; static fields keep their original types.
+- `val to_uniform : t -> Nx.Ptree.tensor Uniform.t` — packs tensor leaves.
+- `val of_uniform : Nx.Ptree.tensor Uniform.t -> t` — unpacks with dtype
+  checks (generated only when every leaf dtype is statically known, e.g.
+  `Nx.float32_t`; errors carry the leaf's path).
 
 ```ocaml
 type t = { w : Nx.float32_t; b : Nx.float16_t }
-[@@deriving ptree, gtree]
+[@@deriving ptree ~mirror]
 
-(* Gtree traversals on the uniform view: *)
-let symmetrize (params : t) (syms : Symmetry.t Params.Gtree.t) : t =
-  let u = to_gtree params in
-  let zipped = Params.Gtree.map2 (fun (Nx.Ptree.P x) sym ->
-    Nx.Ptree.P (Symmetry.project sym x)) u syms
+(* uniform traversals on the mirror view: *)
+let symmetrize (params : t) (syms : Symmetry.t Uniform.t) : t =
+  let u = to_uniform params in
+  let zipped =
+    Uniform.map2
+      (fun (Nx.Ptree.P x) sym -> Nx.Ptree.P (Symmetry.project sym x))
+      u syms
   in
-  of_gtree zipped
+  of_uniform zipped
 ```
 
-Also works for nested models where each sub-module derives `[@@deriving ptree, gtree]`:
-a field `linear : Linear.t` maps to `'a Linear.Gtree.t` in the mirror.
+A field `linear : Linear.t` maps to `'m Linear.Uniform.t` in the mirror;
+`Linear` must itself derive `[@@deriving ptree ~mirror]`. Mirror mode applies
+to a single declaration whose definition is visible, without locally declared
+or recursive sub-structures.
 
 ## Example
 

--- a/packages/ppx_ptree/README.md
+++ b/packages/ppx_ptree/README.md
@@ -99,24 +99,28 @@ A field `'a sub` (a sibling type in the same declaration group) or `'a Sub.t`
 delegates to the sibling's or `Sub`'s uniform traversals. Delegated types must
 be applied to the payload parameter alone.
 
+Paths compose: a leaf the delegate reports as `"w"` under a field `head` becomes
+`"head.w"`. A delegate whose payload sits at its own root — `type 'a leaf = 'a`
+— reports the empty path, so a field `bias : 'a leaf` yields `"bias"`.
+
 ### Bridge to Ptree.S
 
 A uniform type instantiated at `Nx.Ptree.tensor` satisfies `Nx.Ptree.S` via
 the `Nx.Ptree.Make` functor:
 
 ```ocaml
-type 'a params = { w : 'a; b : 'a }
-[@@deriving ptree]
+module Params = struct
+  type 'a t = { w : 'a; b : 'a }
+  [@@deriving ptree]
+end
 
-module P = Nx.Ptree.Make (struct
-  type 'a t = 'a params
-  let map = map
-  let map2 = map2
-  let iter = iter
-end)
+module P = Nx.Ptree.Make (Params)
 
 let g = Rune.grad (module P) loss params
 ```
+
+`P.t` is `Nx.Ptree.tensor Params.t`, so the leaves are packed; recover a typed
+tensor from one with `Nx.Ptree.unpack`.
 
 ### Mirror mode (concrete records)
 

--- a/packages/ppx_ptree/ppx_ptree.ml
+++ b/packages/ppx_ptree/ppx_ptree.ml
@@ -1473,8 +1473,8 @@ let uvalidate_declaration ~signature validation type_decl =
   (match body with
   | Some body when not (ubody_has_payload body) ->
       add_error validation ~loc:type_decl.ptype_name.loc
-        "ppx_ptree: the type parameter ['%s] of [%s] never occurs in a \
-         payload position"
+        "ppx_ptree: the type parameter ['%s] of [%s] never occurs in a payload \
+         position"
         parameter type_decl.ptype_name.txt
   | _ -> ());
   let dependencies =
@@ -1521,22 +1521,23 @@ let ucomponent_rec_flag component =
   match component with
   | [] -> assert false
   | [ udecl ] ->
-      if String_set.mem udecl.utype_decl.ptype_name.txt udecl.udependencies
-      then Recursive
+      if String_set.mem udecl.utype_decl.ptype_name.txt udecl.udependencies then
+        Recursive
       else Nonrecursive
   | _ -> Recursive
 
 (* Leaf paths: [None] at the root, otherwise a string expression holding the
-   dot-joined segments so far. Top-level segments are bare; deeper segments
-   are appended with ["."], matching the checkpoint naming convention. *)
+   dot-joined segments so far. Top-level segments are bare; deeper segments are
+   appended with ["."], matching the checkpoint naming convention. *)
 
 let ujoin ~loc path segment =
   match path with
   | None -> segment
   | Some path ->
       call ~loc (Longident.Lident "^")
-        [ call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ];
-          segment ]
+        [
+          call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ]; segment;
+        ]
 
 let upath_expr ~loc path =
   match path with None -> B.estring ~loc "" | Some path -> path
@@ -1552,8 +1553,7 @@ let rec umap_expr fvar shape expr =
   | UPayload -> call ~loc (Lident fvar) [ expr ]
   | UStatic -> expr
   | ULocal name ->
-      call ~loc
-        (Lident (uniform_names_for_type name).umap)
+      call ~loc (Lident (uniform_names_for_type name).umap)
         [ evar ~loc fvar; expr ]
   | UUsing module_path ->
       call ~loc (append_lid module_path "map") [ evar ~loc fvar; expr ]
@@ -1612,8 +1612,7 @@ let rec umap2_expr ~function_path fvar shape left right =
   | UPayload -> call ~loc (Lident fvar) [ left; right ]
   | UStatic -> left
   | ULocal name ->
-      call ~loc
-        (Lident (uniform_names_for_type name).umap2)
+      call ~loc (Lident (uniform_names_for_type name).umap2)
         [ evar ~loc fvar; left; right ]
   | UUsing module_path ->
       call ~loc (append_lid module_path "map2") [ evar ~loc fvar; left; right ]
@@ -1700,7 +1699,8 @@ let rec umap2_expr ~function_path fvar shape left right =
                   (Longident.parse "Stdlib.List.length")
                   [ evar ~loc right_name ];
               ])
-           (invalid_argument ~loc (umismatch_message function_path "list length"))
+           (invalid_argument ~loc
+              (umismatch_message function_path "list length"))
            (Some
               (call ~loc
                  (Longident.parse "Stdlib.List.map2")
@@ -1752,8 +1752,7 @@ let rec uiter_expr fvar shape expr =
   | UPayload -> call ~loc (Lident fvar) [ expr ]
   | UStatic -> B.eunit ~loc
   | ULocal name ->
-      call ~loc
-        (Lident (uniform_names_for_type name).uiter)
+      call ~loc (Lident (uniform_names_for_type name).uiter)
         [ evar ~loc fvar; expr ]
   | UUsing module_path ->
       call ~loc (append_lid module_path "iter") [ evar ~loc fvar; expr ]
@@ -1765,7 +1764,8 @@ let rec uiter_expr fvar shape expr =
         [ B.value_binding ~loc ~pat:pattern ~expr:tuple ]
         (B.esequence ~loc
            (List.map2
-              (fun shape name -> uiter_expr fvar shape (evar ~loc:shape.uloc name))
+              (fun shape name ->
+                uiter_expr fvar shape (evar ~loc:shape.uloc name))
               shapes names))
   | UOption shape ->
       let value = gen_symbol ~prefix:"ptree_value" () in
@@ -1810,8 +1810,7 @@ let udelegate_callback ~loc ~path fvar arity =
 let rec ufold_expr ~path fvar shape expr acc_expr =
   let loc = shape.uloc in
   match shape.udesc with
-  | UPayload ->
-      call ~loc (Lident fvar) [ upath_expr ~loc path; acc_expr; expr ]
+  | UPayload -> call ~loc (Lident fvar) [ upath_expr ~loc path; acc_expr; expr ]
   | UStatic -> acc_expr
   | ULocal _ | UUsing _ ->
       let target =
@@ -1820,8 +1819,7 @@ let rec ufold_expr ~path fvar shape expr acc_expr =
         | UUsing module_path -> append_lid module_path "fold"
         | _ -> assert false
       in
-      call ~loc target
-        [ udelegate_callback ~loc ~path fvar 2; acc_expr; expr ]
+      call ~loc target [ udelegate_callback ~loc ~path fvar 2; acc_expr; expr ]
   | UTuple shapes ->
       let names, pattern, tuple =
         tuple_bindings ~loc expr (List.length shapes)
@@ -1991,7 +1989,8 @@ let rec ufold2_expr ~function_path ~path fvar shape left right acc_expr =
                ~lhs:
                  (B.ppat_tuple ~loc
                     [
-                      construct_pattern ~loc "Some" (Some (pvar ~loc left_value));
+                      construct_pattern ~loc "Some"
+                        (Some (pvar ~loc left_value));
                       construct_pattern ~loc "Some"
                         (Some (pvar ~loc right_value));
                     ])
@@ -2043,7 +2042,8 @@ let rec ufold2_expr ~function_path ~path fvar shape left right acc_expr =
                   (Longident.parse "Stdlib.List.length")
                   [ evar ~loc right_name ];
               ])
-           (invalid_argument ~loc (umismatch_message function_path "list length"))
+           (invalid_argument ~loc
+              (umismatch_message function_path "list length"))
            (Some
               (call ~loc
                  (Longident.parse "Stdlib.List.fold_left2")
@@ -2164,7 +2164,8 @@ let rec unames_expr ~path shape expr =
               (fun index shape ->
                 unames_expr
                   ~path:
-                    (Some (ujoin ~loc path (B.estring ~loc (string_of_int index))))
+                    (Some
+                       (ujoin ~loc path (B.estring ~loc (string_of_int index))))
                   shape
                   (evar ~loc (List.nth names index)))
               shapes))
@@ -2240,8 +2241,8 @@ let rec unames_expr ~path shape expr =
 
 let urecord ~loc bindings =
   lets_located
-    (List.map (fun (field_loc, name, expression, _) ->
-         (field_loc, name, expression))
+    (List.map
+       (fun (field_loc, name, expression, _) -> (field_loc, name, expression))
        bindings)
     (B.pexp_record ~loc
        (List.map
@@ -2260,7 +2261,9 @@ let uoperation_body ~loc ~function_path operation ubody =
   let input = evar ~loc "x" in
   let second = evar ~loc "y" in
   let accumulator = evar ~loc "acc" in
-  let field_path label = Some (B.estring ~loc:label.pld_loc label.pld_name.txt) in
+  let field_path label =
+    Some (B.estring ~loc:label.pld_loc label.pld_name.txt)
+  in
   match (operation, ubody) with
   | `Umap, UAlias shape -> umap_expr "f" shape input
   | `Umap, URecord fields ->
@@ -2374,7 +2377,8 @@ let umake_binding ~module_path operation udecl =
   let functions parameters body =
     List.fold_right
       (fun (name, type_) body ->
-        B.pexp_fun ~loc Nolabel None (constrained_parameter ~loc name type_)
+        B.pexp_fun ~loc Nolabel None
+          (constrained_parameter ~loc name type_)
           body)
       parameters body
   in
@@ -2542,6 +2546,7 @@ let uniform_signature ~ctxt type_declarations =
 let strip_ptree_attributes =
   object
     inherit Ast_traverse.map
+
     method! attributes attributes =
       List.filter
         (fun attribute -> not (is_ptree_attribute attribute.attr_name.txt))
@@ -2557,7 +2562,8 @@ let rec shape_has_local shape =
 
 let body_has_local = function
   | Alias shape -> shape_has_local shape
-  | Record fields -> List.exists (fun (_, shape) -> shape_has_local shape) fields
+  | Record fields ->
+      List.exists (fun (_, shape) -> shape_has_local shape) fields
 
 let body_has_leaf =
   let rec shape_has_leaf shape =
@@ -2586,8 +2592,8 @@ let tuple_arguments core_type =
   | Ptyp_tuple elements -> elements
   | _ -> assert false
 
-(* The mirror type of a position: payloads become ['m], delegations become
-   ['m M.Uniform.t], static positions keep their original type. *)
+(* The mirror type of a position: payloads become ['m], delegations become ['m
+   M.Uniform.t], static positions keep their original type. *)
 let rec mirror_type shape core_type =
   let loc = shape.loc in
   match shape.desc with
@@ -2599,7 +2605,8 @@ let rec mirror_type shape core_type =
         [ B.ptyp_var ~loc "m" ]
   | Local _ -> assert false
   | Tuple shapes ->
-      B.ptyp_tuple ~loc (List.map2 mirror_type shapes (tuple_arguments core_type))
+      B.ptyp_tuple ~loc
+        (List.map2 mirror_type shapes (tuple_arguments core_type))
   | Option shape ->
       B.ptyp_constr ~loc (lident ~loc "option")
         [ mirror_type shape (container_argument core_type) ]
@@ -2777,8 +2784,7 @@ let rec of_uniform_shape ~path shape core_type expr =
               (fun index shape ->
                 of_uniform_shape
                   ~path:(string_of_int index :: path)
-                  shape
-                  (List.nth arguments index)
+                  shape (List.nth arguments index)
                   (evar ~loc (List.nth names index)))
               shapes))
   | Option shape ->
@@ -2897,11 +2903,7 @@ let mirror_udeclaration ~loc declaration =
              fields synth_labels)
     | `Record _, _ -> assert false
   in
-  {
-    utype_decl = synth;
-    ubody = Some ubody;
-    udependencies = String_set.empty;
-  }
+  { utype_decl = synth; ubody = Some ubody; udependencies = String_set.empty }
 
 let mirror_check declarations =
   match declarations with
@@ -2999,8 +3001,7 @@ let mirror_to_uniform ~loc declaration =
   in
   B.pstr_value ~loc Nonrecursive
     [
-      B.value_binding ~loc
-        ~pat:(pvar ~loc "to_uniform")
+      B.value_binding ~loc ~pat:(pvar ~loc "to_uniform")
         ~expr:
           (B.pexp_fun ~loc Nolabel None
              (constrained_parameter ~loc "x"
@@ -3020,25 +3021,23 @@ let mirror_of_uniform ~loc declaration =
           (List.map
              (fun (label, shape) ->
                ( lident ~loc:label.pld_name.loc label.pld_name.txt,
-                 of_uniform_shape
-                   ~path:[ label.pld_name.txt ]
-                   shape label.pld_type
+                 of_uniform_shape ~path:[ label.pld_name.txt ] shape
+                   label.pld_type
                    (B.pexp_field ~loc:label.pld_loc (evar ~loc "u")
                       (located_lid ~loc:label.pld_name.loc
-                         (Longident.Ldot (Lident "Uniform", label.pld_name.txt)))) ))
+                         (Longident.Ldot (Lident "Uniform", label.pld_name.txt))))
+               ))
              fields)
           None
     | None -> assert false
   in
   B.pstr_value ~loc Nonrecursive
     [
-      B.value_binding ~loc
-        ~pat:(pvar ~loc "of_uniform")
+      B.value_binding ~loc ~pat:(pvar ~loc "of_uniform")
         ~expr:
           (B.pexp_fun ~loc Nolabel None
              (constrained_parameter ~loc "u" (tensor_uniform_type ~loc))
-             (B.pexp_constraint ~loc body
-                (declared_type declaration.type_decl)));
+             (B.pexp_constraint ~loc body (declared_type declaration.type_decl)));
     ]
 
 let mirror_structure ~ctxt type_declarations =
@@ -3122,7 +3121,7 @@ let mirror_signature ~ctxt type_declarations =
             ]
           else []
         in
-        (module_item :: to_uniform_item :: of_uniform_items)
+        module_item :: to_uniform_item :: of_uniform_items
 
 (* Deriver registration: one deriver, dispatching on the shape of the
    declaration group. *)
@@ -3140,7 +3139,8 @@ let mirror_on_uniform_error type_declarations =
 
 let ptree_structure ~ctxt (recursive, type_declarations) mirror =
   if uniform_group type_declarations then
-    if mirror then structure_errors [ mirror_on_uniform_error type_declarations ]
+    if mirror then
+      structure_errors [ mirror_on_uniform_error type_declarations ]
     else uniform_structure ~ctxt type_declarations
   else
     let base = structure_generator ~ctxt (recursive, type_declarations) in
@@ -3148,7 +3148,8 @@ let ptree_structure ~ctxt (recursive, type_declarations) mirror =
 
 let ptree_signature ~ctxt (recursive, type_declarations) mirror =
   if uniform_group type_declarations then
-    if mirror then signature_errors [ mirror_on_uniform_error type_declarations ]
+    if mirror then
+      signature_errors [ mirror_on_uniform_error type_declarations ]
     else uniform_signature ~ctxt type_declarations
   else
     let base = signature_generator ~ctxt (recursive, type_declarations) in

--- a/packages/ppx_ptree/ppx_ptree.ml
+++ b/packages/ppx_ptree/ppx_ptree.ml
@@ -1140,11 +1140,58 @@ let generate_operation ~module_path operation components =
         (List.map (make_binding ~module_path operation) component))
     components
 
-(* ——————————————————————————————— *)
-(*  Gtree (uniform homomorphic)   *)
-(* ——————————————————————————————— *)
+let structure_generator ~ctxt (_, type_declarations) =
+  let declarations, errors = validate ~signature:false type_declarations in
+  if errors <> [] then structure_errors errors
+  else
+    let module_path =
+      Expansion_context.Deriver.code_path ctxt |> Code_path.fully_qualified_path
+    in
+    let components = ordered_components declarations in
+    List.concat_map
+      (fun operation -> generate_operation ~module_path operation components)
+      [ `Map; `Map2; `Iter ]
 
-type unames = {
+let signature_type operation type_decl =
+  let loc = type_decl.ptype_loc in
+  let variable_a, variable_b = fresh_callback_variables type_decl in
+  let callback = callback_type ~loc operation variable_a variable_b in
+  let type_ = declared_type type_decl in
+  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
+  match operation with
+  | `Map -> arrow callback (arrow type_ type_)
+  | `Map2 -> arrow callback (arrow type_ (arrow type_ type_))
+  | `Iter ->
+      arrow callback (arrow type_ (B.ptyp_constr ~loc (lident ~loc "unit") []))
+
+let signature_generator ~ctxt (_, type_declarations) =
+  let declarations, errors = validate ~signature:true type_declarations in
+  if errors <> [] then signature_errors errors
+  else
+    let add_values declaration =
+      let type_decl = declaration.type_decl in
+      let names = names_for_type type_decl.ptype_name.txt in
+      List.map
+        (fun operation ->
+          let name = operation_name operation names in
+          let loc = type_decl.ptype_name.loc in
+          B.psig_value ~loc
+            (B.value_description ~loc ~name:{ txt = name; loc }
+               ~type_:(signature_type operation type_decl)
+               ~prim:[]))
+        [ `Map; `Map2; `Iter ]
+    in
+    Stdlib.ignore ctxt;
+    List.concat_map add_values declarations
+
+(* Uniform mode: rank-1 traversals over a single payload type parameter.
+
+   A declaration group derives uniform traversals when every type has exactly
+   one named type parameter and at least one declaration mentions its parameter
+   outside tensor leaf types, at a position not annotated with a ptree
+   attribute. Everything else derives the classic rank-2 traversals above. *)
+
+type uniform_names = {
   umap : string;
   umap2 : string;
   uiter : string;
@@ -1175,7 +1222,7 @@ type udeclaration = {
 
 let ushape ~loc desc = { udesc = desc; uloc = loc }
 
-let unames_for_type = function
+let uniform_names_for_type = function
   | "t" | "params" ->
       {
         umap = "map";
@@ -1204,88 +1251,154 @@ let uoperation_name operation names =
   | `Ufold2 -> names.ufold2
   | `Unames -> names.unames
 
-(* Occurrence analysis: does the payload parameter occur at this position? *)
-let rec uclassify_inner validation param_name core_type =
+(* Mode dispatch *)
+
+let single_parameter type_decl =
+  match type_decl.ptype_params with
+  | [ ({ ptyp_desc = Ptyp_var name; _ }, _) ] -> Some name
+  | _ -> None
+
+let is_tensor_path path =
+  is_nx_alias path
+  || is_path path [ "Nx"; "t" ]
+  || is_path path [ "Nx_effect"; "t" ]
+
+let is_ptree_attribute name =
+  String.equal name "ptree.leaf"
+  || String.equal name "ptree.ignore"
+  || String.equal name "ptree.using"
+
+let core_has_ptree_attribute core_type =
+  List.exists
+    (fun attribute -> is_ptree_attribute attribute.attr_name.txt)
+    core_type.ptyp_attributes
+
+let label_has_ptree_attribute label =
+  List.exists
+    (fun attribute -> is_ptree_attribute attribute.attr_name.txt)
+    label.pld_attributes
+
+(* [occurs_bare parameter core_type] holds when the parameter appears outside
+   tensor leaf types and outside ptree-annotated positions; annotated positions
+   keep their rank-2 meaning. [occurs ~respect_attributes:false] detects the
+   parameter even under annotations, to report meaningless annotations. *)
+let rec occurs ~respect_attributes parameter core_type =
+  ((not respect_attributes) || not (core_has_ptree_attribute core_type))
+  &&
+  match core_type.ptyp_desc with
+  | Ptyp_var name -> String.equal name parameter
+  | Ptyp_constr (path, _) when is_tensor_path path.txt -> false
+  | Ptyp_constr (_, arguments) ->
+      List.exists (occurs ~respect_attributes parameter) arguments
+  | Ptyp_tuple elements ->
+      List.exists (occurs ~respect_attributes parameter) elements
+  | Ptyp_alias (inner, _) -> occurs ~respect_attributes parameter inner
+  | Ptyp_arrow (_, left, right) ->
+      occurs ~respect_attributes parameter left
+      || occurs ~respect_attributes parameter right
+  | _ -> false
+
+let occurs_bare = occurs ~respect_attributes:true
+
+let declaration_occurs_bare type_decl =
+  match single_parameter type_decl with
+  | None -> false
+  | Some parameter -> (
+      match (type_decl.ptype_kind, type_decl.ptype_manifest) with
+      | Ptype_record labels, None ->
+          List.exists
+            (fun label ->
+              (not (label_has_ptree_attribute label))
+              && occurs_bare parameter label.pld_type)
+            labels
+      | Ptype_abstract, Some manifest -> occurs_bare parameter manifest
+      | _ -> false)
+
+let uniform_group type_declarations =
+  List.for_all
+    (fun type_decl -> Option.is_some (single_parameter type_decl))
+    type_declarations
+  && List.exists declaration_occurs_bare type_declarations
+
+(* Classification *)
+
+let rec uconsume_attributes validation core_type =
+  Stdlib.ignore (annotation_at_core validation core_type : annotation list);
+  match core_type.ptyp_desc with
+  | Ptyp_tuple elements -> List.iter (uconsume_attributes validation) elements
+  | Ptyp_constr (_, arguments) ->
+      List.iter (uconsume_attributes validation) arguments
+  | Ptyp_alias (inner, _) -> uconsume_attributes validation inner
+  | Ptyp_arrow (_, left, right) ->
+      uconsume_attributes validation left;
+      uconsume_attributes validation right
+  | _ -> ()
+
+let rec uclassify validation parameter core_type =
   let loc = core_type.ptyp_loc in
   match core_type.ptyp_desc with
-  | Ptyp_var name when name = param_name -> ushape ~loc UPayload
-  | Ptyp_var _ -> ushape ~loc UStatic
-  | Ptyp_constr (path, args) when container_kind path.txt <> None ->
-      uclassify_container validation param_name loc path.txt args
-  | Ptyp_constr (path, _)
-    when is_nx_alias path.txt
-         || is_path path.txt [ "Nx"; "t" ]
-         || is_path path.txt [ "Nx_effect"; "t" ] ->
+  | Ptyp_constr (path, _) when is_tensor_path path.txt ->
+      uconsume_attributes validation core_type;
       ushape ~loc UStatic
-  | Ptyp_constr (path, [ arg ]) when Option.is_some (local_name path.txt) -> (
-      let child = uclassify_inner validation param_name arg in
-      if child.udesc = UStatic then ushape ~loc UStatic
-      else
-        match local_name path.txt with
-        | Some name -> ushape ~loc (ULocal name)
-        | None -> assert false)
-  | Ptyp_constr (path, _) when Option.is_some (external_primary path.txt) ->
-      ushape ~loc (UUsing (Option.get (external_primary path.txt)))
+  | _ when not (occurs_bare parameter core_type) ->
+      if occurs ~respect_attributes:false parameter core_type then
+        add_error validation ~loc
+          "ppx_ptree: ptree attributes do not apply to payload positions of \
+           uniform (parameterised) types; the payload parameter determines the \
+           traversal";
+      uconsume_attributes validation core_type;
+      ushape ~loc UStatic
+  | _ ->
+      Stdlib.ignore (annotation_at_core validation core_type : annotation list);
+      uclassify_bare validation parameter core_type
+
+and uclassify_bare validation parameter core_type =
+  let loc = core_type.ptyp_loc in
+  match core_type.ptyp_desc with
+  | Ptyp_var _ -> ushape ~loc UPayload
+  | Ptyp_constr (path, arguments) when container_kind path.txt <> None -> (
+      match (container_kind path.txt, arguments) with
+      | Some `Option, [ argument ] ->
+          ushape ~loc (UOption (uclassify validation parameter argument))
+      | Some `List, [ argument ] ->
+          ushape ~loc (UList (uclassify validation parameter argument))
+      | Some `Array, [ argument ] ->
+          ushape ~loc (UArray (uclassify validation parameter argument))
+      | _ ->
+          add_error validation ~loc
+            "ppx_ptree: container types must have exactly one argument";
+          ushape ~loc UStatic)
+  | Ptyp_constr (path, [ { ptyp_desc = Ptyp_var _; _ } ]) -> (
+      match local_name path.txt with
+      | Some name -> ushape ~loc (ULocal name)
+      | None -> (
+          match external_primary path.txt with
+          | Some module_path -> ushape ~loc (UUsing module_path)
+          | None ->
+              add_error validation ~loc
+                "ppx_ptree: cannot delegate a uniform traversal to [%a]; only \
+                 locally declared types and qualified [M.t] or [M.params] \
+                 types can be applied to the payload parameter"
+                Pprintast.longident path.txt;
+              ushape ~loc UStatic))
   | Ptyp_constr (path, _) ->
       add_error validation ~loc
-        "ppx_ptree: cannot infer a gtree role for [%a]; the type is applied to \
-         a type parameter but is not a known container or tensor. Annotate \
-         with [@gtree.ignore] or use a type that does not mention the payload \
-         parameter"
+        "ppx_ptree: cannot derive a uniform traversal through [%a]; the \
+         payload parameter may appear directly, under tuples, [option], \
+         [list], [array], or as [M.t] applied to the parameter alone"
         Pprintast.longident path.txt;
       ushape ~loc UStatic
-  | Ptyp_tuple args ->
-      ushape ~loc
-        (UTuple (List.map (uclassify_inner validation param_name) args))
-  | Ptyp_alias (inner, _) -> uclassify_inner validation param_name inner
-  | Ptyp_any ->
-      add_error validation ~loc
-        "ppx_ptree: wildcard type [_] has no derivable gtree shape";
-      ushape ~loc UStatic
+  | Ptyp_tuple elements ->
+      ushape ~loc (UTuple (List.map (uclassify validation parameter) elements))
+  | Ptyp_alias (inner, _) -> uclassify validation parameter inner
   | Ptyp_arrow _ ->
       add_error validation ~loc
-        "ppx_ptree: function types are not gtree shapes; annotate with \
-         [@ptree.ignore] or [@gtree.ignore]";
+        "ppx_ptree: function types cannot carry the payload parameter";
       ushape ~loc UStatic
-  | Ptyp_object _ ->
-      add_error validation ~loc "ppx_ptree: object types are not supported";
-      ushape ~loc UStatic
-  | Ptyp_class _ ->
-      add_error validation ~loc "ppx_ptree: class types are not supported";
-      ushape ~loc UStatic
-  | Ptyp_variant _ ->
+  | _ ->
       add_error validation ~loc
-        "ppx_ptree: polymorphic variants are not supported in gtree";
+        "ppx_ptree: this type cannot carry the payload parameter";
       ushape ~loc UStatic
-  | Ptyp_poly _ ->
-      add_error validation ~loc
-        "ppx_ptree: explicitly polymorphic field types are not supported";
-      ushape ~loc UStatic
-  | Ptyp_package _ ->
-      add_error validation ~loc
-        "ppx_ptree: first-class module types are not supported";
-      ushape ~loc UStatic
-  | Ptyp_extension _ ->
-      add_error validation ~loc "ppx_ptree: extension types are not supported";
-      ushape ~loc UStatic
-  | Ptyp_open _ ->
-      add_error validation ~loc
-        "ppx_ptree: locally opened types are not supported";
-      ushape ~loc UStatic
-
-and uclassify_container validation param_name loc path args =
-  match (container_kind path, args) with
-  | Some `Option, [ arg ] ->
-      ushape ~loc (UOption (uclassify_inner validation param_name arg))
-  | Some `List, [ arg ] ->
-      ushape ~loc (UList (uclassify_inner validation param_name arg))
-  | Some `Array, [ arg ] ->
-      ushape ~loc (UArray (uclassify_inner validation param_name arg))
-  | Some _, _ ->
-      add_error validation ~loc
-        "ppx_ptree: container types must have exactly one argument";
-      ushape ~loc UStatic
-  | None, _ -> assert false
 
 let rec udependencies shape =
   match shape.udesc with
@@ -1293,26 +1406,56 @@ let rec udependencies shape =
   | ULocal name -> String_set.singleton name
   | UTuple shapes ->
       List.fold_left
-        (fun result s -> String_set.union result (udependencies s))
+        (fun result shape -> String_set.union result (udependencies shape))
         String_set.empty shapes
   | UOption shape | UList shape | UArray shape -> udependencies shape
 
-let uvalidate_declaration ~signature validation type_decl param_name =
+let rec ushape_has_payload shape =
+  match shape.udesc with
+  | UPayload | ULocal _ | UUsing _ -> true
+  | UStatic -> false
+  | UTuple shapes -> List.exists ushape_has_payload shapes
+  | UOption shape | UList shape | UArray shape -> ushape_has_payload shape
+
+let ubody_has_payload = function
+  | UAlias shape -> ushape_has_payload shape
+  | URecord fields ->
+      List.exists (fun (_, shape) -> ushape_has_payload shape) fields
+
+let uvalidate_declaration ~signature validation type_decl =
+  let parameter =
+    match single_parameter type_decl with
+    | Some parameter -> parameter
+    | None ->
+        add_error validation ~loc:type_decl.ptype_name.loc
+          "ppx_ptree: every type in a uniform declaration group must have \
+           exactly one type parameter";
+        "_"
+  in
+  if (not signature) && type_decl.ptype_private = Private then
+    add_error validation ~loc:type_decl.ptype_name.loc
+      "ppx_ptree: private type implementations cannot be derived";
+  let classify_label label =
+    if
+      annotation_at_label validation label <> []
+      && occurs_bare parameter label.pld_type
+    then
+      add_error validation ~loc:label.pld_loc
+        "ppx_ptree: ptree attributes do not apply to payload positions of \
+         uniform (parameterised) types; the payload parameter determines the \
+         traversal";
+    (label, uclassify validation parameter label.pld_type)
+  in
   let body =
     match (type_decl.ptype_kind, type_decl.ptype_manifest) with
     | Ptype_record labels, None ->
-        Some
-          (URecord
-             (List.map
-                (fun label ->
-                  (label, uclassify_inner validation param_name label.pld_type))
-                labels))
+        Some (URecord (List.map classify_label labels))
     | Ptype_abstract, Some manifest ->
-        Some (UAlias (uclassify_inner validation param_name manifest))
+        Some (UAlias (uclassify validation parameter manifest))
     | Ptype_abstract, None when signature -> None
     | Ptype_abstract, None ->
         add_error validation ~loc:type_decl.ptype_name.loc
-          "ppx_ptree: an abstract implementation has no derivable gtree shape";
+          "ppx_ptree: an abstract implementation has no traversable shape";
         None
     | Ptype_record _, Some _ ->
         add_error validation ~loc:type_decl.ptype_name.loc
@@ -1320,13 +1463,20 @@ let uvalidate_declaration ~signature validation type_decl param_name =
         None
     | Ptype_variant _, _ ->
         add_error validation ~loc:type_decl.ptype_name.loc
-          "ppx_ptree: variant gtree types are not supported in version 1";
+          "ppx_ptree: variants are not supported in version 1";
         None
     | Ptype_open, _ ->
         add_error validation ~loc:type_decl.ptype_name.loc
           "ppx_ptree: extensible variants are not supported";
         None
   in
+  (match body with
+  | Some body when not (ubody_has_payload body) ->
+      add_error validation ~loc:type_decl.ptype_name.loc
+        "ppx_ptree: the type parameter ['%s] of [%s] never occurs in a \
+         payload position"
+        parameter type_decl.ptype_name.txt
+  | _ -> ());
   let dependencies =
     match body with
     | None -> String_set.empty
@@ -1339,78 +1489,16 @@ let uvalidate_declaration ~signature validation type_decl param_name =
   in
   { utype_decl = type_decl; ubody = body; udependencies = dependencies }
 
-let ufind_payload_param validation type_decls =
-  match type_decls with
-  | [] -> None
-  | first :: _ -> (
-      let params = first.ptype_params in
-      match params with
-      | [ (param, _) ] -> (
-          match param.ptyp_desc with
-          | Ptyp_var name -> Some name
-          | _ ->
-              add_error validation ~loc:param.ptyp_loc
-                "ppx_ptree: gtree type parameter must be a type variable";
-              None)
-      | [] -> None
-      | _ ->
-          add_error validation ~loc:first.ptype_name.loc
-            "ppx_ptree: gtree types support exactly one type parameter";
-          None)
-
-let uhas_payload shape =
-  let rec loop s =
-    match s.udesc with
-    | UPayload -> true
-    | UStatic -> false
-    | UTuple shapes -> List.exists loop shapes
-    | UOption shape | UList shape | UArray shape -> loop shape
-    | ULocal _ | UUsing _ ->
-        (* A delegation implies the payload is present in sub-module. Treat as
-           payload at this level — the sub-module check is a compile error. *)
-        true
-  in
-  loop shape
-
 let uvalidate ~signature type_declarations =
   let validation = { errors_rev = [] } in
-  (* Only process if we find a type with a payload param. *)
-  let payload_param = ufind_payload_param validation type_declarations in
+  validate_primary_owner validation type_declarations;
   let declarations =
-    match payload_param with
-    | None -> []
-    | Some param_name ->
-        List.map
-          (fun td ->
-            let decl =
-              uvalidate_declaration ~signature validation td param_name
-            in
-            (* Check that at least one Payload position exists. *)
-            (match decl.ubody with
-            | Some (UAlias s) ->
-                if not (uhas_payload s) then
-                  add_error validation ~loc:td.ptype_name.loc
-                    "ppx_ptree: gtree type parameter [%s] does not occur in a \
-                     payload position; it only appears inside tensor leaf \
-                     types. Use [@@deriving ptree, gtree] for a mirror view \
-                     instead"
-                    param_name
-            | Some (URecord fields) ->
-                if not (List.exists (fun (_, s) -> uhas_payload s) fields) then
-                  add_error validation ~loc:td.ptype_name.loc
-                    "ppx_ptree: gtree type parameter [%s] does not occur in \
-                     any field as a payload; it only appears inside tensor \
-                     leaf types. Use [@@deriving ptree, gtree] for a mirror \
-                     view instead"
-                    param_name
-            | None -> ());
-            decl)
-          type_declarations
+    List.map (uvalidate_declaration ~signature validation) type_declarations
   in
-  let errors = List.rev validation.errors_rev in
-  (declarations, errors)
+  (declarations, List.rev validation.errors_rev)
 
-(* Wrap udeclarations as declarations for the SCC ordering machinery. *)
+(* Uniform declarations reuse the rank-2 component ordering by wrapping. *)
+
 let udecl_to_decl udecl =
   {
     type_decl = udecl.utype_decl;
@@ -1419,77 +1507,45 @@ let udecl_to_decl udecl =
   }
 
 let uordered_components declarations =
-  let wrapped = List.map udecl_to_decl declarations in
-  let components = strongly_connected_components wrapped in
-  let result = ref [] in
-  List.iter
-    (fun comp_names ->
-      let comp_decls =
-        List.map
-          (fun name ->
-            List.find
-              (fun udecl -> udecl.utype_decl.ptype_name.txt = name)
-              declarations)
-          comp_names
-      in
-      result := comp_decls :: !result)
-    components;
-  List.rev !result
+  let components = ordered_components (List.map udecl_to_decl declarations) in
+  List.map
+    (List.map (fun declaration ->
+         List.find
+           (fun udecl ->
+             String.equal udecl.utype_decl.ptype_name.txt
+               declaration.type_decl.ptype_name.txt)
+           declarations))
+    components
 
 let ucomponent_rec_flag component =
   match component with
   | [] -> assert false
   | [ udecl ] ->
-      if String_set.mem udecl.utype_decl.ptype_name.txt udecl.udependencies then
-        Recursive
+      if String_set.mem udecl.utype_decl.ptype_name.txt udecl.udependencies
+      then Recursive
       else Nonrecursive
   | _ -> Recursive
 
-(* ——— Codegen ——— *)
+(* Leaf paths: [None] at the root, otherwise a string expression holding the
+   dot-joined segments so far. Top-level segments are bare; deeper segments
+   are appended with ["."], matching the checkpoint naming convention. *)
 
-let payload_callback_shape ~loc var_a var_b =
-  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
-  let type_ = B.ptyp_var ~loc var_a in
-  let result = B.ptyp_var ~loc var_b in
-  arrow type_ result
+let ujoin ~loc path segment =
+  match path with
+  | None -> segment
+  | Some path ->
+      call ~loc (Longident.Lident "^")
+        [ call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ];
+          segment ]
 
-let payload_callback2_shape ~loc var_a var_b var_c =
-  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
-  let type_a = B.ptyp_var ~loc var_a in
-  let type_b = B.ptyp_var ~loc var_b in
-  let type_c = B.ptyp_var ~loc var_c in
-  arrow type_a (arrow type_b type_c)
+let upath_expr ~loc path =
+  match path with None -> B.estring ~loc "" | Some path -> path
 
-let callback_with_path_shape ~loc callback_path callback_payload acc_var =
-  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
-  let string_type = B.ptyp_constr ~loc (lident ~loc "string") [] in
-  arrow string_type (arrow callback_payload (arrow acc_var acc_var))
+let umismatch_message function_path kind =
+  Format.sprintf "%s: %s mismatch" function_path kind
 
-let ufunction_expression ~loc ~callback_type ~input_types body =
-  let callback = constrained_parameter ~loc "f" callback_type in
-  let inputs =
-    List.mapi
-      (fun index type_ ->
-        let name =
-          match index with
-          | 0 -> "x"
-          | 1 -> "y"
-          | 2 -> "z"
-          | _ -> Printf.sprintf "p%d" index
-        in
-        constrained_parameter ~loc name type_)
-      input_types
-  in
-  List.fold_right
-    (fun pattern body -> B.pexp_fun ~loc Nolabel None pattern body)
-    (callback :: inputs) body
+(* map *)
 
-let unames_target_type ~loc type_ =
-  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
-  let string_type = B.ptyp_constr ~loc (lident ~loc "string") [] in
-  arrow type_ string_type
-
-(* — map — rank-1, much simpler than ptree map *)
 let rec umap_expr fvar shape expr =
   let loc = shape.uloc in
   match shape.udesc with
@@ -1497,7 +1553,7 @@ let rec umap_expr fvar shape expr =
   | UStatic -> expr
   | ULocal name ->
       call ~loc
-        (Longident.Ldot (Lident (names_for_type name).map, fvar))
+        (Lident (uniform_names_for_type name).umap)
         [ evar ~loc fvar; expr ]
   | UUsing module_path ->
       call ~loc (append_lid module_path "map") [ evar ~loc fvar; expr ]
@@ -1548,7 +1604,8 @@ let rec umap_expr fvar shape expr =
       in
       call ~loc (Longident.parse "Stdlib.Array.map") [ mapper; expr ]
 
-(* — map2 — *)
+(* map2 *)
+
 let rec umap2_expr ~function_path fvar shape left right =
   let loc = shape.uloc in
   match shape.udesc with
@@ -1556,7 +1613,7 @@ let rec umap2_expr ~function_path fvar shape left right =
   | UStatic -> left
   | ULocal name ->
       call ~loc
-        (Longident.Ldot (Lident (names_for_type name).map2, fvar))
+        (Lident (uniform_names_for_type name).umap2)
         [ evar ~loc fvar; left; right ]
   | UUsing module_path ->
       call ~loc (append_lid module_path "map2") [ evar ~loc fvar; left; right ]
@@ -1588,8 +1645,8 @@ let rec umap2_expr ~function_path fvar shape left right =
   | UOption shape ->
       let left_value = gen_symbol ~prefix:"ptree_left" () in
       let right_value = gen_symbol ~prefix:"ptree_right" () in
-      let pair = B.pexp_tuple ~loc [ left; right ] in
-      B.pexp_match ~loc pair
+      B.pexp_match ~loc
+        (B.pexp_tuple ~loc [ left; right ])
         [
           B.case
             ~lhs:
@@ -1617,86 +1674,78 @@ let rec umap2_expr ~function_path fvar shape left right =
           B.case ~lhs:(B.ppat_any ~loc) ~guard:None
             ~rhs:
               (invalid_argument ~loc
-                 (mismatch_message function_path "option constructor" []));
+                 (umismatch_message function_path "option constructor"));
         ]
-  | UList shape -> umap2_list ~loc ~function_path fvar shape left right
-  | UArray shape -> umap2_array ~loc ~function_path fvar shape left right
-
-and umap2_list ~loc ~function_path fvar shape left right =
-  let left_name = gen_symbol ~prefix:"ptree_left" () in
-  let right_name = gen_symbol ~prefix:"ptree_right" () in
-  let left_length = gen_symbol ~prefix:"ptree_left_length" () in
-  let right_length = gen_symbol ~prefix:"ptree_right_length" () in
-  let left_value = gen_symbol ~prefix:"ptree_left_value" () in
-  let right_value = gen_symbol ~prefix:"ptree_right_value" () in
-  let mapper =
-    B.pexp_fun ~loc Nolabel None (pvar ~loc left_value)
-      (B.pexp_fun ~loc Nolabel None (pvar ~loc right_value)
-         (umap2_expr ~function_path fvar shape
-            (evar ~loc:shape.uloc left_value)
-            (evar ~loc:shape.uloc right_value)))
-  in
-  lets ~loc
-    [
-      (left_name, left);
-      (right_name, right);
-      ( left_length,
-        call ~loc (Longident.parse "Stdlib.List.length") [ evar ~loc left_name ]
-      );
-      ( right_length,
+  | UList shape ->
+      let left_name = gen_symbol ~prefix:"ptree_left" () in
+      let right_name = gen_symbol ~prefix:"ptree_right" () in
+      let left_value = gen_symbol ~prefix:"ptree_left_value" () in
+      let right_value = gen_symbol ~prefix:"ptree_right_value" () in
+      let mapper =
+        B.pexp_fun ~loc Nolabel None (pvar ~loc left_value)
+          (B.pexp_fun ~loc Nolabel None (pvar ~loc right_value)
+             (umap2_expr ~function_path fvar shape
+                (evar ~loc:shape.uloc left_value)
+                (evar ~loc:shape.uloc right_value)))
+      in
+      lets ~loc
+        [ (left_name, left); (right_name, right) ]
+        (B.pexp_ifthenelse ~loc
+           (call ~loc (Longident.Lident "<>")
+              [
+                call ~loc
+                  (Longident.parse "Stdlib.List.length")
+                  [ evar ~loc left_name ];
+                call ~loc
+                  (Longident.parse "Stdlib.List.length")
+                  [ evar ~loc right_name ];
+              ])
+           (invalid_argument ~loc (umismatch_message function_path "list length"))
+           (Some
+              (call ~loc
+                 (Longident.parse "Stdlib.List.map2")
+                 [ mapper; evar ~loc left_name; evar ~loc right_name ])))
+  | UArray shape ->
+      let left_name = gen_symbol ~prefix:"ptree_left" () in
+      let right_name = gen_symbol ~prefix:"ptree_right" () in
+      let length_name = gen_symbol ~prefix:"ptree_length" () in
+      let index = gen_symbol ~prefix:"ptree_index" () in
+      let value_at array =
         call ~loc
-          (Longident.parse "Stdlib.List.length")
-          [ evar ~loc right_name ] );
-    ]
-    (B.pexp_ifthenelse ~loc
-       (call ~loc (Longident.Lident "<>")
-          [ evar ~loc left_length; evar ~loc right_length ])
-       (invalid_argument ~loc (mismatch_message function_path "list length" []))
-       (Some
-          (call ~loc
-             (Longident.parse "Stdlib.List.map2")
-             [ mapper; evar ~loc left_name; evar ~loc right_name ])))
+          (Longident.parse "Stdlib.Array.unsafe_get")
+          [ evar ~loc array; evar ~loc index ]
+      in
+      let array_initializer =
+        B.pexp_fun ~loc Nolabel None (pvar ~loc index)
+          (umap2_expr ~function_path fvar shape (value_at left_name)
+             (value_at right_name))
+      in
+      lets ~loc
+        [
+          (left_name, left);
+          (right_name, right);
+          ( length_name,
+            call ~loc
+              (Longident.parse "Stdlib.Array.length")
+              [ evar ~loc left_name ] );
+        ]
+        (B.pexp_ifthenelse ~loc
+           (call ~loc (Longident.Lident "<>")
+              [
+                evar ~loc length_name;
+                call ~loc
+                  (Longident.parse "Stdlib.Array.length")
+                  [ evar ~loc right_name ];
+              ])
+           (invalid_argument ~loc
+              (umismatch_message function_path "array length"))
+           (Some
+              (call ~loc
+                 (Longident.parse "Stdlib.Array.init")
+                 [ evar ~loc length_name; array_initializer ])))
 
-and umap2_array ~loc ~function_path fvar shape left right =
-  let left_name = gen_symbol ~prefix:"ptree_left" () in
-  let right_name = gen_symbol ~prefix:"ptree_right" () in
-  let left_length = gen_symbol ~prefix:"ptree_left_length" () in
-  let right_length = gen_symbol ~prefix:"ptree_right_length" () in
-  let index = gen_symbol ~prefix:"ptree_index" () in
-  let value_at arr =
-    call ~loc
-      (Longident.parse "Stdlib.Array.unsafe_get")
-      [ evar ~loc arr; evar ~loc index ]
-  in
-  let array_initializer =
-    B.pexp_fun ~loc Nolabel None (pvar ~loc index)
-      (umap2_expr ~function_path fvar shape (value_at left_name)
-         (value_at right_name))
-  in
-  lets ~loc
-    [
-      (left_name, left);
-      (right_name, right);
-      ( left_length,
-        call ~loc
-          (Longident.parse "Stdlib.Array.length")
-          [ evar ~loc left_name ] );
-      ( right_length,
-        call ~loc
-          (Longident.parse "Stdlib.Array.length")
-          [ evar ~loc right_name ] );
-    ]
-    (B.pexp_ifthenelse ~loc
-       (call ~loc (Longident.Lident "<>")
-          [ evar ~loc left_length; evar ~loc right_length ])
-       (invalid_argument ~loc
-          (mismatch_message function_path "array length" []))
-       (Some
-          (call ~loc
-             (Longident.parse "Stdlib.Array.init")
-             [ evar ~loc left_length; array_initializer ])))
+(* iter *)
 
-(* — iter — *)
 let rec uiter_expr fvar shape expr =
   let loc = shape.uloc in
   match shape.udesc with
@@ -1704,7 +1753,7 @@ let rec uiter_expr fvar shape expr =
   | UStatic -> B.eunit ~loc
   | ULocal name ->
       call ~loc
-        (Longident.Ldot (Lident (names_for_type name).iter, fvar))
+        (Lident (uniform_names_for_type name).uiter)
         [ evar ~loc fvar; expr ]
   | UUsing module_path ->
       call ~loc (append_lid module_path "iter") [ evar ~loc fvar; expr ]
@@ -1716,8 +1765,7 @@ let rec uiter_expr fvar shape expr =
         [ B.value_binding ~loc ~pat:pattern ~expr:tuple ]
         (B.esequence ~loc
            (List.map2
-              (fun shape name ->
-                uiter_expr fvar shape (evar ~loc:shape.uloc name))
+              (fun shape name -> uiter_expr fvar shape (evar ~loc:shape.uloc name))
               shapes names))
   | UOption shape ->
       let value = gen_symbol ~prefix:"ptree_value" () in
@@ -1746,295 +1794,160 @@ let rec uiter_expr fvar shape expr =
       in
       call ~loc (Longident.parse "Stdlib.Array.iter") [ iterator; expr ]
 
-(* — fold (with paths) —
+(* fold: the callback receives the leaf path, the accumulator, then the leaf.
+   Delegation re-roots the sub-structure's paths under the current path. *)
 
-   ~path: an OCaml expression of type string evaluating to the path segment for
-   this position (e.g. the field name, or "prefix." ^ idx for list items). At
-   the top level this is the empty string literal "". *)
+let udelegate_callback ~loc ~path fvar arity =
+  let sub_path = gen_symbol ~prefix:"ptree_path" () in
+  let rest = List.init arity (fun _ -> gen_symbol ~prefix:"ptree_arg" ()) in
+  B.pexp_fun ~loc Nolabel None (pvar ~loc sub_path)
+    (List.fold_right
+       (fun name body -> B.pexp_fun ~loc Nolabel None (pvar ~loc name) body)
+       rest
+       (call ~loc (Lident fvar)
+          (ujoin ~loc path (evar ~loc sub_path) :: List.map (evar ~loc) rest)))
 
 let rec ufold_expr ~path fvar shape expr acc_expr =
   let loc = shape.uloc in
   match shape.udesc with
   | UPayload ->
-      (* f path acc expr *)
-      call ~loc (Lident fvar) [ path; acc_expr; expr ]
+      call ~loc (Lident fvar) [ upath_expr ~loc path; acc_expr; expr ]
   | UStatic -> acc_expr
-  | ULocal name ->
-      let fold_name = (unames_for_type name).ufold in
-      let sub_path = gen_symbol ~prefix:"u_p" () in
-      let sub_acc = gen_symbol ~prefix:"u_a" () in
-      let sub_x = gen_symbol ~prefix:"u_x" () in
-      (* name.fold (fun p a x -> f (path ^ "." ^ p) a x) acc expr *)
-      let callback =
-        B.pexp_fun ~loc Nolabel None (pvar ~loc sub_path)
-          (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_acc)
-             (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_x)
-                (call ~loc (Lident fvar)
-                   [
-                     call ~loc (Longident.Lident "^")
-                       [
-                         call ~loc (Longident.Lident "^")
-                           [ path; B.estring ~loc "." ];
-                         evar ~loc sub_path;
-                       ];
-                     evar ~loc sub_acc;
-                     evar ~loc sub_x;
-                   ])))
+  | ULocal _ | UUsing _ ->
+      let target =
+        match shape.udesc with
+        | ULocal name -> Longident.Lident (uniform_names_for_type name).ufold
+        | UUsing module_path -> append_lid module_path "fold"
+        | _ -> assert false
       in
-      call ~loc
-        (Longident.Ldot (Lident name, fold_name))
-        [ callback; acc_expr; expr ]
-  | UUsing module_path ->
-      let sub_path = gen_symbol ~prefix:"u_p" () in
-      let sub_acc = gen_symbol ~prefix:"u_a" () in
-      let sub_x = gen_symbol ~prefix:"u_x" () in
-      let callback =
-        B.pexp_fun ~loc Nolabel None (pvar ~loc sub_path)
-          (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_acc)
-             (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_x)
-                (call ~loc (Lident fvar)
-                   [
-                     call ~loc (Longident.Lident "^")
-                       [
-                         call ~loc (Longident.Lident "^")
-                           [ path; B.estring ~loc "." ];
-                         evar ~loc sub_path;
-                       ];
-                     evar ~loc sub_acc;
-                     evar ~loc sub_x;
-                   ])))
-      in
-      call ~loc (append_lid module_path "fold") [ callback; acc_expr; expr ]
+      call ~loc target
+        [ udelegate_callback ~loc ~path fvar 2; acc_expr; expr ]
   | UTuple shapes ->
       let names, pattern, tuple =
         tuple_bindings ~loc expr (List.length shapes)
       in
-      (* let (x0, x1, ...) = expr in f (path ^ ".0") x0 (f (path ^ ".1") x1 (...
-         acc)) *)
-      let rec thread idx acc shapes names =
-        match (shapes, names) with
-        | [], [] -> acc
-        | shape :: rest_shapes, name :: rest_names ->
-            let child_path =
-              call ~loc (Longident.Lident "^")
-                [
-                  call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ];
-                  B.estring ~loc (string_of_int idx);
-                ]
-            in
-            ufold_expr ~path:child_path fvar shape (evar ~loc name)
-              (thread (idx + 1) acc rest_shapes rest_names)
-        | _ -> assert false
+      let _, threaded =
+        List.fold_left2
+          (fun (index, acc) shape name ->
+            ( index + 1,
+              ufold_expr
+                ~path:
+                  (Some (ujoin ~loc path (B.estring ~loc (string_of_int index))))
+                fvar shape (evar ~loc name) acc ))
+          (0, acc_expr) shapes names
       in
       B.pexp_let ~loc Nonrecursive
         [ B.value_binding ~loc ~pat:pattern ~expr:tuple ]
-        (thread 0 acc_expr shapes names)
+        threaded
   | UOption shape ->
-      let value = gen_symbol ~prefix:"u_opt" () in
-      B.pexp_match ~loc expr
-        [
-          B.case
-            ~lhs:(construct_pattern ~loc "None" None)
-            ~guard:None ~rhs:acc_expr;
-          B.case
-            ~lhs:(construct_pattern ~loc "Some" (Some (pvar ~loc value)))
-            ~guard:None
-            ~rhs:
-              (ufold_expr ~path fvar shape
-                 (evar ~loc:shape.uloc value)
-                 acc_expr);
-        ]
+      let acc_name = gen_symbol ~prefix:"ptree_acc" () in
+      let value = gen_symbol ~prefix:"ptree_value" () in
+      let_one ~loc acc_name acc_expr
+        (B.pexp_match ~loc expr
+           [
+             B.case
+               ~lhs:(construct_pattern ~loc "None" None)
+               ~guard:None ~rhs:(evar ~loc acc_name);
+             B.case
+               ~lhs:(construct_pattern ~loc "Some" (Some (pvar ~loc value)))
+               ~guard:None
+               ~rhs:
+                 (ufold_expr ~path fvar shape
+                    (evar ~loc:shape.uloc value)
+                    (evar ~loc acc_name));
+           ])
   | UList shape ->
-      let acc_p = gen_symbol ~prefix:"u_a" () in
-      let idx_v = gen_symbol ~prefix:"u_i" () in
-      let val_v = gen_symbol ~prefix:"u_v" () in
-      let pair_v = gen_symbol ~prefix:"u_p" () in
+      let acc_name = gen_symbol ~prefix:"ptree_acc" () in
+      let index = gen_symbol ~prefix:"ptree_index" () in
+      let value = gen_symbol ~prefix:"ptree_value" () in
+      let pair = gen_symbol ~prefix:"ptree_pair" () in
       let child_path =
-        call ~loc (Longident.Lident "^")
-          [
-            call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ];
-            call ~loc
-              (Longident.parse "Stdlib.string_of_int")
-              [ evar ~loc idx_v ];
-          ]
+        Some
+          (ujoin ~loc path
+             (call ~loc
+                (Longident.parse "Stdlib.string_of_int")
+                [ evar ~loc index ]))
       in
       let inner_body =
         B.pexp_let ~loc Nonrecursive
           [
             B.value_binding ~loc
-              ~pat:(B.ppat_tuple ~loc [ pvar ~loc idx_v; pvar ~loc val_v ])
-              ~expr:(evar ~loc pair_v);
+              ~pat:(B.ppat_tuple ~loc [ pvar ~loc index; pvar ~loc value ])
+              ~expr:(evar ~loc pair);
           ]
-          (ufold_expr ~path:child_path fvar shape (evar ~loc val_v)
-             (evar ~loc acc_p))
+          (ufold_expr ~path:child_path fvar shape (evar ~loc value)
+             (evar ~loc acc_name))
       in
       call ~loc
         (Longident.parse "Stdlib.List.fold_left")
         [
-          B.pexp_fun ~loc Nolabel None (pvar ~loc acc_p)
-            (B.pexp_fun ~loc Nolabel None (pvar ~loc pair_v) inner_body);
+          B.pexp_fun ~loc Nolabel None (pvar ~loc acc_name)
+            (B.pexp_fun ~loc Nolabel None (pvar ~loc pair) inner_body);
           acc_expr;
           call ~loc
             (Longident.parse "Stdlib.List.mapi")
             [
-              B.pexp_fun ~loc Nolabel None (pvar ~loc idx_v)
-                (B.pexp_fun ~loc Nolabel None (pvar ~loc val_v)
-                   (B.pexp_tuple ~loc [ evar ~loc idx_v; evar ~loc val_v ]));
+              B.pexp_fun ~loc Nolabel None (pvar ~loc index)
+                (B.pexp_fun ~loc Nolabel None (pvar ~loc value)
+                   (B.pexp_tuple ~loc [ evar ~loc index; evar ~loc value ]));
               expr;
             ];
         ]
   | UArray shape ->
-      let acc_p = gen_symbol ~prefix:"u_a" () in
-      let idx_v = gen_symbol ~prefix:"u_i" () in
-      let val_v = gen_symbol ~prefix:"u_v" () in
-      let pair_v = gen_symbol ~prefix:"u_p" () in
+      let acc_name = gen_symbol ~prefix:"ptree_acc" () in
+      let index = gen_symbol ~prefix:"ptree_index" () in
+      let value = gen_symbol ~prefix:"ptree_value" () in
+      let pair = gen_symbol ~prefix:"ptree_pair" () in
       let child_path =
-        call ~loc (Longident.Lident "^")
-          [
-            call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ];
-            call ~loc
-              (Longident.parse "Stdlib.string_of_int")
-              [ evar ~loc idx_v ];
-          ]
+        Some
+          (ujoin ~loc path
+             (call ~loc
+                (Longident.parse "Stdlib.string_of_int")
+                [ evar ~loc index ]))
       in
       let inner_body =
         B.pexp_let ~loc Nonrecursive
           [
             B.value_binding ~loc
-              ~pat:(B.ppat_tuple ~loc [ pvar ~loc idx_v; pvar ~loc val_v ])
-              ~expr:(evar ~loc pair_v);
+              ~pat:(B.ppat_tuple ~loc [ pvar ~loc index; pvar ~loc value ])
+              ~expr:(evar ~loc pair);
           ]
-          (ufold_expr ~path:child_path fvar shape (evar ~loc val_v)
-             (evar ~loc acc_p))
+          (ufold_expr ~path:child_path fvar shape (evar ~loc value)
+             (evar ~loc acc_name))
       in
       call ~loc
         (Longident.parse "Stdlib.Array.fold_left")
         [
-          B.pexp_fun ~loc Nolabel None (pvar ~loc acc_p)
-            (B.pexp_fun ~loc Nolabel None (pvar ~loc pair_v) inner_body);
+          B.pexp_fun ~loc Nolabel None (pvar ~loc acc_name)
+            (B.pexp_fun ~loc Nolabel None (pvar ~loc pair) inner_body);
           acc_expr;
           call ~loc
             (Longident.parse "Stdlib.Array.mapi")
             [
-              B.pexp_fun ~loc Nolabel None (pvar ~loc idx_v)
-                (B.pexp_fun ~loc Nolabel None (pvar ~loc val_v)
-                   (B.pexp_tuple ~loc [ evar ~loc idx_v; evar ~loc val_v ]));
+              B.pexp_fun ~loc Nolabel None (pvar ~loc index)
+                (B.pexp_fun ~loc Nolabel None (pvar ~loc value)
+                   (B.pexp_tuple ~loc [ evar ~loc index; evar ~loc value ]));
               expr;
             ];
         ]
 
-let structure_generator ~ctxt (_, type_declarations) =
-  let declarations, errors = validate ~signature:false type_declarations in
-  if errors <> [] then structure_errors errors
-  else
-    let module_path =
-      Expansion_context.Deriver.code_path ctxt |> Code_path.fully_qualified_path
-    in
-    let components = ordered_components declarations in
-    List.concat_map
-      (fun operation -> generate_operation ~module_path operation components)
-      [ `Map; `Map2; `Iter ]
+(* fold2 *)
 
-let signature_type operation type_decl =
-  let loc = type_decl.ptype_loc in
-  let variable_a, variable_b = fresh_callback_variables type_decl in
-  let callback = callback_type ~loc operation variable_a variable_b in
-  let type_ = declared_type type_decl in
-  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
-  match operation with
-  | `Map -> arrow callback (arrow type_ type_)
-  | `Map2 -> arrow callback (arrow type_ (arrow type_ type_))
-  | `Iter ->
-      arrow callback (arrow type_ (B.ptyp_constr ~loc (lident ~loc "unit") []))
-
-let signature_generator ~ctxt (_, type_declarations) =
-  let declarations, errors = validate ~signature:true type_declarations in
-  if errors <> [] then signature_errors errors
-  else
-    let add_values declaration =
-      let type_decl = declaration.type_decl in
-      let names = names_for_type type_decl.ptype_name.txt in
-      List.map
-        (fun operation ->
-          let name = operation_name operation names in
-          let loc = type_decl.ptype_name.loc in
-          B.psig_value ~loc
-            (B.value_description ~loc ~name:{ txt = name; loc }
-               ~type_:(signature_type operation type_decl)
-               ~prim:[]))
-        [ `Map; `Map2; `Iter ]
-    in
-    Stdlib.ignore ctxt;
-    List.concat_map add_values declarations
-
-(* ——————————————————————————————— *)
-(*  Gtree — fold2, names, &        *)
-(*  structure / signature           *)
-(*  generators and deriver          *)
-(* ——————————————————————————————— *)
-
-(* For fold2, the path threading is identical to fold; we just pass two value
-   expressions (left and right) to the callback, include structural equality
-   checks for containers, and skip static fields. *)
-
-let rec ufold2_expr ~path fvar shape left right acc_expr =
+let rec ufold2_expr ~function_path ~path fvar shape left right acc_expr =
   let loc = shape.uloc in
   match shape.udesc with
-  | UPayload -> call ~loc (Lident fvar) [ path; acc_expr; left; right ]
+  | UPayload ->
+      call ~loc (Lident fvar) [ upath_expr ~loc path; acc_expr; left; right ]
   | UStatic -> acc_expr
-  | ULocal name ->
-      let fold2_name = (unames_for_type name).ufold2 in
-      let sub_p = gen_symbol ~prefix:"u2_p" () in
-      let sub_a = gen_symbol ~prefix:"u2_a" () in
-      let sub_x = gen_symbol ~prefix:"u2_x" () in
-      let sub_y = gen_symbol ~prefix:"u2_y" () in
-      let callback =
-        B.pexp_fun ~loc Nolabel None (pvar ~loc sub_p)
-          (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_a)
-             (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_x)
-                (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_y)
-                   (call ~loc (Lident fvar)
-                      [
-                        call ~loc (Longident.Lident "^")
-                          [
-                            call ~loc (Longident.Lident "^")
-                              [ path; B.estring ~loc "." ];
-                            evar ~loc sub_p;
-                          ];
-                        evar ~loc sub_a;
-                        evar ~loc sub_x;
-                        evar ~loc sub_y;
-                      ]))))
+  | ULocal _ | UUsing _ ->
+      let target =
+        match shape.udesc with
+        | ULocal name -> Longident.Lident (uniform_names_for_type name).ufold2
+        | UUsing module_path -> append_lid module_path "fold2"
+        | _ -> assert false
       in
-      call ~loc
-        (Longident.Ldot (Lident name, fold2_name))
-        [ callback; acc_expr; left; right ]
-  | UUsing module_path ->
-      let sub_p = gen_symbol ~prefix:"u2_p" () in
-      let sub_a = gen_symbol ~prefix:"u2_a" () in
-      let sub_x = gen_symbol ~prefix:"u2_x" () in
-      let sub_y = gen_symbol ~prefix:"u2_y" () in
-      let callback =
-        B.pexp_fun ~loc Nolabel None (pvar ~loc sub_p)
-          (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_a)
-             (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_x)
-                (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_y)
-                   (call ~loc (Lident fvar)
-                      [
-                        call ~loc (Longident.Lident "^")
-                          [
-                            call ~loc (Longident.Lident "^")
-                              [ path; B.estring ~loc "." ];
-                            evar ~loc sub_p;
-                          ];
-                        evar ~loc sub_a;
-                        evar ~loc sub_x;
-                        evar ~loc sub_y;
-                      ]))))
-      in
-      call ~loc
-        (append_lid module_path "fold2")
-        [ callback; acc_expr; left; right ]
+      call ~loc target
+        [ udelegate_callback ~loc ~path fvar 3; acc_expr; left; right ]
   | UTuple shapes ->
       let left_names, left_pattern, left_tuple =
         tuple_bindings ~loc left (List.length shapes)
@@ -2042,251 +1955,335 @@ let rec ufold2_expr ~path fvar shape left right acc_expr =
       let right_names, right_pattern, right_tuple =
         tuple_bindings ~loc right (List.length shapes)
       in
-      let rec thread idx acc shapes lnames rnames =
-        match (shapes, lnames, rnames) with
-        | [], [], [] -> acc
-        | shape :: rest_shapes, lname :: rest_lnames, rname :: rest_rnames ->
-            let child_path =
-              call ~loc (Longident.Lident "^")
-                [
-                  call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ];
-                  B.estring ~loc (string_of_int idx);
-                ]
-            in
-            ufold2_expr ~path:child_path fvar shape (evar ~loc lname)
-              (evar ~loc rname)
-              (thread (idx + 1) acc rest_shapes rest_lnames rest_rnames)
-        | _ -> assert false
+      let _, threaded =
+        List.fold_left2
+          (fun (index, acc) shape (left_name, right_name) ->
+            ( index + 1,
+              ufold2_expr ~function_path
+                ~path:
+                  (Some (ujoin ~loc path (B.estring ~loc (string_of_int index))))
+                fvar shape (evar ~loc left_name) (evar ~loc right_name) acc ))
+          (0, acc_expr) shapes
+          (List.combine left_names right_names)
       in
       B.pexp_let ~loc Nonrecursive
         [ B.value_binding ~loc ~pat:left_pattern ~expr:left_tuple ]
         (B.pexp_let ~loc Nonrecursive
            [ B.value_binding ~loc ~pat:right_pattern ~expr:right_tuple ]
-           (thread 0 acc_expr shapes left_names right_names))
+           threaded)
   | UOption shape ->
-      let lv = gen_symbol ~prefix:"u2_l" () in
-      let rv = gen_symbol ~prefix:"u2_r" () in
-      B.pexp_match ~loc
-        (B.pexp_tuple ~loc [ left; right ])
-        [
-          B.case
-            ~lhs:
-              (B.ppat_tuple ~loc
-                 [
-                   construct_pattern ~loc "None" None;
-                   construct_pattern ~loc "None" None;
-                 ])
-            ~guard:None ~rhs:acc_expr;
-          B.case
-            ~lhs:
-              (B.ppat_tuple ~loc
-                 [
-                   construct_pattern ~loc "Some" (Some (pvar ~loc lv));
-                   construct_pattern ~loc "Some" (Some (pvar ~loc rv));
-                 ])
-            ~guard:None
-            ~rhs:
-              (ufold2_expr ~path fvar shape (evar ~loc lv) (evar ~loc rv)
-                 acc_expr);
-          B.case ~lhs:(B.ppat_any ~loc) ~guard:None
-            ~rhs:(invalid_argument ~loc "ufold2: option constructor mismatch");
-        ]
+      let acc_name = gen_symbol ~prefix:"ptree_acc" () in
+      let left_value = gen_symbol ~prefix:"ptree_left" () in
+      let right_value = gen_symbol ~prefix:"ptree_right" () in
+      let_one ~loc acc_name acc_expr
+        (B.pexp_match ~loc
+           (B.pexp_tuple ~loc [ left; right ])
+           [
+             B.case
+               ~lhs:
+                 (B.ppat_tuple ~loc
+                    [
+                      construct_pattern ~loc "None" None;
+                      construct_pattern ~loc "None" None;
+                    ])
+               ~guard:None ~rhs:(evar ~loc acc_name);
+             B.case
+               ~lhs:
+                 (B.ppat_tuple ~loc
+                    [
+                      construct_pattern ~loc "Some" (Some (pvar ~loc left_value));
+                      construct_pattern ~loc "Some"
+                        (Some (pvar ~loc right_value));
+                    ])
+               ~guard:None
+               ~rhs:
+                 (ufold2_expr ~function_path ~path fvar shape
+                    (evar ~loc:shape.uloc left_value)
+                    (evar ~loc:shape.uloc right_value)
+                    (evar ~loc acc_name));
+             B.case ~lhs:(B.ppat_any ~loc) ~guard:None
+               ~rhs:
+                 (invalid_argument ~loc
+                    (umismatch_message function_path "option constructor"));
+           ])
   | UList shape ->
-      let acc_p = gen_symbol ~prefix:"u2_a" () in
-      let idx_v = gen_symbol ~prefix:"u2_i" () in
-      let val_v = gen_symbol ~prefix:"u2_v" () in
-      let val_w = gen_symbol ~prefix:"u2_w" () in
-      let pair_v = gen_symbol ~prefix:"u2_p" () in
+      let left_name = gen_symbol ~prefix:"ptree_left" () in
+      let right_name = gen_symbol ~prefix:"ptree_right" () in
+      let acc_name = gen_symbol ~prefix:"ptree_acc" () in
+      let index = gen_symbol ~prefix:"ptree_index" () in
+      let left_value = gen_symbol ~prefix:"ptree_left_value" () in
+      let right_value = gen_symbol ~prefix:"ptree_right_value" () in
+      let pair = gen_symbol ~prefix:"ptree_pair" () in
       let child_path =
-        call ~loc (Longident.Lident "^")
-          [
-            call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ];
-            call ~loc
-              (Longident.parse "Stdlib.string_of_int")
-              [ evar ~loc idx_v ];
-          ]
+        Some
+          (ujoin ~loc path
+             (call ~loc
+                (Longident.parse "Stdlib.string_of_int")
+                [ evar ~loc index ]))
       in
       let inner_body =
         B.pexp_let ~loc Nonrecursive
           [
             B.value_binding ~loc
-              ~pat:(B.ppat_tuple ~loc [ pvar ~loc idx_v; pvar ~loc val_v ])
-              ~expr:(evar ~loc pair_v);
+              ~pat:(B.ppat_tuple ~loc [ pvar ~loc index; pvar ~loc left_value ])
+              ~expr:(evar ~loc pair);
           ]
-          (ufold2_expr ~path:child_path fvar shape (evar ~loc val_v)
-             (evar ~loc val_w) (evar ~loc acc_p))
+          (ufold2_expr ~function_path ~path:child_path fvar shape
+             (evar ~loc left_value) (evar ~loc right_value) (evar ~loc acc_name))
       in
-      call ~loc
-        (Longident.parse "Stdlib.List.fold_left2")
-        [
-          B.pexp_fun ~loc Nolabel None (pvar ~loc acc_p)
-            (B.pexp_fun ~loc Nolabel None (pvar ~loc pair_v)
-               (B.pexp_fun ~loc Nolabel None (pvar ~loc val_w) inner_body));
-          acc_expr;
-          call ~loc
-            (Longident.parse "Stdlib.List.mapi")
-            [
-              B.pexp_fun ~loc Nolabel None (pvar ~loc idx_v)
-                (B.pexp_fun ~loc Nolabel None (pvar ~loc val_v)
-                   (B.pexp_tuple ~loc [ evar ~loc idx_v; evar ~loc val_v ]));
-              left;
-            ];
-          right;
-        ]
-  | UArray shape ->
-      let idx_v = gen_symbol ~prefix:"u2_i" () in
-      let val_v = gen_symbol ~prefix:"u2_v" () in
-      let val_w = gen_symbol ~prefix:"u2_w" () in
-      let len = gen_symbol ~prefix:"u2_n" () in
-      let child_path =
-        call ~loc (Longident.Lident "^")
-          [
-            call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ];
-            call ~loc
-              (Longident.parse "Stdlib.string_of_int")
-              [ evar ~loc idx_v ];
-          ]
-      in
-      (* Ensure equal length, then fold_left over zipped pairs. *)
       lets ~loc
-        [ (len, call ~loc (Longident.parse "Stdlib.Array.length") [ left ]) ]
+        [ (left_name, left); (right_name, right) ]
         (B.pexp_ifthenelse ~loc
            (call ~loc (Longident.Lident "<>")
               [
-                evar ~loc len;
-                call ~loc (Longident.parse "Stdlib.Array.length") [ right ];
+                call ~loc
+                  (Longident.parse "Stdlib.List.length")
+                  [ evar ~loc left_name ];
+                call ~loc
+                  (Longident.parse "Stdlib.List.length")
+                  [ evar ~loc right_name ];
               ])
-           (invalid_argument ~loc "ufold2: array length mismatch")
+           (invalid_argument ~loc (umismatch_message function_path "list length"))
+           (Some
+              (call ~loc
+                 (Longident.parse "Stdlib.List.fold_left2")
+                 [
+                   B.pexp_fun ~loc Nolabel None (pvar ~loc acc_name)
+                     (B.pexp_fun ~loc Nolabel None (pvar ~loc pair)
+                        (B.pexp_fun ~loc Nolabel None (pvar ~loc right_value)
+                           inner_body));
+                   acc_expr;
+                   call ~loc
+                     (Longident.parse "Stdlib.List.mapi")
+                     [
+                       B.pexp_fun ~loc Nolabel None (pvar ~loc index)
+                         (B.pexp_fun ~loc Nolabel None (pvar ~loc left_value)
+                            (B.pexp_tuple ~loc
+                               [ evar ~loc index; evar ~loc left_value ]));
+                       evar ~loc left_name;
+                     ];
+                   evar ~loc right_name;
+                 ])))
+  | UArray shape ->
+      let left_name = gen_symbol ~prefix:"ptree_left" () in
+      let right_name = gen_symbol ~prefix:"ptree_right" () in
+      let length_name = gen_symbol ~prefix:"ptree_length" () in
+      let acc_name = gen_symbol ~prefix:"ptree_acc" () in
+      let index = gen_symbol ~prefix:"ptree_index" () in
+      let child_path =
+        Some
+          (ujoin ~loc path
+             (call ~loc
+                (Longident.parse "Stdlib.string_of_int")
+                [ evar ~loc index ]))
+      in
+      let value_at array =
+        call ~loc
+          (Longident.parse "Stdlib.Array.unsafe_get")
+          [ evar ~loc array; evar ~loc index ]
+      in
+      lets ~loc
+        [
+          (left_name, left);
+          (right_name, right);
+          ( length_name,
+            call ~loc
+              (Longident.parse "Stdlib.Array.length")
+              [ evar ~loc left_name ] );
+        ]
+        (B.pexp_ifthenelse ~loc
+           (call ~loc (Longident.Lident "<>")
+              [
+                evar ~loc length_name;
+                call ~loc
+                  (Longident.parse "Stdlib.Array.length")
+                  [ evar ~loc right_name ];
+              ])
+           (invalid_argument ~loc
+              (umismatch_message function_path "array length"))
            (Some
               (call ~loc
                  (Longident.parse "Stdlib.Array.fold_left")
                  [
-                   B.pexp_fun ~loc Nolabel None (pvar ~loc idx_v)
-                     (B.pexp_fun ~loc Nolabel None (pvar ~loc val_v)
-                        (B.pexp_fun ~loc Nolabel None (pvar ~loc val_w)
-                           (ufold2_expr ~path:child_path fvar shape
-                              (evar ~loc val_v) (evar ~loc val_w)
-                              (evar ~loc idx_v))));
+                   B.pexp_fun ~loc Nolabel None (pvar ~loc acc_name)
+                     (B.pexp_fun ~loc Nolabel None (pvar ~loc index)
+                        (ufold2_expr ~function_path ~path:child_path fvar shape
+                           (value_at left_name) (value_at right_name)
+                           (evar ~loc acc_name)));
                    acc_expr;
                    call ~loc
-                     (Longident.parse "Stdlib.Array.map2")
+                     (Longident.parse "Stdlib.Array.init")
                      [
-                       B.pexp_fun ~loc Nolabel None (pvar ~loc val_v)
-                         (B.pexp_fun ~loc Nolabel None (pvar ~loc val_w)
-                            (evar ~loc val_w));
-                       left;
-                       right;
+                       evar ~loc length_name;
+                       ident ~loc (Longident.parse "Stdlib.Fun.id");
                      ];
                  ])))
 
-(* — names — *)
+(* names: a path-labelled map. Payload positions become their path; static
+   positions are copied from the input. *)
 
-let module_path_string path =
-  match longident_parts path with
-  | Some parts -> String.concat "." parts
-  | None -> ""
-
-let rec unames_expr shape =
+let rec unames_expr ~path shape expr =
   let loc = shape.uloc in
   match shape.udesc with
-  | UPayload ->
-      (* names is a string tree; leaves are the field path. This is wrapped at
-         the record level — individual payload positions are just the empty
-         string placeholder. *)
-      B.estring ~loc ""
-  | UStatic ->
-      (* Static fields are omitted from names (they have no path). *)
-      B.estring ~loc ""
-  | ULocal name ->
-      let local_names = (unames_for_type name).unames in
-      let sub_n = gen_symbol ~prefix:"u_n" () in
-      call ~loc
-        (Longident.Ldot (Lident name, "map"))
+  | UPayload -> upath_expr ~loc path
+  | UStatic -> expr
+  | ULocal _ | UUsing _ ->
+      let map_target, names_target =
+        match shape.udesc with
+        | ULocal name ->
+            let names = uniform_names_for_type name in
+            (Longident.Lident names.umap, Longident.Lident names.unames)
+        | UUsing module_path ->
+            (append_lid module_path "map", append_lid module_path "names")
+        | _ -> assert false
+      in
+      let sub_path = gen_symbol ~prefix:"ptree_path" () in
+      call ~loc map_target
         [
-          B.pexp_fun ~loc Nolabel None (pvar ~loc sub_n)
-            (call ~loc (Longident.Lident "^")
-               [
-                 call ~loc (Longident.Lident "^")
-                   [ B.estring ~loc ""; B.estring ~loc "." ];
-                 evar ~loc sub_n;
-               ]);
-          evar ~loc local_names;
+          B.pexp_fun ~loc Nolabel None (pvar ~loc sub_path)
+            (ujoin ~loc path (evar ~loc sub_path));
+          call ~loc names_target [ expr ];
         ]
-  | UUsing module_path ->
-      let sub_n = gen_symbol ~prefix:"u_n" () in
-      call ~loc
-        (append_lid module_path "map")
+  | UTuple shapes ->
+      let names =
+        List.map (fun _ -> gen_symbol ~prefix:"ptree_tuple" ()) shapes
+      in
+      let pattern =
+        B.ppat_tuple ~loc
+          (List.map2
+             (fun shape name ->
+               match shape.udesc with
+               | UPayload -> B.ppat_any ~loc
+               | _ -> pvar ~loc name)
+             shapes names)
+      in
+      B.pexp_let ~loc Nonrecursive
+        [ B.value_binding ~loc ~pat:pattern ~expr ]
+        (B.pexp_tuple ~loc
+           (List.mapi
+              (fun index shape ->
+                unames_expr
+                  ~path:
+                    (Some (ujoin ~loc path (B.estring ~loc (string_of_int index))))
+                  shape
+                  (evar ~loc (List.nth names index)))
+              shapes))
+  | UOption shape ->
+      let value = gen_symbol ~prefix:"ptree_value" () in
+      let value_pattern =
+        match shape.udesc with
+        | UPayload -> B.ppat_any ~loc
+        | _ -> pvar ~loc value
+      in
+      B.pexp_match ~loc expr
         [
-          B.pexp_fun ~loc Nolabel None (pvar ~loc sub_n)
-            (call ~loc (Longident.Lident "^")
-               [
-                 call ~loc (Longident.Lident "^")
-                   [ B.estring ~loc ""; B.estring ~loc "." ];
-                 evar ~loc sub_n;
-               ]);
-          evar ~loc (module_path_string module_path ^ ".names");
+          B.case
+            ~lhs:(construct_pattern ~loc "None" None)
+            ~guard:None
+            ~rhs:(construct ~loc "None" None);
+          B.case
+            ~lhs:(construct_pattern ~loc "Some" (Some value_pattern))
+            ~guard:None
+            ~rhs:
+              (construct ~loc "Some"
+                 (Some (unames_expr ~path shape (evar ~loc:shape.uloc value))));
         ]
-  | UTuple shapes -> B.pexp_tuple ~loc (List.map unames_expr shapes)
-  | UOption _ | UList _ | UArray _ ->
-      (* names for containers is not statically determinable; skip *)
-      B.estring ~loc ""
+  | UList shape ->
+      let index = gen_symbol ~prefix:"ptree_index" () in
+      let value = gen_symbol ~prefix:"ptree_value" () in
+      let value_pattern =
+        match shape.udesc with
+        | UPayload -> B.ppat_any ~loc
+        | _ -> pvar ~loc value
+      in
+      call ~loc
+        (Longident.parse "Stdlib.List.mapi")
+        [
+          B.pexp_fun ~loc Nolabel None (pvar ~loc index)
+            (B.pexp_fun ~loc Nolabel None value_pattern
+               (unames_expr
+                  ~path:
+                    (Some
+                       (ujoin ~loc path
+                          (call ~loc
+                             (Longident.parse "Stdlib.string_of_int")
+                             [ evar ~loc index ])))
+                  shape (evar ~loc value)));
+          expr;
+        ]
+  | UArray shape ->
+      let index = gen_symbol ~prefix:"ptree_index" () in
+      let value = gen_symbol ~prefix:"ptree_value" () in
+      let value_pattern =
+        match shape.udesc with
+        | UPayload -> B.ppat_any ~loc
+        | _ -> pvar ~loc value
+      in
+      call ~loc
+        (Longident.parse "Stdlib.Array.mapi")
+        [
+          B.pexp_fun ~loc Nolabel None (pvar ~loc index)
+            (B.pexp_fun ~loc Nolabel None value_pattern
+               (unames_expr
+                  ~path:
+                    (Some
+                       (ujoin ~loc path
+                          (call ~loc
+                             (Longident.parse "Stdlib.string_of_int")
+                             [ evar ~loc index ])))
+                  shape (evar ~loc value)));
+          expr;
+        ]
 
-(* Helper to extract module path as string for names construction *)
-let module_path_string path =
-  match longident_parts path with
-  | Some parts -> String.concat "." parts
-  | None -> ""
+(* Operation bodies over a declaration body. The tree inputs are [x] (and [y]
+   for binary operations), the accumulator is [acc], the callback is [f]. *)
 
-(* — Record / alias codegen for each operation — *)
+let urecord ~loc bindings =
+  lets_located
+    (List.map (fun (field_loc, name, expression, _) ->
+         (field_loc, name, expression))
+       bindings)
+    (B.pexp_record ~loc
+       (List.map
+          (fun (_, name, _, label) ->
+            (lident ~loc:label.pld_name.loc label.pld_name.txt, evar ~loc name))
+          bindings)
+       None)
 
-let uoperation_body ~loc operation ubody =
+let unames_uses_input = function
+  | UAlias { udesc = UPayload; _ } -> false
+  | UAlias _ -> true
+  | URecord fields ->
+      List.exists (fun (_, shape) -> shape.udesc <> UPayload) fields
+
+let uoperation_body ~loc ~function_path operation ubody =
   let input = evar ~loc "x" in
+  let second = evar ~loc "y" in
+  let accumulator = evar ~loc "acc" in
+  let field_path label = Some (B.estring ~loc:label.pld_loc label.pld_name.txt) in
   match (operation, ubody) with
   | `Umap, UAlias shape -> umap_expr "f" shape input
   | `Umap, URecord fields ->
-      let bindings =
-        List.map
-          (fun (label, shape) ->
-            let name = gen_symbol ~prefix:("u_" ^ label.pld_name.txt) () in
-            ( label.pld_loc,
-              name,
-              umap_expr "f" shape (field ~loc:label.pld_loc input label),
-              label ))
-          fields
-      in
-      lets_located
-        (List.map (fun (loc, n, e, _) -> (loc, n, e)) bindings)
-        (B.pexp_record ~loc
-           (List.map
-              (fun (_, n, _, label) ->
-                (lident ~loc:label.pld_name.loc label.pld_name.txt, evar ~loc n))
-              bindings)
-           None)
-  | `Umap2, UAlias shape ->
-      umap2_expr ~function_path:"" "f" shape input (evar ~loc "y")
+      urecord ~loc
+        (List.map
+           (fun (label, shape) ->
+             ( label.pld_loc,
+               gen_symbol ~prefix:("ptree_" ^ label.pld_name.txt) (),
+               umap_expr "f" shape (field ~loc:label.pld_loc input label),
+               label ))
+           fields)
+  | `Umap2, UAlias shape -> umap2_expr ~function_path "f" shape input second
   | `Umap2, URecord fields ->
-      let left = evar ~loc "x" in
-      let right = evar ~loc "y" in
-      let bindings =
-        List.map
-          (fun (label, shape) ->
-            let name = gen_symbol ~prefix:("u2_" ^ label.pld_name.txt) () in
-            ( label.pld_loc,
-              name,
-              umap2_expr ~function_path:"" "f" shape
-                (field ~loc:label.pld_loc left label)
-                (field ~loc:label.pld_loc right label),
-              label ))
-          fields
-      in
-      lets_located
-        (List.map (fun (loc, n, e, _) -> (loc, n, e)) bindings)
-        (B.pexp_record ~loc
-           (List.map
-              (fun (_, n, _, label) ->
-                (lident ~loc:label.pld_name.loc label.pld_name.txt, evar ~loc n))
-              bindings)
-           None)
+      urecord ~loc
+        (List.map
+           (fun (label, shape) ->
+             ( label.pld_loc,
+               gen_symbol ~prefix:("ptree_" ^ label.pld_name.txt) (),
+               umap2_expr ~function_path "f" shape
+                 (field ~loc:label.pld_loc input label)
+                 (field ~loc:label.pld_loc second label),
+               label ))
+           fields)
   | `Uiter, UAlias shape -> uiter_expr "f" shape input
   | `Uiter, URecord fields ->
       B.esequence ~loc
@@ -2294,127 +2291,155 @@ let uoperation_body ~loc operation ubody =
            (fun (label, shape) ->
              uiter_expr "f" shape (field ~loc:label.pld_loc input label))
            fields)
-  | `Ufold, UAlias shape ->
-      ufold_expr ~path:(B.estring ~loc "") "f" shape (evar ~loc "y")
-        (evar ~loc "x")
+  | `Ufold, UAlias shape -> ufold_expr ~path:None "f" shape input accumulator
   | `Ufold, URecord fields ->
       List.fold_left
-        (fun acc_expr (label, shape) ->
-          ufold_expr
-            ~path:(B.estring ~loc label.pld_name.txt)
-            "f" shape
-            (field ~loc:label.pld_loc (evar ~loc "y") label)
-            acc_expr)
-        (evar ~loc "x") fields
+        (fun acc (label, shape) ->
+          ufold_expr ~path:(field_path label) "f" shape
+            (field ~loc:label.pld_loc input label)
+            acc)
+        accumulator fields
   | `Ufold2, UAlias shape ->
-      ufold2_expr ~path:(B.estring ~loc "") "f" shape (evar ~loc "y")
-        (evar ~loc "z") (evar ~loc "x")
+      ufold2_expr ~function_path ~path:None "f" shape input second accumulator
   | `Ufold2, URecord fields ->
-      let left = evar ~loc "y" in
-      let right = evar ~loc "z" in
       List.fold_left
-        (fun acc_expr (label, shape) ->
-          ufold2_expr
-            ~path:(B.estring ~loc label.pld_name.txt)
-            "f" shape
-            (field ~loc:label.pld_loc left label)
-            (field ~loc:label.pld_loc right label)
-            acc_expr)
-        (evar ~loc "x") fields
-  | `Unames, UAlias shape -> unames_expr shape
+        (fun acc (label, shape) ->
+          ufold2_expr ~function_path ~path:(field_path label) "f" shape
+            (field ~loc:label.pld_loc input label)
+            (field ~loc:label.pld_loc second label)
+            acc)
+        accumulator fields
+  | `Unames, UAlias shape ->
+      let body = unames_expr ~path:None shape input in
+      if unames_uses_input ubody then body
+      else
+        B.pexp_sequence ~loc
+          (call ~loc (Longident.parse "Stdlib.ignore") [ input ])
+          body
   | `Unames, URecord fields ->
-      B.pexp_record ~loc
-        (List.map
-           (fun (label, shape) ->
-             ( lident ~loc:label.pld_name.loc label.pld_name.txt,
-               unames_expr shape ))
-           fields)
-        None
+      let body =
+        B.pexp_record ~loc
+          (List.map
+             (fun (label, shape) ->
+               ( lident ~loc:label.pld_name.loc label.pld_name.txt,
+                 unames_expr ~path:(field_path label) shape
+                   (field ~loc:label.pld_loc input label) ))
+             fields)
+          None
+      in
+      if unames_uses_input ubody then body
+      else
+        B.pexp_sequence ~loc
+          (call ~loc (Longident.parse "Stdlib.ignore") [ input ])
+          body
 
-(* FIXME: fvar in map2/map2 refers to "f" hardcoded above but in the
-   callback-type builders we need the *actual* parameter. The code above assumes
-   the callback is named "f" which matches ufunction_expression below. *)
-
-let rec ubody_uses_callback = function
-  | UAlias shape -> ushape_has_payload shape
-  | URecord fields -> List.exists (fun (_, s) -> ushape_has_payload s) fields
-
-and ushape_has_payload shape =
-  match shape.udesc with
-  | UPayload -> true
-  | UStatic -> false
-  | UTuple shapes -> List.exists ushape_has_payload shapes
-  | UOption s | UList s | UArray s -> ushape_has_payload s
-  | ULocal _ | UUsing _ -> true
-
-let ucallback_type ~loc operation var_a var_b var_c =
-  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
-  let string_ty = B.ptyp_constr ~loc (lident ~loc "string") [] in
-  let acc_ty = B.ptyp_var ~loc "acc" in
-  let var_ty name = B.ptyp_var ~loc name in
-  match operation with
-  | `Umap -> arrow (var_ty var_a) (var_ty var_b)
-  | `Umap2 -> arrow (var_ty var_a) (arrow (var_ty var_b) (var_ty var_c))
-  | `Uiter -> arrow (var_ty var_a) (B.ptyp_constr ~loc (lident ~loc "unit") [])
-  | `Ufold -> arrow string_ty (arrow acc_ty (arrow (var_ty var_a) acc_ty))
-  | `Ufold2 ->
-      arrow string_ty
-        (arrow acc_ty (arrow (var_ty var_a) (arrow (var_ty var_b) acc_ty)))
-  | `Unames ->
-      (* names : unit -> string t, i.e., a constant *)
-      arrow
-        (B.ptyp_constr ~loc (lident ~loc "unit") [])
-        (B.ptyp_constr ~loc (lident ~loc "string") [])
-
-(** arity of the function value after the callback: map=1, map2=2, iter=1,
-    fold=2 (tree + acc), fold2=3 (tree + tree + acc), names=1 *)
-let uoperation_arity = function
-  | `Umap | `Uiter | `Unames -> 1
-  | `Umap2 -> 2
-  | `Ufold -> 2
-  | `Ufold2 -> 3
+let ufresh_variables type_decl =
+  let used = used_type_variables type_decl in
+  let choose base =
+    let rec loop candidate index =
+      if String_set.mem candidate used then
+        loop (base ^ string_of_int index) (index + 1)
+      else candidate
+    in
+    loop base 0
+  in
+  (choose "a", choose "b", choose "c", choose "acc")
 
 let umake_binding ~module_path operation udecl =
   let type_decl = udecl.utype_decl in
   let loc = type_decl.ptype_loc in
-  let names = unames_for_type type_decl.ptype_name.txt in
+  let names = uniform_names_for_type type_decl.ptype_name.txt in
   let name = uoperation_name operation names in
-  let var_a = "a" in
-  let var_b = "b" in
-  let var_c = "c" in
-  let cb_ty = ucallback_type ~loc operation var_a var_b var_c in
-  let type_ = declared_type type_decl in
-  let body_expr =
+  let function_path =
+    if module_path = "" then name else module_path ^ "." ^ name
+  in
+  let variable_a, variable_b, variable_c, variable_acc =
+    ufresh_variables type_decl
+  in
+  let applied variable =
+    B.ptyp_constr ~loc
+      (lident ~loc type_decl.ptype_name.txt)
+      [ B.ptyp_var ~loc variable ]
+  in
+  let variable name = B.ptyp_var ~loc name in
+  let string_type = B.ptyp_constr ~loc (lident ~loc "string") [] in
+  let unit_type = B.ptyp_constr ~loc (lident ~loc "unit") [] in
+  let accumulator_type = variable variable_acc in
+  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
+  let body =
     match udecl.ubody with
-    | Some ubody -> uoperation_body ~loc operation ubody
+    | Some ubody -> uoperation_body ~loc ~function_path operation ubody
     | None -> assert false
   in
-  let input_types =
+  let functions parameters body =
+    List.fold_right
+      (fun (name, type_) body ->
+        B.pexp_fun ~loc Nolabel None (constrained_parameter ~loc name type_)
+          body)
+      parameters body
+  in
+  let constrained body type_ = B.pexp_constraint ~loc body type_ in
+  let expr =
     match operation with
-    | `Unames -> [ type_ ]
-    | `Ufold -> [ B.ptyp_var ~loc "acc"; type_ ]
-    | `Ufold2 -> [ B.ptyp_var ~loc "acc"; type_; type_ ]
-    | _ -> List.init (uoperation_arity operation) (fun _ -> type_)
+    | `Umap ->
+        functions
+          [
+            ("f", arrow (variable variable_a) (variable variable_b));
+            ("x", applied variable_a);
+          ]
+          (constrained body (applied variable_b))
+    | `Umap2 ->
+        functions
+          [
+            ( "f",
+              arrow (variable variable_a)
+                (arrow (variable variable_b) (variable variable_c)) );
+            ("x", applied variable_a);
+            ("y", applied variable_b);
+          ]
+          (constrained body (applied variable_c))
+    | `Uiter ->
+        functions
+          [
+            ("f", arrow (variable variable_a) unit_type);
+            ("x", applied variable_a);
+          ]
+          body
+    | `Ufold ->
+        functions
+          [
+            ( "f",
+              arrow string_type
+                (arrow accumulator_type
+                   (arrow (variable variable_a) accumulator_type)) );
+            ("acc", accumulator_type);
+            ("x", applied variable_a);
+          ]
+          body
+    | `Ufold2 ->
+        functions
+          [
+            ( "f",
+              arrow string_type
+                (arrow accumulator_type
+                   (arrow (variable variable_a)
+                      (arrow (variable variable_b) accumulator_type))) );
+            ("acc", accumulator_type);
+            ("x", applied variable_a);
+            ("y", applied variable_b);
+          ]
+          body
+    | `Unames ->
+        functions
+          [ ("x", applied variable_a) ]
+          (constrained body
+             (B.ptyp_constr ~loc
+                (lident ~loc type_decl.ptype_name.txt)
+                [ string_type ]))
   in
-  let fun_expr =
-    ufunction_expression ~loc ~callback_type:cb_ty ~input_types body_expr
-  in
-  let pat =
-    if operation = `Unames then
-      (* names takes no callback argument; it's a constant. *)
-      pvar ~loc name
-    else pvar ~loc name
-  in
-  B.value_binding ~loc ~pat ~expr:fun_expr
+  B.value_binding ~loc ~pat:(pvar ~loc name) ~expr
 
-let ucomponent_rec_flag component =
-  match component with
-  | [] -> assert false
-  | [ udecl ] ->
-      if String_set.mem udecl.utype_decl.ptype_name.txt udecl.udependencies then
-        Recursive
-      else Nonrecursive
-  | _ -> Recursive
+let uniform_operations = [ `Umap; `Umap2; `Uiter; `Ufold; `Ufold2; `Unames ]
 
 let ugenerate_operation ~module_path operation components =
   List.map
@@ -2425,147 +2450,168 @@ let ugenerate_operation ~module_path operation components =
         (List.map (umake_binding ~module_path operation) component))
     components
 
-let ustructure_has_payload_param type_decls =
-  match type_decls with
-  | decl :: _ -> (
-      match decl.ptype_params with
-      | [ (p, _) ] -> (
-          match p.ptyp_desc with Ptyp_var _ -> true | _ -> false)
-      | _ -> false)
-  | [] -> false
+let uniform_structure ~ctxt type_declarations =
+  let declarations, errors = uvalidate ~signature:false type_declarations in
+  if errors <> [] then structure_errors errors
+  else
+    let module_path =
+      Expansion_context.Deriver.code_path ctxt |> Code_path.fully_qualified_path
+    in
+    let components = uordered_components declarations in
+    List.concat_map
+      (fun operation -> ugenerate_operation ~module_path operation components)
+      uniform_operations
 
-(* ——— Mirror mode ——— *)
+let usignature_type operation type_decl =
+  let loc = type_decl.ptype_loc in
+  let variable_a, variable_b, variable_c, variable_acc =
+    ufresh_variables type_decl
+  in
+  let applied variable =
+    B.ptyp_constr ~loc
+      (lident ~loc type_decl.ptype_name.txt)
+      [ B.ptyp_var ~loc variable ]
+  in
+  let variable name = B.ptyp_var ~loc name in
+  let string_type = B.ptyp_constr ~loc (lident ~loc "string") [] in
+  let unit_type = B.ptyp_constr ~loc (lident ~loc "unit") [] in
+  let accumulator_type = variable variable_acc in
+  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
+  match operation with
+  | `Umap ->
+      arrow
+        (arrow (variable variable_a) (variable variable_b))
+        (arrow (applied variable_a) (applied variable_b))
+  | `Umap2 ->
+      arrow
+        (arrow (variable variable_a)
+           (arrow (variable variable_b) (variable variable_c)))
+        (arrow (applied variable_a)
+           (arrow (applied variable_b) (applied variable_c)))
+  | `Uiter ->
+      arrow
+        (arrow (variable variable_a) unit_type)
+        (arrow (applied variable_a) unit_type)
+  | `Ufold ->
+      arrow
+        (arrow string_type
+           (arrow accumulator_type
+              (arrow (variable variable_a) accumulator_type)))
+        (arrow accumulator_type (arrow (applied variable_a) accumulator_type))
+  | `Ufold2 ->
+      arrow
+        (arrow string_type
+           (arrow accumulator_type
+              (arrow (variable variable_a)
+                 (arrow (variable variable_b) accumulator_type))))
+        (arrow accumulator_type
+           (arrow (applied variable_a)
+              (arrow (applied variable_b) accumulator_type)))
+  | `Unames ->
+      arrow (applied variable_a)
+        (B.ptyp_constr ~loc
+           (lident ~loc type_decl.ptype_name.txt)
+           [ string_type ])
 
-(* Translate a static ptree [shape] into a parameterised ushape. Every [Leaf]
-   becomes the payload param ['a]; [Ignored] stays static; [Using M] becomes
-   [UUsing M] (Gtree.t delegation convention). *)
+let uniform_signature ~ctxt type_declarations =
+  let declarations, errors = uvalidate ~signature:true type_declarations in
+  if errors <> [] then signature_errors errors
+  else
+    let add_values udecl =
+      let type_decl = udecl.utype_decl in
+      let names = uniform_names_for_type type_decl.ptype_name.txt in
+      List.map
+        (fun operation ->
+          let name = uoperation_name operation names in
+          let loc = type_decl.ptype_name.loc in
+          B.psig_value ~loc
+            (B.value_description ~loc ~name:{ txt = name; loc }
+               ~type_:(usignature_type operation type_decl)
+               ~prim:[]))
+        uniform_operations
+    in
+    Stdlib.ignore ctxt;
+    List.concat_map add_values declarations
 
-let rec ushape_of_shape shape =
+(* Mirror mode: [@@deriving ptree ~mirror] on a concrete type additionally
+   generates [module Uniform] (the payload-generic mirror of the record, with
+   all uniform traversals), [to_uniform] packing tensor leaves as
+   [Nx.Ptree.tensor], and — when every leaf dtype is statically known —
+   [of_uniform] unpacking them back with dtype checks. *)
+
+let strip_ptree_attributes =
+  object
+    inherit Ast_traverse.map
+    method! attributes attributes =
+      List.filter
+        (fun attribute -> not (is_ptree_attribute attribute.attr_name.txt))
+        attributes
+  end
+
+let rec shape_has_local shape =
+  match shape.desc with
+  | Local _ -> true
+  | Leaf | Ignored | Using _ -> false
+  | Tuple shapes -> List.exists shape_has_local shapes
+  | Option shape | List shape | Array shape -> shape_has_local shape
+
+let body_has_local = function
+  | Alias shape -> shape_has_local shape
+  | Record fields -> List.exists (fun (_, shape) -> shape_has_local shape) fields
+
+let body_has_leaf =
+  let rec shape_has_leaf shape =
+    match shape.desc with
+    | Leaf | Using _ -> true
+    | Ignored | Local _ -> false
+    | Tuple shapes -> List.exists shape_has_leaf shapes
+    | Option shape | List shape | Array shape -> shape_has_leaf shape
+  in
+  function
+  | Alias shape -> shape_has_leaf shape
+  | Record fields -> List.exists (fun (_, shape) -> shape_has_leaf shape) fields
+
+let rec unwrap_core_type core_type =
+  match core_type.ptyp_desc with
+  | Ptyp_alias (inner, _) -> unwrap_core_type inner
+  | _ -> core_type
+
+let container_argument core_type =
+  match (unwrap_core_type core_type).ptyp_desc with
+  | Ptyp_constr (_, [ argument ]) -> argument
+  | _ -> assert false
+
+let tuple_arguments core_type =
+  match (unwrap_core_type core_type).ptyp_desc with
+  | Ptyp_tuple elements -> elements
+  | _ -> assert false
+
+(* The mirror type of a position: payloads become ['m], delegations become
+   ['m M.Uniform.t], static positions keep their original type. *)
+let rec mirror_type shape core_type =
   let loc = shape.loc in
   match shape.desc with
-  | Leaf -> ushape ~loc UPayload
-  | Ignored -> ushape ~loc UStatic
-  | Local name -> ushape ~loc (ULocal name)
-  | Using m -> ushape ~loc (UUsing (append_lid m "Gtree"))
-  | Tuple shapes -> ushape ~loc (UTuple (List.map ushape_of_shape shapes))
-  | Option s -> ushape ~loc (UOption (ushape_of_shape s))
-  | List s -> ushape ~loc (UList (ushape_of_shape s))
-  | Array s -> ushape ~loc (UArray (ushape_of_shape s))
-
-(* Build the core_type for a mirror type position. UPayload → 'a, UStatic → unit
-   (placeholder, replaced at record level), ULocal/UUsing → 'a M.t or 'a
-   M.Gtree.t, containers → recurse. *)
-
-let rec build_mirror_type ~loc shape =
-  match shape.udesc with
-  | UPayload -> B.ptyp_var ~loc "m"
-  | UStatic -> B.ptyp_constr ~loc (lident ~loc "unit") []
-  | ULocal name ->
+  | Leaf -> B.ptyp_var ~loc "m"
+  | Ignored -> strip_ptree_attributes#core_type core_type
+  | Using module_path ->
       B.ptyp_constr ~loc
-        (located_lid ~loc
-           (Longident.Ldot (Longident.Ldot (Lident name, "Gtree"), "t")))
+        (located_lid ~loc (append_lid (append_lid module_path "Uniform") "t"))
         [ B.ptyp_var ~loc "m" ]
-  | UUsing path ->
-      B.ptyp_constr ~loc
-        (located_lid ~loc (append_lid path "t"))
-        [ B.ptyp_var ~loc "m" ]
-  | UTuple shapes ->
-      B.ptyp_tuple ~loc (List.map (build_mirror_type ~loc) shapes)
-  | UOption s ->
-      B.ptyp_constr ~loc (lident ~loc "option") [ build_mirror_type ~loc s ]
-  | UList s ->
-      B.ptyp_constr ~loc (lident ~loc "list") [ build_mirror_type ~loc s ]
-  | UArray s ->
-      B.ptyp_constr ~loc (lident ~loc "array") [ build_mirror_type ~loc s ]
+  | Local _ -> assert false
+  | Tuple shapes ->
+      B.ptyp_tuple ~loc (List.map2 mirror_type shapes (tuple_arguments core_type))
+  | Option shape ->
+      B.ptyp_constr ~loc (lident ~loc "option")
+        [ mirror_type shape (container_argument core_type) ]
+  | List shape ->
+      B.ptyp_constr ~loc (lident ~loc "list")
+        [ mirror_type shape (container_argument core_type) ]
+  | Array shape ->
+      B.ptyp_constr ~loc (lident ~loc "array")
+        [ mirror_type shape (container_argument core_type) ]
 
-(* Build a synthetic ['a t] type declaration. *)
+(* Dtype recovery for [of_uniform]. *)
 
-let synth_mirror_type_decl ~loc name fields : type_declaration =
-  {
-    ptype_name = { txt = name; loc };
-    ptype_params = [ (B.ptyp_var ~loc "m", (Covariant, NoInjectivity)) ];
-    ptype_cstrs = [];
-    ptype_kind = Ptype_record fields;
-    ptype_private = Public;
-    ptype_manifest = None;
-    ptype_attributes = [];
-    ptype_loc = loc;
-  }
-
-let synth_mirror_alias_decl ~loc name alias_type : type_declaration =
-  {
-    ptype_name = { txt = name; loc };
-    ptype_params = [ (B.ptyp_var ~loc "m", (Covariant, NoInjectivity)) ];
-    ptype_cstrs = [];
-    ptype_kind = Ptype_abstract;
-    ptype_private = Public;
-    ptype_manifest = Some alias_type;
-    ptype_attributes = [];
-    ptype_loc = loc;
-  }
-
-(* Generate traversal bindings from a synthetic udeclaration. *)
-
-let mirror_traversals ~module_path udecl : structure =
-  let type_decl = udecl.utype_decl in
-  let loc = type_decl.ptype_loc in
-  List.map
-    (fun op ->
-      let vb = umake_binding ~module_path op udecl in
-      B.pstr_value ~loc Nonrecursive [ vb ])
-    [ `Umap; `Umap2; `Uiter; `Ufold; `Ufold2; `Unames ]
-
-(* Generate [module Gtree = struct ... end]. *)
-
-let generate_gtree_module ~module_path static_decls : structure =
-  let type_decl = (List.hd static_decls).type_decl in
-  let loc = type_decl.ptype_loc in
-  let body = (List.hd static_decls).body in
-  let module_items : structure =
-    match body with
-    | Some (Alias s) ->
-        let us = ushape_of_shape s in
-        let alias_ty = build_mirror_type ~loc us in
-        let synth = synth_mirror_alias_decl ~loc "t" alias_ty in
-        let type_item = B.pstr_type ~loc Nonrecursive [ synth ] in
-        let udecl =
-          {
-            utype_decl = synth;
-            ubody = Some (UAlias us);
-            udependencies = String_set.empty;
-          }
-        in
-        type_item :: mirror_traversals ~module_path udecl
-    | Some (Record fields) ->
-        let ufields =
-          List.map (fun (lbl, sh) -> (lbl, ushape_of_shape sh)) fields
-        in
-        let synth_labels =
-          List.map
-            (fun (lbl, us) -> { lbl with pld_type = build_mirror_type ~loc us })
-            ufields
-        in
-        let synth = synth_mirror_type_decl ~loc "t" synth_labels in
-        let type_item = B.pstr_type ~loc Nonrecursive [ synth ] in
-        let udecl =
-          {
-            utype_decl = synth;
-            ubody = Some (URecord ufields);
-            udependencies = String_set.empty;
-          }
-        in
-        type_item :: mirror_traversals ~module_path udecl
-    | None -> []
-  in
-  let mod_name = { txt = Some "Gtree"; loc } in
-  let mod_expr = B.pmod_structure ~loc module_items in
-  let mb = B.module_binding ~loc ~name:mod_name ~expr:mod_expr in
-  [ B.pstr_module ~loc mb ]
-
-(* ——— dtype extraction for mirror-mode of_gtree ——— *)
-
-(* Maps an Nx type alias base name (without _t suffix) or element type name to
-   the corresponding dtype value name in the Nx module. *)
 let dtype_name_of_nx_name = function
   | "float16" | "float16_elt" -> Some "float16"
   | "float32" | "float32_elt" -> Some "float32"
@@ -2589,27 +2635,38 @@ let dtype_name_of_nx_name = function
   | _ -> None
 
 let chop_suffix name suffix =
-  let name_len = String.length name in
-  let suffix_len = String.length suffix in
+  let name_length = String.length name in
+  let suffix_length = String.length suffix in
   if
-    name_len > suffix_len
-    && String.equal (String.sub name (name_len - suffix_len) suffix_len) suffix
-  then Some (String.sub name 0 (name_len - suffix_len))
+    name_length > suffix_length
+    && String.equal
+         (String.sub name (name_length - suffix_length) suffix_length)
+         suffix
+  then Some (String.sub name 0 (name_length - suffix_length))
   else None
 
-(** [dtype_expr_of_core_type ~loc core_type] returns an expression that
-    evaluates to the {!Nx_core.Dtype.t} for the Nx tensor type represented by
-    [core_type], or [None] if the dtype cannot be determined. *)
-let rec dtype_expr_of_core_type ~loc core_type =
-  match core_type.ptyp_desc with
+let dtype_expr_of_elt_type ~loc core_type =
+  match (unwrap_core_type core_type).ptyp_desc with
+  | Ptyp_constr (path, []) -> (
+      match longident_parts path.txt with
+      | Some [ name ] | Some [ "Nx"; name ] -> (
+          match dtype_name_of_nx_name name with
+          | Some dtype_name ->
+              Some (ident ~loc (Longident.Ldot (Lident "Nx", dtype_name)))
+          | None -> None)
+      | _ -> None)
+  | _ -> None
+
+let dtype_expr_of_core_type ~loc core_type =
+  match (unwrap_core_type core_type).ptyp_desc with
   | Ptyp_constr (path, []) -> (
       match longident_parts path.txt with
       | Some [ name ] | Some [ "Nx"; name ] -> (
           match chop_suffix name "_t" with
           | Some base -> (
               match dtype_name_of_nx_name base with
-              | Some dname ->
-                  Some (ident ~loc (Longident.Ldot (Lident "Nx", dname)))
+              | Some dtype_name ->
+                  Some (ident ~loc (Longident.Ldot (Lident "Nx", dtype_name)))
               | None -> None)
           | None -> None)
       | _ -> None)
@@ -2617,59 +2674,55 @@ let rec dtype_expr_of_core_type ~loc core_type =
     when is_path path.txt [ "Nx"; "t" ] || is_path path.txt [ "Nx_effect"; "t" ]
     ->
       dtype_expr_of_elt_type ~loc elt_type
-  | Ptyp_alias (inner, _) -> dtype_expr_of_core_type ~loc inner
   | _ -> None
 
-(** [dtype_expr_of_elt_type ~loc core_type] extracts a dtype expression from an
-    element type like [float32_elt] or [complex32_elt]. *)
-and dtype_expr_of_elt_type ~loc core_type =
-  match core_type.ptyp_desc with
-  | Ptyp_constr (path, []) -> (
-      match longident_parts path.txt with
-      | Some [ name ] | Some [ "Nx"; name ] -> (
-          match dtype_name_of_nx_name name with
-          | Some dname ->
-              Some (ident ~loc (Longident.Ldot (Lident "Nx", dname)))
-          | None -> None)
-      | _ -> None)
-  | Ptyp_alias (inner, _) -> dtype_expr_of_elt_type ~loc inner
-  | _ -> None
+let rec mirror_dtypes_known shape core_type =
+  match shape.desc with
+  | Leaf -> Option.is_some (dtype_expr_of_core_type ~loc:shape.loc core_type)
+  | Ignored | Using _ -> true
+  | Local _ -> assert false
+  | Tuple shapes ->
+      List.for_all2 mirror_dtypes_known shapes (tuple_arguments core_type)
+  | Option shape | List shape | Array shape ->
+      mirror_dtypes_known shape (container_argument core_type)
 
-(* Converters — pack/unpack tensor leaves through the existential. *)
+(* to_uniform / of_uniform *)
 
 let pack_leaf ~loc expr =
-  (* Nx.Ptree.P expr *)
   B.pexp_construct ~loc
     (located_lid ~loc
        (Longident.Ldot (Longident.Ldot (Lident "Nx", "Ptree"), "P")))
     (Some expr)
 
-let unpack_leaf ~loc ~dtype expr =
-  call ~loc (Longident.parse "Nx.Ptree.unpack") [ dtype; expr ]
+let unpack_leaf ~loc ~path ~dtype expr =
+  B.pexp_apply ~loc
+    (ident ~loc (Longident.parse "Nx.Ptree.unpack"))
+    [
+      (Labelled "at", B.estring ~loc (String.concat "." (List.rev path)));
+      (Nolabel, dtype);
+      (Nolabel, expr);
+    ]
 
-(* Recursively convert a static expression through a ptree [shape] into a gtree
-   mirror expression. *)
-let rec to_gtree_shape ~loc shape expr =
+let rec to_uniform_shape shape expr =
+  let loc = shape.loc in
   match shape.desc with
   | Leaf -> pack_leaf ~loc expr
   | Ignored -> expr
-  | Using m -> call ~loc (append_lid m "to_gtree") [ expr ]
-  | Local _ -> expr
+  | Using module_path ->
+      call ~loc (append_lid module_path "to_uniform") [ expr ]
+  | Local _ -> assert false
   | Tuple shapes ->
-      let count = List.length shapes in
-      let names = List.init count (fun _ -> gen_symbol ~prefix:"ptree_tg" ()) in
-      let pattern = B.ppat_tuple ~loc (List.map (pvar ~loc) names) in
-      let converted =
-        List.map2
-          (fun shape name ->
-            to_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc name))
-          shapes names
+      let names, pattern, tuple =
+        tuple_bindings ~loc expr (List.length shapes)
       in
       B.pexp_let ~loc Nonrecursive
-        [ B.value_binding ~loc ~pat:pattern ~expr ]
-        (B.pexp_tuple ~loc converted)
+        [ B.value_binding ~loc ~pat:pattern ~expr:tuple ]
+        (B.pexp_tuple ~loc
+           (List.map2
+              (fun shape name -> to_uniform_shape shape (evar ~loc name))
+              shapes names))
   | Option shape ->
-      let v = gen_symbol ~prefix:"ptree_tg" () in
+      let value = gen_symbol ~prefix:"ptree_value" () in
       B.pexp_match ~loc expr
         [
           B.case
@@ -2677,55 +2730,59 @@ let rec to_gtree_shape ~loc shape expr =
             ~guard:None
             ~rhs:(construct ~loc "None" None);
           B.case
-            ~lhs:(construct_pattern ~loc "Some" (Some (pvar ~loc v)))
+            ~lhs:(construct_pattern ~loc "Some" (Some (pvar ~loc value)))
             ~guard:None
             ~rhs:
               (construct ~loc "Some"
-                 (Some
-                    (to_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc v))));
+                 (Some (to_uniform_shape shape (evar ~loc value))));
         ]
   | List shape ->
-      let v = gen_symbol ~prefix:"ptree_tg" () in
+      let value = gen_symbol ~prefix:"ptree_value" () in
       call ~loc
         (Longident.parse "Stdlib.List.map")
         [
-          B.pexp_fun ~loc Nolabel None (pvar ~loc v)
-            (to_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc v));
+          B.pexp_fun ~loc Nolabel None (pvar ~loc value)
+            (to_uniform_shape shape (evar ~loc value));
           expr;
         ]
   | Array shape ->
-      let v = gen_symbol ~prefix:"ptree_tg" () in
+      let value = gen_symbol ~prefix:"ptree_value" () in
       call ~loc
         (Longident.parse "Stdlib.Array.map")
         [
-          B.pexp_fun ~loc Nolabel None (pvar ~loc v)
-            (to_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc v));
+          B.pexp_fun ~loc Nolabel None (pvar ~loc value)
+            (to_uniform_shape shape (evar ~loc value));
           expr;
         ]
 
-(* Recursively convert a gtree mirror expression back through a ptree [shape]
-   into a static expression. *)
-let rec of_gtree_shape ~loc shape expr =
+let rec of_uniform_shape ~path shape core_type expr =
+  let loc = shape.loc in
   match shape.desc with
-  | Leaf -> expr
+  | Leaf ->
+      let dtype = Option.get (dtype_expr_of_core_type ~loc core_type) in
+      unpack_leaf ~loc ~path ~dtype expr
   | Ignored -> expr
-  | Using m -> call ~loc (append_lid m "of_gtree") [ expr ]
-  | Local _ -> expr
+  | Using module_path ->
+      call ~loc (append_lid module_path "of_uniform") [ expr ]
+  | Local _ -> assert false
   | Tuple shapes ->
-      let count = List.length shapes in
-      let names = List.init count (fun _ -> gen_symbol ~prefix:"ptree_og" ()) in
-      let pattern = B.ppat_tuple ~loc (List.map (pvar ~loc) names) in
-      let converted =
-        List.map2
-          (fun shape name ->
-            of_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc name))
-          shapes names
+      let arguments = tuple_arguments core_type in
+      let names, pattern, tuple =
+        tuple_bindings ~loc expr (List.length shapes)
       in
       B.pexp_let ~loc Nonrecursive
-        [ B.value_binding ~loc ~pat:pattern ~expr ]
-        (B.pexp_tuple ~loc converted)
+        [ B.value_binding ~loc ~pat:pattern ~expr:tuple ]
+        (B.pexp_tuple ~loc
+           (List.mapi
+              (fun index shape ->
+                of_uniform_shape
+                  ~path:(string_of_int index :: path)
+                  shape
+                  (List.nth arguments index)
+                  (evar ~loc (List.nth names index)))
+              shapes))
   | Option shape ->
-      let v = gen_symbol ~prefix:"ptree_og" () in
+      let value = gen_symbol ~prefix:"ptree_value" () in
       B.pexp_match ~loc expr
         [
           B.case
@@ -2733,210 +2790,378 @@ let rec of_gtree_shape ~loc shape expr =
             ~guard:None
             ~rhs:(construct ~loc "None" None);
           B.case
-            ~lhs:(construct_pattern ~loc "Some" (Some (pvar ~loc v)))
+            ~lhs:(construct_pattern ~loc "Some" (Some (pvar ~loc value)))
             ~guard:None
             ~rhs:
               (construct ~loc "Some"
                  (Some
-                    (of_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc v))));
+                    (of_uniform_shape ~path shape
+                       (container_argument core_type)
+                       (evar ~loc value))));
         ]
   | List shape ->
-      let v = gen_symbol ~prefix:"ptree_og" () in
+      let value = gen_symbol ~prefix:"ptree_value" () in
       call ~loc
         (Longident.parse "Stdlib.List.map")
         [
-          B.pexp_fun ~loc Nolabel None (pvar ~loc v)
-            (of_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc v));
+          B.pexp_fun ~loc Nolabel None (pvar ~loc value)
+            (of_uniform_shape ~path shape
+               (container_argument core_type)
+               (evar ~loc value));
           expr;
         ]
   | Array shape ->
-      let v = gen_symbol ~prefix:"ptree_og" () in
+      let value = gen_symbol ~prefix:"ptree_value" () in
       call ~loc
         (Longident.parse "Stdlib.Array.map")
         [
-          B.pexp_fun ~loc Nolabel None (pvar ~loc v)
-            (of_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc v));
+          B.pexp_fun ~loc Nolabel None (pvar ~loc value)
+            (of_uniform_shape ~path shape
+               (container_argument core_type)
+               (evar ~loc value));
           expr;
         ]
 
-let generate_to_gtree ~module_path static_decls : structure =
-  let type_decl = (List.hd static_decls).type_decl in
-  let loc = type_decl.ptype_loc in
-  let body = (List.hd static_decls).body in
-  let rhs =
-    match body with
-    | Some (Alias shape) -> to_gtree_shape ~loc shape (evar ~loc "x")
+(* Synthesising the mirror declaration and its uniform traversals *)
+
+let mirror_shapes declaration =
+  let rec convert shape =
+    let desc =
+      match shape.desc with
+      | Leaf -> UPayload
+      | Ignored -> UStatic
+      | Using module_path -> UUsing (append_lid module_path "Uniform")
+      | Local _ -> assert false
+      | Tuple shapes -> UTuple (List.map convert shapes)
+      | Option shape -> UOption (convert shape)
+      | List shape -> UList (convert shape)
+      | Array shape -> UArray (convert shape)
+    in
+    { udesc = desc; uloc = shape.loc }
+  in
+  match declaration.body with
+  | Some (Alias shape) -> `Alias (convert shape)
+  | Some (Record fields) ->
+      `Record (List.map (fun (label, shape) -> (label, convert shape)) fields)
+  | None -> assert false
+
+let synthesise_mirror_decl ~loc declaration =
+  let params = [ (B.ptyp_var ~loc "m", (NoVariance, NoInjectivity)) ] in
+  match declaration.body with
+  | Some (Alias shape) ->
+      let manifest =
+        mirror_type shape (Option.get declaration.type_decl.ptype_manifest)
+      in
+      {
+        ptype_name = { txt = "t"; loc };
+        ptype_params = params;
+        ptype_cstrs = [];
+        ptype_kind = Ptype_abstract;
+        ptype_private = Public;
+        ptype_manifest = Some manifest;
+        ptype_attributes = [];
+        ptype_loc = loc;
+      }
+  | Some (Record fields) ->
+      let labels =
+        List.map
+          (fun (label, shape) ->
+            {
+              label with
+              pld_type = mirror_type shape label.pld_type;
+              pld_attributes = [];
+            })
+          fields
+      in
+      {
+        ptype_name = { txt = "t"; loc };
+        ptype_params = params;
+        ptype_cstrs = [];
+        ptype_kind = Ptype_record labels;
+        ptype_private = Public;
+        ptype_manifest = None;
+        ptype_attributes = [];
+        ptype_loc = loc;
+      }
+  | None -> assert false
+
+let mirror_udeclaration ~loc declaration =
+  let synth = synthesise_mirror_decl ~loc declaration in
+  let ubody =
+    match (mirror_shapes declaration, synth.ptype_kind) with
+    | `Alias ushape, _ -> UAlias ushape
+    | `Record fields, Ptype_record synth_labels ->
+        URecord
+          (List.map2
+             (fun (_, ushape) synth_label -> (synth_label, ushape))
+             fields synth_labels)
+    | `Record _, _ -> assert false
+  in
+  {
+    utype_decl = synth;
+    ubody = Some ubody;
+    udependencies = String_set.empty;
+  }
+
+let mirror_check declarations =
+  match declarations with
+  | [ declaration ] -> (
+      match declaration.body with
+      | None ->
+          Error
+            [
+              Location.Error.make ~loc:declaration.type_decl.ptype_name.loc
+                "ppx_ptree: mirror mode requires the type's definition; \
+                 abstract types cannot be mirrored"
+                ~sub:[];
+            ]
+      | Some body ->
+          if body_has_local body then
+            Error
+              [
+                Location.Error.make ~loc:declaration.type_decl.ptype_name.loc
+                  "ppx_ptree: mirror mode does not support locally declared or \
+                   recursive types; move the sub-structure to its own module \
+                   deriving [ptree ~mirror]"
+                  ~sub:[];
+              ]
+          else if not (body_has_leaf body) then
+            Error
+              [
+                Location.Error.make ~loc:declaration.type_decl.ptype_name.loc
+                  "ppx_ptree: mirror mode requires at least one tensor leaf"
+                  ~sub:[];
+              ]
+          else Ok declaration)
+  | _ ->
+      let loc =
+        match declarations with
+        | declaration :: _ -> declaration.type_decl.ptype_name.loc
+        | [] -> Location.none
+      in
+      Error
+        [
+          Location.Error.make ~loc
+            "ppx_ptree: mirror mode supports a single type declaration" ~sub:[];
+        ]
+
+let mirror_declaration_dtypes_known declaration =
+  match declaration.body with
+  | Some (Alias shape) ->
+      mirror_dtypes_known shape
+        (Option.get declaration.type_decl.ptype_manifest)
+  | Some (Record fields) ->
+      List.for_all
+        (fun (label, shape) -> mirror_dtypes_known shape label.pld_type)
+        fields
+  | None -> false
+
+let tensor_uniform_type ~loc =
+  B.ptyp_constr ~loc
+    (located_lid ~loc (Longident.Ldot (Lident "Uniform", "t")))
+    [
+      B.ptyp_constr ~loc
+        (located_lid ~loc (Longident.parse "Nx.Ptree.tensor"))
+        [];
+    ]
+
+let mirror_module_items ~module_path declaration =
+  let loc = declaration.type_decl.ptype_loc in
+  let udecl = mirror_udeclaration ~loc declaration in
+  let type_item = B.pstr_type ~loc Nonrecursive [ udecl.utype_decl ] in
+  let module_path =
+    if module_path = "" then "Uniform" else module_path ^ ".Uniform"
+  in
+  let traversals =
+    List.map
+      (fun operation ->
+        B.pstr_value ~loc Nonrecursive
+          [ umake_binding ~module_path operation udecl ])
+      uniform_operations
+  in
+  type_item :: traversals
+
+let mirror_to_uniform ~loc declaration =
+  let body =
+    match declaration.body with
+    | Some (Alias shape) -> to_uniform_shape shape (evar ~loc "x")
     | Some (Record fields) ->
-        let field_exprs =
-          List.map
-            (fun (lbl, sh) ->
-              let access = field ~loc:lbl.pld_loc (evar ~loc "x") lbl in
-              let expr =
-                match sh.desc with
-                | Leaf -> pack_leaf ~loc access
-                | Ignored -> access
-                | Using m -> call ~loc (append_lid m "to_gtree") [ access ]
-                | Local _ -> access
-                | Tuple _ | Option _ | List _ | Array _ ->
-                    to_gtree_shape ~loc:sh.loc sh access
-              in
-              ( located_lid ~loc
-                  (Longident.Ldot (Lident "Gtree", lbl.pld_name.txt)),
-                expr ))
-            fields
-        in
         B.pexp_record ~loc
-          (List.map (fun (lid, e) -> (lid, e)) field_exprs)
+          (List.map
+             (fun (label, shape) ->
+               ( located_lid ~loc:label.pld_name.loc
+                   (Longident.Ldot (Lident "Uniform", label.pld_name.txt)),
+                 to_uniform_shape shape
+                   (field ~loc:label.pld_loc (evar ~loc "x") label) ))
+             fields)
           None
-    | None -> B.eunit ~loc
+    | None -> assert false
   in
-  [
-    B.pstr_value ~loc Nonrecursive
-      [
-        B.value_binding ~loc ~pat:(pvar ~loc "to_gtree")
-          ~expr:(B.pexp_fun ~loc Nolabel None (pvar ~loc "x") rhs);
-      ];
-  ]
+  B.pstr_value ~loc Nonrecursive
+    [
+      B.value_binding ~loc
+        ~pat:(pvar ~loc "to_uniform")
+        ~expr:
+          (B.pexp_fun ~loc Nolabel None
+             (constrained_parameter ~loc "x"
+                (declared_type declaration.type_decl))
+             (B.pexp_constraint ~loc body (tensor_uniform_type ~loc)));
+    ]
 
-let gtree_field_access ~loc expr name =
-  B.pexp_field ~loc expr
-    (located_lid ~loc (Longident.Ldot (Lident "Gtree", name)))
-
-let generate_of_gtree ~module_path static_decls : structure =
-  let type_decl = (List.hd static_decls).type_decl in
-  let loc = type_decl.ptype_loc in
-  let body = (List.hd static_decls).body in
-  let rhs =
-    match body with
-    | Some (Alias s) -> (
-        match s.desc with
-        | Leaf -> (
-            match type_decl.ptype_manifest with
-            | Some manifest -> (
-                match dtype_expr_of_core_type ~loc manifest with
-                | Some dtype -> unpack_leaf ~loc ~dtype (evar ~loc "u")
-                | None -> evar ~loc "u")
-            | None -> evar ~loc "u")
-        | _ -> of_gtree_shape ~loc s (evar ~loc "u"))
+let mirror_of_uniform ~loc declaration =
+  let body =
+    match declaration.body with
+    | Some (Alias shape) ->
+        of_uniform_shape ~path:[] shape
+          (Option.get declaration.type_decl.ptype_manifest)
+          (evar ~loc "u")
     | Some (Record fields) ->
-        let field_exprs =
-          List.map
-            (fun (lbl, sh) ->
-              let access =
-                gtree_field_access ~loc (evar ~loc "u") lbl.pld_name.txt
-              in
-              let expr =
-                match sh.desc with
-                | Leaf -> (
-                    match dtype_expr_of_core_type ~loc lbl.pld_type with
-                    | Some dtype -> unpack_leaf ~loc ~dtype access
-                    | None -> access)
-                | Ignored -> access
-                | Using m -> call ~loc (append_lid m "of_gtree") [ access ]
-                | Local _ -> access
-                | Tuple _ | Option _ | List _ | Array _ ->
-                    of_gtree_shape ~loc:sh.loc sh access
-              in
-              (lident ~loc:lbl.pld_name.loc lbl.pld_name.txt, expr))
-            fields
-        in
-        B.pexp_record ~loc field_exprs None
-    | None -> evar ~loc "u"
+        B.pexp_record ~loc
+          (List.map
+             (fun (label, shape) ->
+               ( lident ~loc:label.pld_name.loc label.pld_name.txt,
+                 of_uniform_shape
+                   ~path:[ label.pld_name.txt ]
+                   shape label.pld_type
+                   (B.pexp_field ~loc:label.pld_loc (evar ~loc "u")
+                      (located_lid ~loc:label.pld_name.loc
+                         (Longident.Ldot (Lident "Uniform", label.pld_name.txt)))) ))
+             fields)
+          None
+    | None -> assert false
   in
-  [
-    B.pstr_value ~loc Nonrecursive
-      [
-        B.value_binding ~loc ~pat:(pvar ~loc "of_gtree")
-          ~expr:(B.pexp_fun ~loc Nolabel None (pvar ~loc "u") rhs);
-      ];
-  ]
+  B.pstr_value ~loc Nonrecursive
+    [
+      B.value_binding ~loc
+        ~pat:(pvar ~loc "of_uniform")
+        ~expr:
+          (B.pexp_fun ~loc Nolabel None
+             (constrained_parameter ~loc "u" (tensor_uniform_type ~loc))
+             (B.pexp_constraint ~loc body
+                (declared_type declaration.type_decl)));
+    ]
 
-let generate_gtree_mirror ~ctxt type_declarations : structure =
-  let ptree_decls, errors = validate ~signature:false type_declarations in
-  if errors <> [] then structure_errors errors
-  else if ptree_decls = [] then []
+let mirror_structure ~ctxt type_declarations =
+  let declarations, errors = validate ~signature:false type_declarations in
+  if errors <> [] then []
   else
-    let module_path =
-      Expansion_context.Deriver.code_path ctxt |> Code_path.fully_qualified_path
-    in
-    let mod_part = generate_gtree_module ~module_path ptree_decls in
-    let to_part = generate_to_gtree ~module_path ptree_decls in
-    let of_part = generate_of_gtree ~module_path ptree_decls in
-    mod_part @ to_part @ of_part
+    match mirror_check declarations with
+    | Error errors -> structure_errors errors
+    | Ok declaration ->
+        let loc = declaration.type_decl.ptype_loc in
+        let module_path =
+          Expansion_context.Deriver.code_path ctxt
+          |> Code_path.fully_qualified_path
+        in
+        let module_item =
+          B.pstr_module ~loc
+            (B.module_binding ~loc
+               ~name:{ txt = Some "Uniform"; loc }
+               ~expr:
+                 (B.pmod_structure ~loc
+                    (mirror_module_items ~module_path declaration)))
+        in
+        let conversions =
+          mirror_to_uniform ~loc declaration
+          ::
+          (if mirror_declaration_dtypes_known declaration then
+             [ mirror_of_uniform ~loc declaration ]
+           else [])
+        in
+        module_item :: conversions
 
-let gtree_structure_generator ~ctxt (_, type_declarations) =
-  let declarations, errors = uvalidate ~signature:false type_declarations in
-  if errors <> [] then structure_errors errors
-  else if declarations = [] then
-    (* Mirror mode *)
-    generate_gtree_mirror ~ctxt type_declarations
+let mirror_signature ~ctxt type_declarations =
+  let declarations, errors = validate ~signature:true type_declarations in
+  if errors <> [] then []
   else
-    let module_path =
-      Expansion_context.Deriver.code_path ctxt |> Code_path.fully_qualified_path
-    in
-    let components = uordered_components declarations in
-    List.concat_map
-      (fun operation -> ugenerate_operation ~module_path operation components)
-      [ `Umap; `Umap2; `Uiter; `Ufold; `Ufold2; `Unames ]
-
-let usignature_type operation type_decl =
-  let loc = type_decl.ptype_loc in
-  let var_a = "a" in
-  let var_b = "b" in
-  let var_c = "c" in
-  let cb_ty = ucallback_type ~loc operation var_a var_b var_c in
-  let type_ = declared_type type_decl in
-  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
-  let acc_ty = B.ptyp_var ~loc "acc" in
-  match operation with
-  | `Umap -> arrow cb_ty (arrow type_ (B.ptyp_var ~loc "b"))
-  | `Umap2 -> arrow cb_ty (arrow type_ (arrow type_ (B.ptyp_var ~loc "c")))
-  | `Uiter ->
-      arrow cb_ty (arrow type_ (B.ptyp_constr ~loc (lident ~loc "unit") []))
-  | `Ufold -> arrow cb_ty (arrow acc_ty (arrow type_ acc_ty))
-  | `Ufold2 -> arrow cb_ty (arrow acc_ty (arrow type_ (arrow type_ acc_ty)))
-  | `Unames ->
-      arrow
-        (B.ptyp_constr ~loc (lident ~loc "unit") [])
-        (B.ptyp_constr ~loc (lident ~loc "string") [])
-
-let gtree_signature_generator ~ctxt (_, type_declarations) =
-  let declarations, errors = uvalidate ~signature:true type_declarations in
-  if errors <> [] then signature_errors errors
-  else if declarations = [] then []
-  else
-    let add_values udecl =
-      let type_decl = udecl.utype_decl in
-      let names = unames_for_type type_decl.ptype_name.txt in
-      List.map
-        (fun operation ->
-          let name = uoperation_name operation names in
-          let loc = type_decl.ptype_name.loc in
+    match mirror_check declarations with
+    | Error errors -> signature_errors errors
+    | Ok declaration ->
+        Stdlib.ignore ctxt;
+        let loc = declaration.type_decl.ptype_loc in
+        let udecl = mirror_udeclaration ~loc declaration in
+        let type_item = B.psig_type ~loc Nonrecursive [ udecl.utype_decl ] in
+        let traversal_values =
+          List.map
+            (fun operation ->
+              let name =
+                uoperation_name operation (uniform_names_for_type "t")
+              in
+              B.psig_value ~loc
+                (B.value_description ~loc ~name:{ txt = name; loc }
+                   ~type_:(usignature_type operation udecl.utype_decl)
+                   ~prim:[]))
+            uniform_operations
+        in
+        let module_item =
+          B.psig_module ~loc
+            (B.module_declaration ~loc
+               ~name:{ txt = Some "Uniform"; loc }
+               ~type_:(B.pmty_signature ~loc (type_item :: traversal_values)))
+        in
+        let to_uniform_item =
           B.psig_value ~loc
-            (B.value_description ~loc ~name:{ txt = name; loc }
-               ~type_:(usignature_type operation type_decl)
-               ~prim:[]))
-        [ `Umap; `Umap2; `Uiter; `Ufold; `Ufold2; `Unames ]
-    in
-    Stdlib.ignore ctxt;
-    List.concat_map add_values declarations
+            (B.value_description ~loc
+               ~name:{ txt = "to_uniform"; loc }
+               ~type_:
+                 (B.ptyp_arrow ~loc Nolabel
+                    (declared_type declaration.type_decl)
+                    (tensor_uniform_type ~loc))
+               ~prim:[])
+        in
+        let of_uniform_items =
+          if mirror_declaration_dtypes_known declaration then
+            [
+              B.psig_value ~loc
+                (B.value_description ~loc
+                   ~name:{ txt = "of_uniform"; loc }
+                   ~type_:
+                     (B.ptyp_arrow ~loc Nolabel (tensor_uniform_type ~loc)
+                        (declared_type declaration.type_decl))
+                   ~prim:[]);
+            ]
+          else []
+        in
+        (module_item :: to_uniform_item :: of_uniform_items)
+
+(* Deriver registration: one deriver, dispatching on the shape of the
+   declaration group. *)
+
+let mirror_on_uniform_error type_declarations =
+  let loc =
+    match type_declarations with
+    | type_decl :: _ -> type_decl.ptype_name.loc
+    | [] -> Location.none
+  in
+  Location.Error.make ~loc
+    "ppx_ptree: [~mirror] applies to concrete types; uniform (parameterised) \
+     types are their own mirror"
+    ~sub:[]
+
+let ptree_structure ~ctxt (recursive, type_declarations) mirror =
+  if uniform_group type_declarations then
+    if mirror then structure_errors [ mirror_on_uniform_error type_declarations ]
+    else uniform_structure ~ctxt type_declarations
+  else
+    let base = structure_generator ~ctxt (recursive, type_declarations) in
+    if mirror then base @ mirror_structure ~ctxt type_declarations else base
+
+let ptree_signature ~ctxt (recursive, type_declarations) mirror =
+  if uniform_group type_declarations then
+    if mirror then signature_errors [ mirror_on_uniform_error type_declarations ]
+    else uniform_signature ~ctxt type_declarations
+  else
+    let base = signature_generator ~ctxt (recursive, type_declarations) in
+    if mirror then base @ mirror_signature ~ctxt type_declarations else base
 
 let () =
   Deriving.add "ptree"
     ~str_type_decl:
-      (Deriving.Generator.V2.make_noarg ~unused_code_warnings:true
-         structure_generator)
+      (Deriving.Generator.V2.make ~unused_code_warnings:true
+         Deriving.Args.(empty +> flag "mirror")
+         ptree_structure)
     ~sig_type_decl:
-      (Deriving.Generator.V2.make_noarg ~unused_code_warnings:true
-         signature_generator)
-  |> Deriving.ignore
-
-let () =
-  Deriving.add "gtree"
-    ~str_type_decl:
-      (Deriving.Generator.V2.make_noarg ~unused_code_warnings:true
-         gtree_structure_generator)
-    ~sig_type_decl:
-      (Deriving.Generator.V2.make_noarg ~unused_code_warnings:true
-         gtree_signature_generator)
+      (Deriving.Generator.V2.make ~unused_code_warnings:true
+         Deriving.Args.(empty +> flag "mirror")
+         ptree_signature)
   |> Deriving.ignore

--- a/packages/ppx_ptree/ppx_ptree.ml
+++ b/packages/ppx_ptree/ppx_ptree.ml
@@ -494,6 +494,7 @@ let signature_errors errors =
 let located_lid ~loc path = { txt = path; loc }
 let lident ~loc name = located_lid ~loc (Longident.Lident name)
 let append_lid path name = Longident.Ldot (path, name)
+let stdlib_operator name = Longident.Ldot (Lident "Stdlib", name)
 let ident ~loc path = B.pexp_ident ~loc (located_lid ~loc path)
 let evar ~loc name = B.evar ~loc name
 let pvar ~loc name = B.pvar ~loc name
@@ -775,7 +776,7 @@ and map2_list ~loc ~function_path ~path callback shape left right =
           [ evar ~loc right_name ] );
     ]
     (B.pexp_ifthenelse ~loc
-       (call ~loc (Longident.Lident "<>")
+       (call ~loc (stdlib_operator "<>")
           [ evar ~loc left_length; evar ~loc right_length ])
        (invalid_argument ~loc
           (mismatch_message function_path "list length" path))
@@ -814,7 +815,7 @@ and map2_array ~loc ~function_path ~path callback shape left right =
           [ evar ~loc right_name ] );
     ]
     (B.pexp_ifthenelse ~loc
-       (call ~loc (Longident.Lident "<>")
+       (call ~loc (stdlib_operator "<>")
           [ evar ~loc left_length; evar ~loc right_length ])
        (invalid_argument ~loc
           (mismatch_message function_path "array length" path))
@@ -1526,24 +1527,68 @@ let ucomponent_rec_flag component =
       else Nonrecursive
   | _ -> Recursive
 
-(* Leaf paths: [None] at the root, otherwise a string expression holding the
-   dot-joined segments so far. Top-level segments are bare; deeper segments are
-   appended with ["."], matching the checkpoint naming convention. *)
+(* Leaf paths. Record fields and tuple positions are known while expanding, so a
+   path stays a literal until a container index or a delegated sub-path makes it
+   depend on the value. Segments are joined with ["."], matching the checkpoint
+   naming convention; the root is the empty path. *)
 
-let ujoin ~loc path segment =
+type upath = Uroot | Uliteral of string | Ucomputed of expression
+
+let concat ~loc left right = call ~loc (stdlib_operator "^") [ left; right ]
+
+let ujoin_literal ~loc path segment =
   match path with
-  | None -> segment
-  | Some path ->
-      call ~loc (Longident.Lident "^")
-        [
-          call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ]; segment;
-        ]
+  | Uroot -> Uliteral segment
+  | Uliteral prefix -> Uliteral (prefix ^ "." ^ segment)
+  | Ucomputed prefix ->
+      Ucomputed (concat ~loc prefix (B.estring ~loc ("." ^ segment)))
+
+let ujoin_computed ~loc path segment =
+  match path with
+  | Uroot -> Ucomputed segment
+  | Uliteral prefix ->
+      Ucomputed (concat ~loc (B.estring ~loc (prefix ^ ".")) segment)
+  | Ucomputed prefix ->
+      Ucomputed (concat ~loc (concat ~loc prefix (B.estring ~loc ".")) segment)
 
 let upath_expr ~loc path =
-  match path with None -> B.estring ~loc "" | Some path -> path
+  match path with
+  | Uroot -> B.estring ~loc ""
+  | Uliteral path -> B.estring ~loc path
+  | Ucomputed path -> path
 
-let umismatch_message function_path kind =
-  Format.sprintf "%s: %s mismatch" function_path kind
+(* A delegated traversal numbers its leaves from its own root, so a payload
+   sitting at that root hands back the empty path. Joining it unconditionally
+   would leave a trailing separator. *)
+let ujoin_delegated ~loc path segment =
+  let guarded prefix =
+    B.pexp_ifthenelse ~loc
+      (call ~loc
+         (Longident.parse "Stdlib.String.equal")
+         [ segment; B.estring ~loc "" ])
+      (upath_expr ~loc prefix)
+      (Some (upath_expr ~loc (ujoin_computed ~loc prefix segment)))
+  in
+  match path with
+  | Uroot -> segment
+  | Uliteral _ -> guarded path
+  | Ucomputed prefix ->
+      let name = gen_symbol ~prefix:"ptree_prefix" () in
+      let_one ~loc name prefix (guarded (Ucomputed (evar ~loc name)))
+
+let uindex_path ~loc path index =
+  ujoin_computed ~loc path
+    (call ~loc (Longident.parse "Stdlib.string_of_int") [ evar ~loc index ])
+
+let umismatch ~loc ~function_path ~path kind =
+  let message = Format.sprintf "%s: %s mismatch at " function_path kind in
+  match path with
+  | Uroot -> invalid_argument ~loc (message ^ "<root>")
+  | Uliteral path -> invalid_argument ~loc (message ^ path)
+  | Ucomputed path ->
+      call ~loc
+        (Longident.Ldot (Lident "Stdlib", "invalid_arg"))
+        [ concat ~loc (B.estring ~loc message) path ]
 
 (* map *)
 
@@ -1606,7 +1651,7 @@ let rec umap_expr fvar shape expr =
 
 (* map2 *)
 
-let rec umap2_expr ~function_path fvar shape left right =
+let rec umap2_expr ~function_path ~path fvar shape left right =
   let loc = shape.uloc in
   match shape.udesc with
   | UPayload -> call ~loc (Lident fvar) [ left; right ]
@@ -1629,7 +1674,9 @@ let rec umap2_expr ~function_path fvar shape left right =
       let mapped =
         List.mapi
           (fun index shape ->
-            umap2_expr ~function_path fvar shape
+            umap2_expr ~function_path
+              ~path:(ujoin_literal ~loc path (string_of_int index))
+              fvar shape
               (evar ~loc:shape.uloc (List.nth left_names index))
               (evar ~loc:shape.uloc (List.nth right_names index)))
           shapes
@@ -1667,13 +1714,11 @@ let rec umap2_expr ~function_path fvar shape left right =
             ~rhs:
               (construct ~loc "Some"
                  (Some
-                    (umap2_expr ~function_path fvar shape
+                    (umap2_expr ~function_path ~path fvar shape
                        (evar ~loc:shape.uloc left_value)
                        (evar ~loc:shape.uloc right_value))));
           B.case ~lhs:(B.ppat_any ~loc) ~guard:None
-            ~rhs:
-              (invalid_argument ~loc
-                 (umismatch_message function_path "option constructor"));
+            ~rhs:(umismatch ~loc ~function_path ~path "option constructor");
         ]
   | UList shape ->
       let left_name = gen_symbol ~prefix:"ptree_left" () in
@@ -1683,14 +1728,14 @@ let rec umap2_expr ~function_path fvar shape left right =
       let mapper =
         B.pexp_fun ~loc Nolabel None (pvar ~loc left_value)
           (B.pexp_fun ~loc Nolabel None (pvar ~loc right_value)
-             (umap2_expr ~function_path fvar shape
+             (umap2_expr ~function_path ~path fvar shape
                 (evar ~loc:shape.uloc left_value)
                 (evar ~loc:shape.uloc right_value)))
       in
       lets ~loc
         [ (left_name, left); (right_name, right) ]
         (B.pexp_ifthenelse ~loc
-           (call ~loc (Longident.Lident "<>")
+           (call ~loc (stdlib_operator "<>")
               [
                 call ~loc
                   (Longident.parse "Stdlib.List.length")
@@ -1699,8 +1744,7 @@ let rec umap2_expr ~function_path fvar shape left right =
                   (Longident.parse "Stdlib.List.length")
                   [ evar ~loc right_name ];
               ])
-           (invalid_argument ~loc
-              (umismatch_message function_path "list length"))
+           (umismatch ~loc ~function_path ~path "list length")
            (Some
               (call ~loc
                  (Longident.parse "Stdlib.List.map2")
@@ -1717,7 +1761,7 @@ let rec umap2_expr ~function_path fvar shape left right =
       in
       let array_initializer =
         B.pexp_fun ~loc Nolabel None (pvar ~loc index)
-          (umap2_expr ~function_path fvar shape (value_at left_name)
+          (umap2_expr ~function_path ~path fvar shape (value_at left_name)
              (value_at right_name))
       in
       lets ~loc
@@ -1730,15 +1774,14 @@ let rec umap2_expr ~function_path fvar shape left right =
               [ evar ~loc left_name ] );
         ]
         (B.pexp_ifthenelse ~loc
-           (call ~loc (Longident.Lident "<>")
+           (call ~loc (stdlib_operator "<>")
               [
                 evar ~loc length_name;
                 call ~loc
                   (Longident.parse "Stdlib.Array.length")
                   [ evar ~loc right_name ];
               ])
-           (invalid_argument ~loc
-              (umismatch_message function_path "array length"))
+           (umismatch ~loc ~function_path ~path "array length")
            (Some
               (call ~loc
                  (Longident.parse "Stdlib.Array.init")
@@ -1805,7 +1848,8 @@ let udelegate_callback ~loc ~path fvar arity =
        (fun name body -> B.pexp_fun ~loc Nolabel None (pvar ~loc name) body)
        rest
        (call ~loc (Lident fvar)
-          (ujoin ~loc path (evar ~loc sub_path) :: List.map (evar ~loc) rest)))
+          (ujoin_delegated ~loc path (evar ~loc sub_path)
+          :: List.map (evar ~loc) rest)))
 
 let rec ufold_expr ~path fvar shape expr acc_expr =
   let loc = shape.uloc in
@@ -1829,8 +1873,7 @@ let rec ufold_expr ~path fvar shape expr acc_expr =
           (fun (index, acc) shape name ->
             ( index + 1,
               ufold_expr
-                ~path:
-                  (Some (ujoin ~loc path (B.estring ~loc (string_of_int index))))
+                ~path:(ujoin_literal ~loc path (string_of_int index))
                 fvar shape (evar ~loc name) acc ))
           (0, acc_expr) shapes names
       in
@@ -1859,13 +1902,7 @@ let rec ufold_expr ~path fvar shape expr acc_expr =
       let index = gen_symbol ~prefix:"ptree_index" () in
       let value = gen_symbol ~prefix:"ptree_value" () in
       let pair = gen_symbol ~prefix:"ptree_pair" () in
-      let child_path =
-        Some
-          (ujoin ~loc path
-             (call ~loc
-                (Longident.parse "Stdlib.string_of_int")
-                [ evar ~loc index ]))
-      in
+      let child_path = uindex_path ~loc path index in
       let inner_body =
         B.pexp_let ~loc Nonrecursive
           [
@@ -1896,13 +1933,7 @@ let rec ufold_expr ~path fvar shape expr acc_expr =
       let index = gen_symbol ~prefix:"ptree_index" () in
       let value = gen_symbol ~prefix:"ptree_value" () in
       let pair = gen_symbol ~prefix:"ptree_pair" () in
-      let child_path =
-        Some
-          (ujoin ~loc path
-             (call ~loc
-                (Longident.parse "Stdlib.string_of_int")
-                [ evar ~loc index ]))
-      in
+      let child_path = uindex_path ~loc path index in
       let inner_body =
         B.pexp_let ~loc Nonrecursive
           [
@@ -1958,8 +1989,7 @@ let rec ufold2_expr ~function_path ~path fvar shape left right acc_expr =
           (fun (index, acc) shape (left_name, right_name) ->
             ( index + 1,
               ufold2_expr ~function_path
-                ~path:
-                  (Some (ujoin ~loc path (B.estring ~loc (string_of_int index))))
+                ~path:(ujoin_literal ~loc path (string_of_int index))
                 fvar shape (evar ~loc left_name) (evar ~loc right_name) acc ))
           (0, acc_expr) shapes
           (List.combine left_names right_names)
@@ -2001,9 +2031,7 @@ let rec ufold2_expr ~function_path ~path fvar shape left right acc_expr =
                     (evar ~loc:shape.uloc right_value)
                     (evar ~loc acc_name));
              B.case ~lhs:(B.ppat_any ~loc) ~guard:None
-               ~rhs:
-                 (invalid_argument ~loc
-                    (umismatch_message function_path "option constructor"));
+               ~rhs:(umismatch ~loc ~function_path ~path "option constructor");
            ])
   | UList shape ->
       let left_name = gen_symbol ~prefix:"ptree_left" () in
@@ -2013,13 +2041,7 @@ let rec ufold2_expr ~function_path ~path fvar shape left right acc_expr =
       let left_value = gen_symbol ~prefix:"ptree_left_value" () in
       let right_value = gen_symbol ~prefix:"ptree_right_value" () in
       let pair = gen_symbol ~prefix:"ptree_pair" () in
-      let child_path =
-        Some
-          (ujoin ~loc path
-             (call ~loc
-                (Longident.parse "Stdlib.string_of_int")
-                [ evar ~loc index ]))
-      in
+      let child_path = uindex_path ~loc path index in
       let inner_body =
         B.pexp_let ~loc Nonrecursive
           [
@@ -2033,7 +2055,7 @@ let rec ufold2_expr ~function_path ~path fvar shape left right acc_expr =
       lets ~loc
         [ (left_name, left); (right_name, right) ]
         (B.pexp_ifthenelse ~loc
-           (call ~loc (Longident.Lident "<>")
+           (call ~loc (stdlib_operator "<>")
               [
                 call ~loc
                   (Longident.parse "Stdlib.List.length")
@@ -2042,8 +2064,7 @@ let rec ufold2_expr ~function_path ~path fvar shape left right acc_expr =
                   (Longident.parse "Stdlib.List.length")
                   [ evar ~loc right_name ];
               ])
-           (invalid_argument ~loc
-              (umismatch_message function_path "list length"))
+           (umismatch ~loc ~function_path ~path "list length")
            (Some
               (call ~loc
                  (Longident.parse "Stdlib.List.fold_left2")
@@ -2070,13 +2091,7 @@ let rec ufold2_expr ~function_path ~path fvar shape left right acc_expr =
       let length_name = gen_symbol ~prefix:"ptree_length" () in
       let acc_name = gen_symbol ~prefix:"ptree_acc" () in
       let index = gen_symbol ~prefix:"ptree_index" () in
-      let child_path =
-        Some
-          (ujoin ~loc path
-             (call ~loc
-                (Longident.parse "Stdlib.string_of_int")
-                [ evar ~loc index ]))
-      in
+      let child_path = uindex_path ~loc path index in
       let value_at array =
         call ~loc
           (Longident.parse "Stdlib.Array.unsafe_get")
@@ -2092,15 +2107,14 @@ let rec ufold2_expr ~function_path ~path fvar shape left right acc_expr =
               [ evar ~loc left_name ] );
         ]
         (B.pexp_ifthenelse ~loc
-           (call ~loc (Longident.Lident "<>")
+           (call ~loc (stdlib_operator "<>")
               [
                 evar ~loc length_name;
                 call ~loc
                   (Longident.parse "Stdlib.Array.length")
                   [ evar ~loc right_name ];
               ])
-           (invalid_argument ~loc
-              (umismatch_message function_path "array length"))
+           (umismatch ~loc ~function_path ~path "array length")
            (Some
               (call ~loc
                  (Longident.parse "Stdlib.Array.fold_left")
@@ -2141,7 +2155,7 @@ let rec unames_expr ~path shape expr =
       call ~loc map_target
         [
           B.pexp_fun ~loc Nolabel None (pvar ~loc sub_path)
-            (ujoin ~loc path (evar ~loc sub_path));
+            (ujoin_delegated ~loc path (evar ~loc sub_path));
           call ~loc names_target [ expr ];
         ]
   | UTuple shapes ->
@@ -2163,9 +2177,7 @@ let rec unames_expr ~path shape expr =
            (List.mapi
               (fun index shape ->
                 unames_expr
-                  ~path:
-                    (Some
-                       (ujoin ~loc path (B.estring ~loc (string_of_int index))))
+                  ~path:(ujoin_literal ~loc path (string_of_int index))
                   shape
                   (evar ~loc (List.nth names index)))
               shapes))
@@ -2203,12 +2215,7 @@ let rec unames_expr ~path shape expr =
           B.pexp_fun ~loc Nolabel None (pvar ~loc index)
             (B.pexp_fun ~loc Nolabel None value_pattern
                (unames_expr
-                  ~path:
-                    (Some
-                       (ujoin ~loc path
-                          (call ~loc
-                             (Longident.parse "Stdlib.string_of_int")
-                             [ evar ~loc index ])))
+                  ~path:(uindex_path ~loc path index)
                   shape (evar ~loc value)));
           expr;
         ]
@@ -2226,12 +2233,7 @@ let rec unames_expr ~path shape expr =
           B.pexp_fun ~loc Nolabel None (pvar ~loc index)
             (B.pexp_fun ~loc Nolabel None value_pattern
                (unames_expr
-                  ~path:
-                    (Some
-                       (ujoin ~loc path
-                          (call ~loc
-                             (Longident.parse "Stdlib.string_of_int")
-                             [ evar ~loc index ])))
+                  ~path:(uindex_path ~loc path index)
                   shape (evar ~loc value)));
           expr;
         ]
@@ -2261,9 +2263,7 @@ let uoperation_body ~loc ~function_path operation ubody =
   let input = evar ~loc "x" in
   let second = evar ~loc "y" in
   let accumulator = evar ~loc "acc" in
-  let field_path label =
-    Some (B.estring ~loc:label.pld_loc label.pld_name.txt)
-  in
+  let field_path label = Uliteral label.pld_name.txt in
   match (operation, ubody) with
   | `Umap, UAlias shape -> umap_expr "f" shape input
   | `Umap, URecord fields ->
@@ -2275,14 +2275,15 @@ let uoperation_body ~loc ~function_path operation ubody =
                umap_expr "f" shape (field ~loc:label.pld_loc input label),
                label ))
            fields)
-  | `Umap2, UAlias shape -> umap2_expr ~function_path "f" shape input second
+  | `Umap2, UAlias shape ->
+      umap2_expr ~function_path ~path:Uroot "f" shape input second
   | `Umap2, URecord fields ->
       urecord ~loc
         (List.map
            (fun (label, shape) ->
              ( label.pld_loc,
                gen_symbol ~prefix:("ptree_" ^ label.pld_name.txt) (),
-               umap2_expr ~function_path "f" shape
+               umap2_expr ~function_path ~path:(field_path label) "f" shape
                  (field ~loc:label.pld_loc input label)
                  (field ~loc:label.pld_loc second label),
                label ))
@@ -2294,7 +2295,7 @@ let uoperation_body ~loc ~function_path operation ubody =
            (fun (label, shape) ->
              uiter_expr "f" shape (field ~loc:label.pld_loc input label))
            fields)
-  | `Ufold, UAlias shape -> ufold_expr ~path:None "f" shape input accumulator
+  | `Ufold, UAlias shape -> ufold_expr ~path:Uroot "f" shape input accumulator
   | `Ufold, URecord fields ->
       List.fold_left
         (fun acc (label, shape) ->
@@ -2303,7 +2304,7 @@ let uoperation_body ~loc ~function_path operation ubody =
             acc)
         accumulator fields
   | `Ufold2, UAlias shape ->
-      ufold2_expr ~function_path ~path:None "f" shape input second accumulator
+      ufold2_expr ~function_path ~path:Uroot "f" shape input second accumulator
   | `Ufold2, URecord fields ->
       List.fold_left
         (fun acc (label, shape) ->
@@ -2313,7 +2314,7 @@ let uoperation_body ~loc ~function_path operation ubody =
             acc)
         accumulator fields
   | `Unames, UAlias shape ->
-      let body = unames_expr ~path:None shape input in
+      let body = unames_expr ~path:Uroot shape input in
       if unames_uses_input ubody then body
       else
         B.pexp_sequence ~loc
@@ -2704,11 +2705,7 @@ let pack_leaf ~loc expr =
 let unpack_leaf ~loc ~path ~dtype expr =
   B.pexp_apply ~loc
     (ident ~loc (Longident.parse "Nx.Ptree.unpack"))
-    [
-      (Labelled "at", B.estring ~loc (String.concat "." (List.rev path)));
-      (Nolabel, dtype);
-      (Nolabel, expr);
-    ]
+    [ (Labelled "at", upath_expr ~loc path); (Nolabel, dtype); (Nolabel, expr) ]
 
 let rec to_uniform_shape shape expr =
   let loc = shape.loc in
@@ -2783,7 +2780,7 @@ let rec of_uniform_shape ~path shape core_type expr =
            (List.mapi
               (fun index shape ->
                 of_uniform_shape
-                  ~path:(string_of_int index :: path)
+                  ~path:(ujoin_literal ~loc path (string_of_int index))
                   shape (List.nth arguments index)
                   (evar ~loc (List.nth names index)))
               shapes))
@@ -2806,25 +2803,33 @@ let rec of_uniform_shape ~path shape core_type expr =
                        (evar ~loc value))));
         ]
   | List shape ->
+      let index = gen_symbol ~prefix:"ptree_index" () in
       let value = gen_symbol ~prefix:"ptree_value" () in
       call ~loc
-        (Longident.parse "Stdlib.List.map")
+        (Longident.parse "Stdlib.List.mapi")
         [
-          B.pexp_fun ~loc Nolabel None (pvar ~loc value)
-            (of_uniform_shape ~path shape
-               (container_argument core_type)
-               (evar ~loc value));
+          B.pexp_fun ~loc Nolabel None (pvar ~loc index)
+            (B.pexp_fun ~loc Nolabel None (pvar ~loc value)
+               (of_uniform_shape
+                  ~path:(uindex_path ~loc path index)
+                  shape
+                  (container_argument core_type)
+                  (evar ~loc value)));
           expr;
         ]
   | Array shape ->
+      let index = gen_symbol ~prefix:"ptree_index" () in
       let value = gen_symbol ~prefix:"ptree_value" () in
       call ~loc
-        (Longident.parse "Stdlib.Array.map")
+        (Longident.parse "Stdlib.Array.mapi")
         [
-          B.pexp_fun ~loc Nolabel None (pvar ~loc value)
-            (of_uniform_shape ~path shape
-               (container_argument core_type)
-               (evar ~loc value));
+          B.pexp_fun ~loc Nolabel None (pvar ~loc index)
+            (B.pexp_fun ~loc Nolabel None (pvar ~loc value)
+               (of_uniform_shape
+                  ~path:(uindex_path ~loc path index)
+                  shape
+                  (container_argument core_type)
+                  (evar ~loc value)));
           expr;
         ]
 
@@ -3013,7 +3018,7 @@ let mirror_of_uniform ~loc declaration =
   let body =
     match declaration.body with
     | Some (Alias shape) ->
-        of_uniform_shape ~path:[] shape
+        of_uniform_shape ~path:Uroot shape
           (Option.get declaration.type_decl.ptype_manifest)
           (evar ~loc "u")
     | Some (Record fields) ->
@@ -3021,7 +3026,7 @@ let mirror_of_uniform ~loc declaration =
           (List.map
              (fun (label, shape) ->
                ( lident ~loc:label.pld_name.loc label.pld_name.txt,
-                 of_uniform_shape ~path:[ label.pld_name.txt ] shape
+                 of_uniform_shape ~path:(Uliteral label.pld_name.txt) shape
                    label.pld_type
                    (B.pexp_field ~loc:label.pld_loc (evar ~loc "u")
                       (located_lid ~loc:label.pld_name.loc

--- a/packages/ppx_ptree/ppx_ptree.ml
+++ b/packages/ppx_ptree/ppx_ptree.ml
@@ -1590,6 +1590,38 @@ let umismatch ~loc ~function_path ~path kind =
         (Longident.Ldot (Lident "Stdlib", "invalid_arg"))
         [ concat ~loc (B.estring ~loc message) path ]
 
+(* Indexed traversal: [fold] and [fold2] number the elements they visit, which a
+   local loop carries in a parameter rather than in a paired-up copy of the
+   container. *)
+
+let successor ~loc name =
+  call ~loc (stdlib_operator "+") [ evar ~loc name; B.eint ~loc 1 ]
+
+let nil_pattern ~loc = B.ppat_construct ~loc (lident ~loc "[]") None
+
+let cons_pattern ~loc head tail =
+  B.ppat_construct ~loc (lident ~loc "::")
+    (Some (B.ppat_tuple ~loc [ pvar ~loc head; pvar ~loc tail ]))
+
+let array_length ~loc name =
+  call ~loc (Longident.parse "Stdlib.Array.length") [ evar ~loc name ]
+
+let element_at ~loc array index =
+  call ~loc
+    (Longident.parse "Stdlib.Array.unsafe_get")
+    [ evar ~loc array; evar ~loc index ]
+
+let let_rec_loop ~loc name parameters body arguments =
+  let abstraction =
+    List.fold_right
+      (fun parameter body ->
+        B.pexp_fun ~loc Nolabel None (pvar ~loc parameter) body)
+      parameters body
+  in
+  B.pexp_let ~loc Recursive
+    [ B.value_binding ~loc ~pat:(pvar ~loc name) ~expr:abstraction ]
+    (call ~loc (Lident name) arguments)
+
 (* map *)
 
 let rec umap_expr fvar shape expr =
@@ -1898,67 +1930,55 @@ let rec ufold_expr ~path fvar shape expr acc_expr =
                     (evar ~loc acc_name));
            ])
   | UList shape ->
+      let loop = gen_symbol ~prefix:"ptree_loop" () in
       let acc_name = gen_symbol ~prefix:"ptree_acc" () in
       let index = gen_symbol ~prefix:"ptree_index" () in
+      let list_name = gen_symbol ~prefix:"ptree_list" () in
       let value = gen_symbol ~prefix:"ptree_value" () in
-      let pair = gen_symbol ~prefix:"ptree_pair" () in
+      let rest = gen_symbol ~prefix:"ptree_rest" () in
       let child_path = uindex_path ~loc path index in
-      let inner_body =
-        B.pexp_let ~loc Nonrecursive
+      let step =
+        call ~loc (Lident loop)
           [
-            B.value_binding ~loc
-              ~pat:(B.ppat_tuple ~loc [ pvar ~loc index; pvar ~loc value ])
-              ~expr:(evar ~loc pair);
+            successor ~loc index;
+            ufold_expr ~path:child_path fvar shape (evar ~loc value)
+              (evar ~loc acc_name);
+            evar ~loc rest;
           ]
-          (ufold_expr ~path:child_path fvar shape (evar ~loc value)
-             (evar ~loc acc_name))
       in
-      call ~loc
-        (Longident.parse "Stdlib.List.fold_left")
-        [
-          B.pexp_fun ~loc Nolabel None (pvar ~loc acc_name)
-            (B.pexp_fun ~loc Nolabel None (pvar ~loc pair) inner_body);
-          acc_expr;
-          call ~loc
-            (Longident.parse "Stdlib.List.mapi")
-            [
-              B.pexp_fun ~loc Nolabel None (pvar ~loc index)
-                (B.pexp_fun ~loc Nolabel None (pvar ~loc value)
-                   (B.pexp_tuple ~loc [ evar ~loc index; evar ~loc value ]));
-              expr;
-            ];
-        ]
+      let_rec_loop ~loc loop
+        [ index; acc_name; list_name ]
+        (B.pexp_match ~loc (evar ~loc list_name)
+           [
+             B.case ~lhs:(nil_pattern ~loc) ~guard:None
+               ~rhs:(evar ~loc acc_name);
+             B.case ~lhs:(cons_pattern ~loc value rest) ~guard:None ~rhs:step;
+           ])
+        [ B.eint ~loc 0; acc_expr; expr ]
   | UArray shape ->
+      let loop = gen_symbol ~prefix:"ptree_loop" () in
+      let array_name = gen_symbol ~prefix:"ptree_array" () in
+      let length_name = gen_symbol ~prefix:"ptree_length" () in
       let acc_name = gen_symbol ~prefix:"ptree_acc" () in
       let index = gen_symbol ~prefix:"ptree_index" () in
-      let value = gen_symbol ~prefix:"ptree_value" () in
-      let pair = gen_symbol ~prefix:"ptree_pair" () in
       let child_path = uindex_path ~loc path index in
-      let inner_body =
-        B.pexp_let ~loc Nonrecursive
+      let step =
+        call ~loc (Lident loop)
           [
-            B.value_binding ~loc
-              ~pat:(B.ppat_tuple ~loc [ pvar ~loc index; pvar ~loc value ])
-              ~expr:(evar ~loc pair);
+            successor ~loc index;
+            ufold_expr ~path:child_path fvar shape
+              (element_at ~loc array_name index)
+              (evar ~loc acc_name);
           ]
-          (ufold_expr ~path:child_path fvar shape (evar ~loc value)
-             (evar ~loc acc_name))
       in
-      call ~loc
-        (Longident.parse "Stdlib.Array.fold_left")
-        [
-          B.pexp_fun ~loc Nolabel None (pvar ~loc acc_name)
-            (B.pexp_fun ~loc Nolabel None (pvar ~loc pair) inner_body);
-          acc_expr;
-          call ~loc
-            (Longident.parse "Stdlib.Array.mapi")
-            [
-              B.pexp_fun ~loc Nolabel None (pvar ~loc index)
-                (B.pexp_fun ~loc Nolabel None (pvar ~loc value)
-                   (B.pexp_tuple ~loc [ evar ~loc index; evar ~loc value ]));
-              expr;
-            ];
-        ]
+      lets ~loc
+        [ (array_name, expr); (length_name, array_length ~loc array_name) ]
+        (let_rec_loop ~loc loop [ index; acc_name ]
+           (B.pexp_ifthenelse ~loc
+              (call ~loc (stdlib_operator "=")
+                 [ evar ~loc index; evar ~loc length_name ])
+              (evar ~loc acc_name) (Some step))
+           [ B.eint ~loc 0; acc_expr ])
 
 (* fold2 *)
 
@@ -2034,104 +2054,82 @@ let rec ufold2_expr ~function_path ~path fvar shape left right acc_expr =
                ~rhs:(umismatch ~loc ~function_path ~path "option constructor");
            ])
   | UList shape ->
+      let loop = gen_symbol ~prefix:"ptree_loop" () in
       let left_name = gen_symbol ~prefix:"ptree_left" () in
       let right_name = gen_symbol ~prefix:"ptree_right" () in
       let acc_name = gen_symbol ~prefix:"ptree_acc" () in
       let index = gen_symbol ~prefix:"ptree_index" () in
+      let left_rest = gen_symbol ~prefix:"ptree_left_rest" () in
+      let right_rest = gen_symbol ~prefix:"ptree_right_rest" () in
       let left_value = gen_symbol ~prefix:"ptree_left_value" () in
       let right_value = gen_symbol ~prefix:"ptree_right_value" () in
-      let pair = gen_symbol ~prefix:"ptree_pair" () in
       let child_path = uindex_path ~loc path index in
-      let inner_body =
-        B.pexp_let ~loc Nonrecursive
+      let step =
+        call ~loc (Lident loop)
           [
-            B.value_binding ~loc
-              ~pat:(B.ppat_tuple ~loc [ pvar ~loc index; pvar ~loc left_value ])
-              ~expr:(evar ~loc pair);
+            successor ~loc index;
+            ufold2_expr ~function_path ~path:child_path fvar shape
+              (evar ~loc left_value) (evar ~loc right_value)
+              (evar ~loc acc_name);
+            evar ~loc left_rest;
+            evar ~loc right_rest;
           ]
-          (ufold2_expr ~function_path ~path:child_path fvar shape
-             (evar ~loc left_value) (evar ~loc right_value) (evar ~loc acc_name))
       in
-      lets ~loc
-        [ (left_name, left); (right_name, right) ]
-        (B.pexp_ifthenelse ~loc
-           (call ~loc (stdlib_operator "<>")
-              [
-                call ~loc
-                  (Longident.parse "Stdlib.List.length")
-                  [ evar ~loc left_name ];
-                call ~loc
-                  (Longident.parse "Stdlib.List.length")
-                  [ evar ~loc right_name ];
-              ])
-           (umismatch ~loc ~function_path ~path "list length")
-           (Some
-              (call ~loc
-                 (Longident.parse "Stdlib.List.fold_left2")
-                 [
-                   B.pexp_fun ~loc Nolabel None (pvar ~loc acc_name)
-                     (B.pexp_fun ~loc Nolabel None (pvar ~loc pair)
-                        (B.pexp_fun ~loc Nolabel None (pvar ~loc right_value)
-                           inner_body));
-                   acc_expr;
-                   call ~loc
-                     (Longident.parse "Stdlib.List.mapi")
-                     [
-                       B.pexp_fun ~loc Nolabel None (pvar ~loc index)
-                         (B.pexp_fun ~loc Nolabel None (pvar ~loc left_value)
-                            (B.pexp_tuple ~loc
-                               [ evar ~loc index; evar ~loc left_value ]));
-                       evar ~loc left_name;
-                     ];
-                   evar ~loc right_name;
-                 ])))
+      let_rec_loop ~loc loop
+        [ index; acc_name; left_name; right_name ]
+        (B.pexp_match ~loc
+           (B.pexp_tuple ~loc [ evar ~loc left_name; evar ~loc right_name ])
+           [
+             B.case
+               ~lhs:
+                 (B.ppat_tuple ~loc
+                    [
+                      cons_pattern ~loc left_value left_rest;
+                      cons_pattern ~loc right_value right_rest;
+                    ])
+               ~guard:None ~rhs:step;
+             B.case
+               ~lhs:(B.ppat_tuple ~loc [ nil_pattern ~loc; nil_pattern ~loc ])
+               ~guard:None ~rhs:(evar ~loc acc_name);
+             B.case ~lhs:(B.ppat_any ~loc) ~guard:None
+               ~rhs:(umismatch ~loc ~function_path ~path "list length");
+           ])
+        [ B.eint ~loc 0; acc_expr; left; right ]
   | UArray shape ->
+      let loop = gen_symbol ~prefix:"ptree_loop" () in
       let left_name = gen_symbol ~prefix:"ptree_left" () in
       let right_name = gen_symbol ~prefix:"ptree_right" () in
       let length_name = gen_symbol ~prefix:"ptree_length" () in
       let acc_name = gen_symbol ~prefix:"ptree_acc" () in
       let index = gen_symbol ~prefix:"ptree_index" () in
       let child_path = uindex_path ~loc path index in
-      let value_at array =
-        call ~loc
-          (Longident.parse "Stdlib.Array.unsafe_get")
-          [ evar ~loc array; evar ~loc index ]
+      let step =
+        call ~loc (Lident loop)
+          [
+            successor ~loc index;
+            ufold2_expr ~function_path ~path:child_path fvar shape
+              (element_at ~loc left_name index)
+              (element_at ~loc right_name index)
+              (evar ~loc acc_name);
+          ]
       in
       lets ~loc
         [
           (left_name, left);
           (right_name, right);
-          ( length_name,
-            call ~loc
-              (Longident.parse "Stdlib.Array.length")
-              [ evar ~loc left_name ] );
+          (length_name, array_length ~loc left_name);
         ]
         (B.pexp_ifthenelse ~loc
            (call ~loc (stdlib_operator "<>")
-              [
-                evar ~loc length_name;
-                call ~loc
-                  (Longident.parse "Stdlib.Array.length")
-                  [ evar ~loc right_name ];
-              ])
+              [ evar ~loc length_name; array_length ~loc right_name ])
            (umismatch ~loc ~function_path ~path "array length")
            (Some
-              (call ~loc
-                 (Longident.parse "Stdlib.Array.fold_left")
-                 [
-                   B.pexp_fun ~loc Nolabel None (pvar ~loc acc_name)
-                     (B.pexp_fun ~loc Nolabel None (pvar ~loc index)
-                        (ufold2_expr ~function_path ~path:child_path fvar shape
-                           (value_at left_name) (value_at right_name)
-                           (evar ~loc acc_name)));
-                   acc_expr;
-                   call ~loc
-                     (Longident.parse "Stdlib.Array.init")
-                     [
-                       evar ~loc length_name;
-                       ident ~loc (Longident.parse "Stdlib.Fun.id");
-                     ];
-                 ])))
+              (let_rec_loop ~loc loop [ index; acc_name ]
+                 (B.pexp_ifthenelse ~loc
+                    (call ~loc (stdlib_operator "=")
+                       [ evar ~loc index; evar ~loc length_name ])
+                    (evar ~loc acc_name) (Some step))
+                 [ B.eint ~loc 0; acc_expr ])))
 
 (* names: a path-labelled map. Payload positions become their path; static
    positions are copied from the input. *)

--- a/packages/ppx_ptree/ppx_ptree.ml
+++ b/packages/ppx_ptree/ppx_ptree.ml
@@ -1140,6 +1140,789 @@ let generate_operation ~module_path operation components =
         (List.map (make_binding ~module_path operation) component))
     components
 
+(* ——————————————————————————————— *)
+(*  Gtree (uniform homomorphic)   *)
+(* ——————————————————————————————— *)
+
+type unames = {
+  umap : string;
+  umap2 : string;
+  uiter : string;
+  ufold : string;
+  ufold2 : string;
+  unames : string;
+}
+
+type ushape_desc =
+  | UPayload
+  | UStatic
+  | UTuple of ushape list
+  | UOption of ushape
+  | UList of ushape
+  | UArray of ushape
+  | ULocal of string
+  | UUsing of Longident.t
+
+and ushape = { udesc : ushape_desc; uloc : Location.t }
+
+type ubody = UAlias of ushape | URecord of (label_declaration * ushape) list
+
+type udeclaration = {
+  utype_decl : type_declaration;
+  ubody : ubody option;
+  udependencies : String_set.t;
+}
+
+let ushape ~loc desc = { udesc = desc; uloc = loc }
+
+let unames_for_type = function
+  | "t" | "params" ->
+      {
+        umap = "map";
+        umap2 = "map2";
+        uiter = "iter";
+        ufold = "fold";
+        ufold2 = "fold2";
+        unames = "names";
+      }
+  | name ->
+      {
+        umap = "map_" ^ name;
+        umap2 = "map2_" ^ name;
+        uiter = "iter_" ^ name;
+        ufold = "fold_" ^ name;
+        ufold2 = "fold2_" ^ name;
+        unames = "names_" ^ name;
+      }
+
+let uoperation_name operation names =
+  match operation with
+  | `Umap -> names.umap
+  | `Umap2 -> names.umap2
+  | `Uiter -> names.uiter
+  | `Ufold -> names.ufold
+  | `Ufold2 -> names.ufold2
+  | `Unames -> names.unames
+
+(* Occurrence analysis: does the payload parameter occur at this position? *)
+let rec uclassify_inner validation param_name core_type =
+  let loc = core_type.ptyp_loc in
+  match core_type.ptyp_desc with
+  | Ptyp_var name when name = param_name -> ushape ~loc UPayload
+  | Ptyp_var _ -> ushape ~loc UStatic
+  | Ptyp_constr (path, args) when container_kind path.txt <> None ->
+      uclassify_container validation param_name loc path.txt args
+  | Ptyp_constr (path, _)
+    when is_nx_alias path.txt
+         || is_path path.txt [ "Nx"; "t" ]
+         || is_path path.txt [ "Nx_effect"; "t" ] ->
+      ushape ~loc UStatic
+  | Ptyp_constr (path, [ arg ]) when Option.is_some (local_name path.txt) -> (
+      let child = uclassify_inner validation param_name arg in
+      if child.udesc = UStatic then ushape ~loc UStatic
+      else
+        match local_name path.txt with
+        | Some name -> ushape ~loc (ULocal name)
+        | None -> assert false)
+  | Ptyp_constr (path, _) when Option.is_some (external_primary path.txt) ->
+      ushape ~loc (UUsing (Option.get (external_primary path.txt)))
+  | Ptyp_constr (path, _) ->
+      add_error validation ~loc
+        "ppx_ptree: cannot infer a gtree role for [%a]; the type is applied to \
+         a type parameter but is not a known container or tensor. Annotate \
+         with [@gtree.ignore] or use a type that does not mention the payload \
+         parameter"
+        Pprintast.longident path.txt;
+      ushape ~loc UStatic
+  | Ptyp_tuple args ->
+      ushape ~loc
+        (UTuple (List.map (uclassify_inner validation param_name) args))
+  | Ptyp_alias (inner, _) -> uclassify_inner validation param_name inner
+  | Ptyp_any ->
+      add_error validation ~loc
+        "ppx_ptree: wildcard type [_] has no derivable gtree shape";
+      ushape ~loc UStatic
+  | Ptyp_arrow _ ->
+      add_error validation ~loc
+        "ppx_ptree: function types are not gtree shapes; annotate with \
+         [@ptree.ignore] or [@gtree.ignore]";
+      ushape ~loc UStatic
+  | Ptyp_object _ ->
+      add_error validation ~loc "ppx_ptree: object types are not supported";
+      ushape ~loc UStatic
+  | Ptyp_class _ ->
+      add_error validation ~loc "ppx_ptree: class types are not supported";
+      ushape ~loc UStatic
+  | Ptyp_variant _ ->
+      add_error validation ~loc
+        "ppx_ptree: polymorphic variants are not supported in gtree";
+      ushape ~loc UStatic
+  | Ptyp_poly _ ->
+      add_error validation ~loc
+        "ppx_ptree: explicitly polymorphic field types are not supported";
+      ushape ~loc UStatic
+  | Ptyp_package _ ->
+      add_error validation ~loc
+        "ppx_ptree: first-class module types are not supported";
+      ushape ~loc UStatic
+  | Ptyp_extension _ ->
+      add_error validation ~loc "ppx_ptree: extension types are not supported";
+      ushape ~loc UStatic
+  | Ptyp_open _ ->
+      add_error validation ~loc
+        "ppx_ptree: locally opened types are not supported";
+      ushape ~loc UStatic
+
+and uclassify_container validation param_name loc path args =
+  match (container_kind path, args) with
+  | Some `Option, [ arg ] ->
+      ushape ~loc (UOption (uclassify_inner validation param_name arg))
+  | Some `List, [ arg ] ->
+      ushape ~loc (UList (uclassify_inner validation param_name arg))
+  | Some `Array, [ arg ] ->
+      ushape ~loc (UArray (uclassify_inner validation param_name arg))
+  | Some _, _ ->
+      add_error validation ~loc
+        "ppx_ptree: container types must have exactly one argument";
+      ushape ~loc UStatic
+  | None, _ -> assert false
+
+let rec udependencies shape =
+  match shape.udesc with
+  | UPayload | UStatic | UUsing _ -> String_set.empty
+  | ULocal name -> String_set.singleton name
+  | UTuple shapes ->
+      List.fold_left
+        (fun result s -> String_set.union result (udependencies s))
+        String_set.empty shapes
+  | UOption shape | UList shape | UArray shape -> udependencies shape
+
+let uvalidate_declaration ~signature validation type_decl param_name =
+  let body =
+    match (type_decl.ptype_kind, type_decl.ptype_manifest) with
+    | Ptype_record labels, None ->
+        Some
+          (URecord
+             (List.map
+                (fun label ->
+                  (label, uclassify_inner validation param_name label.pld_type))
+                labels))
+    | Ptype_abstract, Some manifest ->
+        Some (UAlias (uclassify_inner validation param_name manifest))
+    | Ptype_abstract, None when signature -> None
+    | Ptype_abstract, None ->
+        add_error validation ~loc:type_decl.ptype_name.loc
+          "ppx_ptree: an abstract implementation has no derivable gtree shape";
+        None
+    | Ptype_record _, Some _ ->
+        add_error validation ~loc:type_decl.ptype_name.loc
+          "ppx_ptree: representation re-exports with records are not supported";
+        None
+    | Ptype_variant _, _ ->
+        add_error validation ~loc:type_decl.ptype_name.loc
+          "ppx_ptree: variant gtree types are not supported in version 1";
+        None
+    | Ptype_open, _ ->
+        add_error validation ~loc:type_decl.ptype_name.loc
+          "ppx_ptree: extensible variants are not supported";
+        None
+  in
+  let dependencies =
+    match body with
+    | None -> String_set.empty
+    | Some (UAlias shape) -> udependencies shape
+    | Some (URecord fields) ->
+        List.fold_left
+          (fun result (_, shape) ->
+            String_set.union result (udependencies shape))
+          String_set.empty fields
+  in
+  { utype_decl = type_decl; ubody = body; udependencies = dependencies }
+
+let ufind_payload_param validation type_decls =
+  match type_decls with
+  | [] -> None
+  | first :: _ -> (
+      let params = first.ptype_params in
+      match params with
+      | [ (param, _) ] -> (
+          match param.ptyp_desc with
+          | Ptyp_var name -> Some name
+          | _ ->
+              add_error validation ~loc:param.ptyp_loc
+                "ppx_ptree: gtree type parameter must be a type variable";
+              None)
+      | [] -> None
+      | _ ->
+          add_error validation ~loc:first.ptype_name.loc
+            "ppx_ptree: gtree types support exactly one type parameter";
+          None)
+
+let uhas_payload shape =
+  let rec loop s =
+    match s.udesc with
+    | UPayload -> true
+    | UStatic -> false
+    | UTuple shapes -> List.exists loop shapes
+    | UOption shape | UList shape | UArray shape -> loop shape
+    | ULocal _ | UUsing _ ->
+        (* A delegation implies the payload is present in sub-module. Treat as
+           payload at this level — the sub-module check is a compile error. *)
+        true
+  in
+  loop shape
+
+let uvalidate ~signature type_declarations =
+  let validation = { errors_rev = [] } in
+  (* Only process if we find a type with a payload param. *)
+  let payload_param = ufind_payload_param validation type_declarations in
+  let declarations =
+    match payload_param with
+    | None -> []
+    | Some param_name ->
+        List.map
+          (fun td ->
+            let decl =
+              uvalidate_declaration ~signature validation td param_name
+            in
+            (* Check that at least one Payload position exists. *)
+            (match decl.ubody with
+            | Some (UAlias s) ->
+                if not (uhas_payload s) then
+                  add_error validation ~loc:td.ptype_name.loc
+                    "ppx_ptree: gtree type parameter [%s] does not occur in a \
+                     payload position; it only appears inside tensor leaf \
+                     types. Use [@@deriving ptree, gtree] for a mirror view \
+                     instead"
+                    param_name
+            | Some (URecord fields) ->
+                if not (List.exists (fun (_, s) -> uhas_payload s) fields) then
+                  add_error validation ~loc:td.ptype_name.loc
+                    "ppx_ptree: gtree type parameter [%s] does not occur in \
+                     any field as a payload; it only appears inside tensor \
+                     leaf types. Use [@@deriving ptree, gtree] for a mirror \
+                     view instead"
+                    param_name
+            | None -> ());
+            decl)
+          type_declarations
+  in
+  let errors = List.rev validation.errors_rev in
+  (declarations, errors)
+
+(* Wrap udeclarations as declarations for the SCC ordering machinery. *)
+let udecl_to_decl udecl =
+  {
+    type_decl = udecl.utype_decl;
+    body = None;
+    dependencies = udecl.udependencies;
+  }
+
+let uordered_components declarations =
+  let wrapped = List.map udecl_to_decl declarations in
+  let components = strongly_connected_components wrapped in
+  let result = ref [] in
+  List.iter
+    (fun comp_names ->
+      let comp_decls =
+        List.map
+          (fun name ->
+            List.find
+              (fun udecl -> udecl.utype_decl.ptype_name.txt = name)
+              declarations)
+          comp_names
+      in
+      result := comp_decls :: !result)
+    components;
+  List.rev !result
+
+let ucomponent_rec_flag component =
+  match component with
+  | [] -> assert false
+  | [ udecl ] ->
+      if String_set.mem udecl.utype_decl.ptype_name.txt udecl.udependencies then
+        Recursive
+      else Nonrecursive
+  | _ -> Recursive
+
+(* ——— Codegen ——— *)
+
+let payload_callback_shape ~loc var_a var_b =
+  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
+  let type_ = B.ptyp_var ~loc var_a in
+  let result = B.ptyp_var ~loc var_b in
+  arrow type_ result
+
+let payload_callback2_shape ~loc var_a var_b var_c =
+  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
+  let type_a = B.ptyp_var ~loc var_a in
+  let type_b = B.ptyp_var ~loc var_b in
+  let type_c = B.ptyp_var ~loc var_c in
+  arrow type_a (arrow type_b type_c)
+
+let callback_with_path_shape ~loc callback_path callback_payload acc_var =
+  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
+  let string_type = B.ptyp_constr ~loc (lident ~loc "string") [] in
+  arrow string_type (arrow callback_payload (arrow acc_var acc_var))
+
+let ufunction_expression ~loc ~callback_type ~input_types body =
+  let callback = constrained_parameter ~loc "f" callback_type in
+  let inputs =
+    List.mapi
+      (fun index type_ ->
+        let name =
+          match index with
+          | 0 -> "x"
+          | 1 -> "y"
+          | 2 -> "z"
+          | _ -> Printf.sprintf "p%d" index
+        in
+        constrained_parameter ~loc name type_)
+      input_types
+  in
+  List.fold_right
+    (fun pattern body -> B.pexp_fun ~loc Nolabel None pattern body)
+    (callback :: inputs) body
+
+let unames_target_type ~loc type_ =
+  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
+  let string_type = B.ptyp_constr ~loc (lident ~loc "string") [] in
+  arrow type_ string_type
+
+(* — map — rank-1, much simpler than ptree map *)
+let rec umap_expr fvar shape expr =
+  let loc = shape.uloc in
+  match shape.udesc with
+  | UPayload -> call ~loc (Lident fvar) [ expr ]
+  | UStatic -> expr
+  | ULocal name ->
+      call ~loc
+        (Longident.Ldot (Lident (names_for_type name).map, fvar))
+        [ evar ~loc fvar; expr ]
+  | UUsing module_path ->
+      call ~loc (append_lid module_path "map") [ evar ~loc fvar; expr ]
+  | UTuple shapes ->
+      let names, pattern, tuple =
+        tuple_bindings ~loc expr (List.length shapes)
+      in
+      let mapped_names =
+        List.map (fun _ -> gen_symbol ~prefix:"ptree_mapped" ()) shapes
+      in
+      let mapped =
+        List.map2
+          (fun shape name -> umap_expr fvar shape (evar ~loc:shape.uloc name))
+          shapes names
+      in
+      B.pexp_let ~loc Nonrecursive
+        [ B.value_binding ~loc ~pat:pattern ~expr:tuple ]
+        (lets ~loc
+           (List.combine mapped_names mapped)
+           (B.pexp_tuple ~loc (List.map (evar ~loc) mapped_names)))
+  | UOption shape ->
+      let value = gen_symbol ~prefix:"ptree_value" () in
+      B.pexp_match ~loc expr
+        [
+          B.case
+            ~lhs:(construct_pattern ~loc "None" None)
+            ~guard:None
+            ~rhs:(construct ~loc "None" None);
+          B.case
+            ~lhs:(construct_pattern ~loc "Some" (Some (pvar ~loc value)))
+            ~guard:None
+            ~rhs:
+              (construct ~loc "Some"
+                 (Some (umap_expr fvar shape (evar ~loc:shape.uloc value))));
+        ]
+  | UList shape ->
+      let value = gen_symbol ~prefix:"ptree_value" () in
+      let mapper =
+        B.pexp_fun ~loc Nolabel None (pvar ~loc value)
+          (umap_expr fvar shape (evar ~loc:shape.uloc value))
+      in
+      call ~loc (Longident.parse "Stdlib.List.map") [ mapper; expr ]
+  | UArray shape ->
+      let value = gen_symbol ~prefix:"ptree_value" () in
+      let mapper =
+        B.pexp_fun ~loc Nolabel None (pvar ~loc value)
+          (umap_expr fvar shape (evar ~loc:shape.uloc value))
+      in
+      call ~loc (Longident.parse "Stdlib.Array.map") [ mapper; expr ]
+
+(* — map2 — *)
+let rec umap2_expr ~function_path fvar shape left right =
+  let loc = shape.uloc in
+  match shape.udesc with
+  | UPayload -> call ~loc (Lident fvar) [ left; right ]
+  | UStatic -> left
+  | ULocal name ->
+      call ~loc
+        (Longident.Ldot (Lident (names_for_type name).map2, fvar))
+        [ evar ~loc fvar; left; right ]
+  | UUsing module_path ->
+      call ~loc (append_lid module_path "map2") [ evar ~loc fvar; left; right ]
+  | UTuple shapes ->
+      let left_names, left_pattern, left_tuple =
+        tuple_bindings ~loc left (List.length shapes)
+      in
+      let right_names, right_pattern, right_tuple =
+        tuple_bindings ~loc right (List.length shapes)
+      in
+      let mapped_names =
+        List.map (fun _ -> gen_symbol ~prefix:"ptree_mapped" ()) shapes
+      in
+      let mapped =
+        List.mapi
+          (fun index shape ->
+            umap2_expr ~function_path fvar shape
+              (evar ~loc:shape.uloc (List.nth left_names index))
+              (evar ~loc:shape.uloc (List.nth right_names index)))
+          shapes
+      in
+      B.pexp_let ~loc Nonrecursive
+        [ B.value_binding ~loc ~pat:left_pattern ~expr:left_tuple ]
+        (B.pexp_let ~loc Nonrecursive
+           [ B.value_binding ~loc ~pat:right_pattern ~expr:right_tuple ]
+           (lets ~loc
+              (List.combine mapped_names mapped)
+              (B.pexp_tuple ~loc (List.map (evar ~loc) mapped_names))))
+  | UOption shape ->
+      let left_value = gen_symbol ~prefix:"ptree_left" () in
+      let right_value = gen_symbol ~prefix:"ptree_right" () in
+      let pair = B.pexp_tuple ~loc [ left; right ] in
+      B.pexp_match ~loc pair
+        [
+          B.case
+            ~lhs:
+              (B.ppat_tuple ~loc
+                 [
+                   construct_pattern ~loc "None" None;
+                   construct_pattern ~loc "None" None;
+                 ])
+            ~guard:None
+            ~rhs:(construct ~loc "None" None);
+          B.case
+            ~lhs:
+              (B.ppat_tuple ~loc
+                 [
+                   construct_pattern ~loc "Some" (Some (pvar ~loc left_value));
+                   construct_pattern ~loc "Some" (Some (pvar ~loc right_value));
+                 ])
+            ~guard:None
+            ~rhs:
+              (construct ~loc "Some"
+                 (Some
+                    (umap2_expr ~function_path fvar shape
+                       (evar ~loc:shape.uloc left_value)
+                       (evar ~loc:shape.uloc right_value))));
+          B.case ~lhs:(B.ppat_any ~loc) ~guard:None
+            ~rhs:
+              (invalid_argument ~loc
+                 (mismatch_message function_path "option constructor" []));
+        ]
+  | UList shape -> umap2_list ~loc ~function_path fvar shape left right
+  | UArray shape -> umap2_array ~loc ~function_path fvar shape left right
+
+and umap2_list ~loc ~function_path fvar shape left right =
+  let left_name = gen_symbol ~prefix:"ptree_left" () in
+  let right_name = gen_symbol ~prefix:"ptree_right" () in
+  let left_length = gen_symbol ~prefix:"ptree_left_length" () in
+  let right_length = gen_symbol ~prefix:"ptree_right_length" () in
+  let left_value = gen_symbol ~prefix:"ptree_left_value" () in
+  let right_value = gen_symbol ~prefix:"ptree_right_value" () in
+  let mapper =
+    B.pexp_fun ~loc Nolabel None (pvar ~loc left_value)
+      (B.pexp_fun ~loc Nolabel None (pvar ~loc right_value)
+         (umap2_expr ~function_path fvar shape
+            (evar ~loc:shape.uloc left_value)
+            (evar ~loc:shape.uloc right_value)))
+  in
+  lets ~loc
+    [
+      (left_name, left);
+      (right_name, right);
+      ( left_length,
+        call ~loc (Longident.parse "Stdlib.List.length") [ evar ~loc left_name ]
+      );
+      ( right_length,
+        call ~loc
+          (Longident.parse "Stdlib.List.length")
+          [ evar ~loc right_name ] );
+    ]
+    (B.pexp_ifthenelse ~loc
+       (call ~loc (Longident.Lident "<>")
+          [ evar ~loc left_length; evar ~loc right_length ])
+       (invalid_argument ~loc (mismatch_message function_path "list length" []))
+       (Some
+          (call ~loc
+             (Longident.parse "Stdlib.List.map2")
+             [ mapper; evar ~loc left_name; evar ~loc right_name ])))
+
+and umap2_array ~loc ~function_path fvar shape left right =
+  let left_name = gen_symbol ~prefix:"ptree_left" () in
+  let right_name = gen_symbol ~prefix:"ptree_right" () in
+  let left_length = gen_symbol ~prefix:"ptree_left_length" () in
+  let right_length = gen_symbol ~prefix:"ptree_right_length" () in
+  let index = gen_symbol ~prefix:"ptree_index" () in
+  let value_at arr =
+    call ~loc
+      (Longident.parse "Stdlib.Array.unsafe_get")
+      [ evar ~loc arr; evar ~loc index ]
+  in
+  let array_initializer =
+    B.pexp_fun ~loc Nolabel None (pvar ~loc index)
+      (umap2_expr ~function_path fvar shape (value_at left_name)
+         (value_at right_name))
+  in
+  lets ~loc
+    [
+      (left_name, left);
+      (right_name, right);
+      ( left_length,
+        call ~loc
+          (Longident.parse "Stdlib.Array.length")
+          [ evar ~loc left_name ] );
+      ( right_length,
+        call ~loc
+          (Longident.parse "Stdlib.Array.length")
+          [ evar ~loc right_name ] );
+    ]
+    (B.pexp_ifthenelse ~loc
+       (call ~loc (Longident.Lident "<>")
+          [ evar ~loc left_length; evar ~loc right_length ])
+       (invalid_argument ~loc
+          (mismatch_message function_path "array length" []))
+       (Some
+          (call ~loc
+             (Longident.parse "Stdlib.Array.init")
+             [ evar ~loc left_length; array_initializer ])))
+
+(* — iter — *)
+let rec uiter_expr fvar shape expr =
+  let loc = shape.uloc in
+  match shape.udesc with
+  | UPayload -> call ~loc (Lident fvar) [ expr ]
+  | UStatic -> B.eunit ~loc
+  | ULocal name ->
+      call ~loc
+        (Longident.Ldot (Lident (names_for_type name).iter, fvar))
+        [ evar ~loc fvar; expr ]
+  | UUsing module_path ->
+      call ~loc (append_lid module_path "iter") [ evar ~loc fvar; expr ]
+  | UTuple shapes ->
+      let names, pattern, tuple =
+        tuple_bindings ~loc expr (List.length shapes)
+      in
+      B.pexp_let ~loc Nonrecursive
+        [ B.value_binding ~loc ~pat:pattern ~expr:tuple ]
+        (B.esequence ~loc
+           (List.map2
+              (fun shape name ->
+                uiter_expr fvar shape (evar ~loc:shape.uloc name))
+              shapes names))
+  | UOption shape ->
+      let value = gen_symbol ~prefix:"ptree_value" () in
+      B.pexp_match ~loc expr
+        [
+          B.case
+            ~lhs:(construct_pattern ~loc "None" None)
+            ~guard:None ~rhs:(B.eunit ~loc);
+          B.case
+            ~lhs:(construct_pattern ~loc "Some" (Some (pvar ~loc value)))
+            ~guard:None
+            ~rhs:(uiter_expr fvar shape (evar ~loc:shape.uloc value));
+        ]
+  | UList shape ->
+      let value = gen_symbol ~prefix:"ptree_value" () in
+      let iterator =
+        B.pexp_fun ~loc Nolabel None (pvar ~loc value)
+          (uiter_expr fvar shape (evar ~loc:shape.uloc value))
+      in
+      call ~loc (Longident.parse "Stdlib.List.iter") [ iterator; expr ]
+  | UArray shape ->
+      let value = gen_symbol ~prefix:"ptree_value" () in
+      let iterator =
+        B.pexp_fun ~loc Nolabel None (pvar ~loc value)
+          (uiter_expr fvar shape (evar ~loc:shape.uloc value))
+      in
+      call ~loc (Longident.parse "Stdlib.Array.iter") [ iterator; expr ]
+
+(* — fold (with paths) —
+
+   ~path: an OCaml expression of type string evaluating to the path segment for
+   this position (e.g. the field name, or "prefix." ^ idx for list items). At
+   the top level this is the empty string literal "". *)
+
+let rec ufold_expr ~path fvar shape expr acc_expr =
+  let loc = shape.uloc in
+  match shape.udesc with
+  | UPayload ->
+      (* f path acc expr *)
+      call ~loc (Lident fvar) [ path; acc_expr; expr ]
+  | UStatic -> acc_expr
+  | ULocal name ->
+      let fold_name = (unames_for_type name).ufold in
+      let sub_path = gen_symbol ~prefix:"u_p" () in
+      let sub_acc = gen_symbol ~prefix:"u_a" () in
+      let sub_x = gen_symbol ~prefix:"u_x" () in
+      (* name.fold (fun p a x -> f (path ^ "." ^ p) a x) acc expr *)
+      let callback =
+        B.pexp_fun ~loc Nolabel None (pvar ~loc sub_path)
+          (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_acc)
+             (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_x)
+                (call ~loc (Lident fvar)
+                   [
+                     call ~loc (Longident.Lident "^")
+                       [
+                         call ~loc (Longident.Lident "^")
+                           [ path; B.estring ~loc "." ];
+                         evar ~loc sub_path;
+                       ];
+                     evar ~loc sub_acc;
+                     evar ~loc sub_x;
+                   ])))
+      in
+      call ~loc
+        (Longident.Ldot (Lident name, fold_name))
+        [ callback; acc_expr; expr ]
+  | UUsing module_path ->
+      let sub_path = gen_symbol ~prefix:"u_p" () in
+      let sub_acc = gen_symbol ~prefix:"u_a" () in
+      let sub_x = gen_symbol ~prefix:"u_x" () in
+      let callback =
+        B.pexp_fun ~loc Nolabel None (pvar ~loc sub_path)
+          (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_acc)
+             (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_x)
+                (call ~loc (Lident fvar)
+                   [
+                     call ~loc (Longident.Lident "^")
+                       [
+                         call ~loc (Longident.Lident "^")
+                           [ path; B.estring ~loc "." ];
+                         evar ~loc sub_path;
+                       ];
+                     evar ~loc sub_acc;
+                     evar ~loc sub_x;
+                   ])))
+      in
+      call ~loc (append_lid module_path "fold") [ callback; acc_expr; expr ]
+  | UTuple shapes ->
+      let names, pattern, tuple =
+        tuple_bindings ~loc expr (List.length shapes)
+      in
+      (* let (x0, x1, ...) = expr in f (path ^ ".0") x0 (f (path ^ ".1") x1 (...
+         acc)) *)
+      let rec thread idx acc shapes names =
+        match (shapes, names) with
+        | [], [] -> acc
+        | shape :: rest_shapes, name :: rest_names ->
+            let child_path =
+              call ~loc (Longident.Lident "^")
+                [
+                  call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ];
+                  B.estring ~loc (string_of_int idx);
+                ]
+            in
+            ufold_expr ~path:child_path fvar shape (evar ~loc name)
+              (thread (idx + 1) acc rest_shapes rest_names)
+        | _ -> assert false
+      in
+      B.pexp_let ~loc Nonrecursive
+        [ B.value_binding ~loc ~pat:pattern ~expr:tuple ]
+        (thread 0 acc_expr shapes names)
+  | UOption shape ->
+      let value = gen_symbol ~prefix:"u_opt" () in
+      B.pexp_match ~loc expr
+        [
+          B.case
+            ~lhs:(construct_pattern ~loc "None" None)
+            ~guard:None ~rhs:acc_expr;
+          B.case
+            ~lhs:(construct_pattern ~loc "Some" (Some (pvar ~loc value)))
+            ~guard:None
+            ~rhs:
+              (ufold_expr ~path fvar shape
+                 (evar ~loc:shape.uloc value)
+                 acc_expr);
+        ]
+  | UList shape ->
+      let acc_p = gen_symbol ~prefix:"u_a" () in
+      let idx_v = gen_symbol ~prefix:"u_i" () in
+      let val_v = gen_symbol ~prefix:"u_v" () in
+      let pair_v = gen_symbol ~prefix:"u_p" () in
+      let child_path =
+        call ~loc (Longident.Lident "^")
+          [
+            call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ];
+            call ~loc
+              (Longident.parse "Stdlib.string_of_int")
+              [ evar ~loc idx_v ];
+          ]
+      in
+      let inner_body =
+        B.pexp_let ~loc Nonrecursive
+          [
+            B.value_binding ~loc
+              ~pat:(B.ppat_tuple ~loc [ pvar ~loc idx_v; pvar ~loc val_v ])
+              ~expr:(evar ~loc pair_v);
+          ]
+          (ufold_expr ~path:child_path fvar shape (evar ~loc val_v)
+             (evar ~loc acc_p))
+      in
+      call ~loc
+        (Longident.parse "Stdlib.List.fold_left")
+        [
+          B.pexp_fun ~loc Nolabel None (pvar ~loc acc_p)
+            (B.pexp_fun ~loc Nolabel None (pvar ~loc pair_v) inner_body);
+          acc_expr;
+          call ~loc
+            (Longident.parse "Stdlib.List.mapi")
+            [
+              B.pexp_fun ~loc Nolabel None (pvar ~loc idx_v)
+                (B.pexp_fun ~loc Nolabel None (pvar ~loc val_v)
+                   (B.pexp_tuple ~loc [ evar ~loc idx_v; evar ~loc val_v ]));
+              expr;
+            ];
+        ]
+  | UArray shape ->
+      let acc_p = gen_symbol ~prefix:"u_a" () in
+      let idx_v = gen_symbol ~prefix:"u_i" () in
+      let val_v = gen_symbol ~prefix:"u_v" () in
+      let pair_v = gen_symbol ~prefix:"u_p" () in
+      let child_path =
+        call ~loc (Longident.Lident "^")
+          [
+            call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ];
+            call ~loc
+              (Longident.parse "Stdlib.string_of_int")
+              [ evar ~loc idx_v ];
+          ]
+      in
+      let inner_body =
+        B.pexp_let ~loc Nonrecursive
+          [
+            B.value_binding ~loc
+              ~pat:(B.ppat_tuple ~loc [ pvar ~loc idx_v; pvar ~loc val_v ])
+              ~expr:(evar ~loc pair_v);
+          ]
+          (ufold_expr ~path:child_path fvar shape (evar ~loc val_v)
+             (evar ~loc acc_p))
+      in
+      call ~loc
+        (Longident.parse "Stdlib.Array.fold_left")
+        [
+          B.pexp_fun ~loc Nolabel None (pvar ~loc acc_p)
+            (B.pexp_fun ~loc Nolabel None (pvar ~loc pair_v) inner_body);
+          acc_expr;
+          call ~loc
+            (Longident.parse "Stdlib.Array.mapi")
+            [
+              B.pexp_fun ~loc Nolabel None (pvar ~loc idx_v)
+                (B.pexp_fun ~loc Nolabel None (pvar ~loc val_v)
+                   (B.pexp_tuple ~loc [ evar ~loc idx_v; evar ~loc val_v ]));
+              expr;
+            ];
+        ]
+
 let structure_generator ~ctxt (_, type_declarations) =
   let declarations, errors = validate ~signature:false type_declarations in
   if errors <> [] then structure_errors errors
@@ -1184,6 +1967,960 @@ let signature_generator ~ctxt (_, type_declarations) =
     Stdlib.ignore ctxt;
     List.concat_map add_values declarations
 
+(* ——————————————————————————————— *)
+(*  Gtree — fold2, names, &        *)
+(*  structure / signature           *)
+(*  generators and deriver          *)
+(* ——————————————————————————————— *)
+
+(* For fold2, the path threading is identical to fold; we just pass two value
+   expressions (left and right) to the callback, include structural equality
+   checks for containers, and skip static fields. *)
+
+let rec ufold2_expr ~path fvar shape left right acc_expr =
+  let loc = shape.uloc in
+  match shape.udesc with
+  | UPayload -> call ~loc (Lident fvar) [ path; acc_expr; left; right ]
+  | UStatic -> acc_expr
+  | ULocal name ->
+      let fold2_name = (unames_for_type name).ufold2 in
+      let sub_p = gen_symbol ~prefix:"u2_p" () in
+      let sub_a = gen_symbol ~prefix:"u2_a" () in
+      let sub_x = gen_symbol ~prefix:"u2_x" () in
+      let sub_y = gen_symbol ~prefix:"u2_y" () in
+      let callback =
+        B.pexp_fun ~loc Nolabel None (pvar ~loc sub_p)
+          (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_a)
+             (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_x)
+                (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_y)
+                   (call ~loc (Lident fvar)
+                      [
+                        call ~loc (Longident.Lident "^")
+                          [
+                            call ~loc (Longident.Lident "^")
+                              [ path; B.estring ~loc "." ];
+                            evar ~loc sub_p;
+                          ];
+                        evar ~loc sub_a;
+                        evar ~loc sub_x;
+                        evar ~loc sub_y;
+                      ]))))
+      in
+      call ~loc
+        (Longident.Ldot (Lident name, fold2_name))
+        [ callback; acc_expr; left; right ]
+  | UUsing module_path ->
+      let sub_p = gen_symbol ~prefix:"u2_p" () in
+      let sub_a = gen_symbol ~prefix:"u2_a" () in
+      let sub_x = gen_symbol ~prefix:"u2_x" () in
+      let sub_y = gen_symbol ~prefix:"u2_y" () in
+      let callback =
+        B.pexp_fun ~loc Nolabel None (pvar ~loc sub_p)
+          (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_a)
+             (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_x)
+                (B.pexp_fun ~loc Nolabel None (pvar ~loc sub_y)
+                   (call ~loc (Lident fvar)
+                      [
+                        call ~loc (Longident.Lident "^")
+                          [
+                            call ~loc (Longident.Lident "^")
+                              [ path; B.estring ~loc "." ];
+                            evar ~loc sub_p;
+                          ];
+                        evar ~loc sub_a;
+                        evar ~loc sub_x;
+                        evar ~loc sub_y;
+                      ]))))
+      in
+      call ~loc
+        (append_lid module_path "fold2")
+        [ callback; acc_expr; left; right ]
+  | UTuple shapes ->
+      let left_names, left_pattern, left_tuple =
+        tuple_bindings ~loc left (List.length shapes)
+      in
+      let right_names, right_pattern, right_tuple =
+        tuple_bindings ~loc right (List.length shapes)
+      in
+      let rec thread idx acc shapes lnames rnames =
+        match (shapes, lnames, rnames) with
+        | [], [], [] -> acc
+        | shape :: rest_shapes, lname :: rest_lnames, rname :: rest_rnames ->
+            let child_path =
+              call ~loc (Longident.Lident "^")
+                [
+                  call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ];
+                  B.estring ~loc (string_of_int idx);
+                ]
+            in
+            ufold2_expr ~path:child_path fvar shape (evar ~loc lname)
+              (evar ~loc rname)
+              (thread (idx + 1) acc rest_shapes rest_lnames rest_rnames)
+        | _ -> assert false
+      in
+      B.pexp_let ~loc Nonrecursive
+        [ B.value_binding ~loc ~pat:left_pattern ~expr:left_tuple ]
+        (B.pexp_let ~loc Nonrecursive
+           [ B.value_binding ~loc ~pat:right_pattern ~expr:right_tuple ]
+           (thread 0 acc_expr shapes left_names right_names))
+  | UOption shape ->
+      let lv = gen_symbol ~prefix:"u2_l" () in
+      let rv = gen_symbol ~prefix:"u2_r" () in
+      B.pexp_match ~loc
+        (B.pexp_tuple ~loc [ left; right ])
+        [
+          B.case
+            ~lhs:
+              (B.ppat_tuple ~loc
+                 [
+                   construct_pattern ~loc "None" None;
+                   construct_pattern ~loc "None" None;
+                 ])
+            ~guard:None ~rhs:acc_expr;
+          B.case
+            ~lhs:
+              (B.ppat_tuple ~loc
+                 [
+                   construct_pattern ~loc "Some" (Some (pvar ~loc lv));
+                   construct_pattern ~loc "Some" (Some (pvar ~loc rv));
+                 ])
+            ~guard:None
+            ~rhs:
+              (ufold2_expr ~path fvar shape (evar ~loc lv) (evar ~loc rv)
+                 acc_expr);
+          B.case ~lhs:(B.ppat_any ~loc) ~guard:None
+            ~rhs:(invalid_argument ~loc "ufold2: option constructor mismatch");
+        ]
+  | UList shape ->
+      let acc_p = gen_symbol ~prefix:"u2_a" () in
+      let idx_v = gen_symbol ~prefix:"u2_i" () in
+      let val_v = gen_symbol ~prefix:"u2_v" () in
+      let val_w = gen_symbol ~prefix:"u2_w" () in
+      let pair_v = gen_symbol ~prefix:"u2_p" () in
+      let child_path =
+        call ~loc (Longident.Lident "^")
+          [
+            call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ];
+            call ~loc
+              (Longident.parse "Stdlib.string_of_int")
+              [ evar ~loc idx_v ];
+          ]
+      in
+      let inner_body =
+        B.pexp_let ~loc Nonrecursive
+          [
+            B.value_binding ~loc
+              ~pat:(B.ppat_tuple ~loc [ pvar ~loc idx_v; pvar ~loc val_v ])
+              ~expr:(evar ~loc pair_v);
+          ]
+          (ufold2_expr ~path:child_path fvar shape (evar ~loc val_v)
+             (evar ~loc val_w) (evar ~loc acc_p))
+      in
+      call ~loc
+        (Longident.parse "Stdlib.List.fold_left2")
+        [
+          B.pexp_fun ~loc Nolabel None (pvar ~loc acc_p)
+            (B.pexp_fun ~loc Nolabel None (pvar ~loc pair_v)
+               (B.pexp_fun ~loc Nolabel None (pvar ~loc val_w) inner_body));
+          acc_expr;
+          call ~loc
+            (Longident.parse "Stdlib.List.mapi")
+            [
+              B.pexp_fun ~loc Nolabel None (pvar ~loc idx_v)
+                (B.pexp_fun ~loc Nolabel None (pvar ~loc val_v)
+                   (B.pexp_tuple ~loc [ evar ~loc idx_v; evar ~loc val_v ]));
+              left;
+            ];
+          right;
+        ]
+  | UArray shape ->
+      let idx_v = gen_symbol ~prefix:"u2_i" () in
+      let val_v = gen_symbol ~prefix:"u2_v" () in
+      let val_w = gen_symbol ~prefix:"u2_w" () in
+      let len = gen_symbol ~prefix:"u2_n" () in
+      let child_path =
+        call ~loc (Longident.Lident "^")
+          [
+            call ~loc (Longident.Lident "^") [ path; B.estring ~loc "." ];
+            call ~loc
+              (Longident.parse "Stdlib.string_of_int")
+              [ evar ~loc idx_v ];
+          ]
+      in
+      (* Ensure equal length, then fold_left over zipped pairs. *)
+      lets ~loc
+        [ (len, call ~loc (Longident.parse "Stdlib.Array.length") [ left ]) ]
+        (B.pexp_ifthenelse ~loc
+           (call ~loc (Longident.Lident "<>")
+              [
+                evar ~loc len;
+                call ~loc (Longident.parse "Stdlib.Array.length") [ right ];
+              ])
+           (invalid_argument ~loc "ufold2: array length mismatch")
+           (Some
+              (call ~loc
+                 (Longident.parse "Stdlib.Array.fold_left")
+                 [
+                   B.pexp_fun ~loc Nolabel None (pvar ~loc idx_v)
+                     (B.pexp_fun ~loc Nolabel None (pvar ~loc val_v)
+                        (B.pexp_fun ~loc Nolabel None (pvar ~loc val_w)
+                           (ufold2_expr ~path:child_path fvar shape
+                              (evar ~loc val_v) (evar ~loc val_w)
+                              (evar ~loc idx_v))));
+                   acc_expr;
+                   call ~loc
+                     (Longident.parse "Stdlib.Array.map2")
+                     [
+                       B.pexp_fun ~loc Nolabel None (pvar ~loc val_v)
+                         (B.pexp_fun ~loc Nolabel None (pvar ~loc val_w)
+                            (evar ~loc val_w));
+                       left;
+                       right;
+                     ];
+                 ])))
+
+(* — names — *)
+
+let module_path_string path =
+  match longident_parts path with
+  | Some parts -> String.concat "." parts
+  | None -> ""
+
+let rec unames_expr shape =
+  let loc = shape.uloc in
+  match shape.udesc with
+  | UPayload ->
+      (* names is a string tree; leaves are the field path. This is wrapped at
+         the record level — individual payload positions are just the empty
+         string placeholder. *)
+      B.estring ~loc ""
+  | UStatic ->
+      (* Static fields are omitted from names (they have no path). *)
+      B.estring ~loc ""
+  | ULocal name ->
+      let local_names = (unames_for_type name).unames in
+      let sub_n = gen_symbol ~prefix:"u_n" () in
+      call ~loc
+        (Longident.Ldot (Lident name, "map"))
+        [
+          B.pexp_fun ~loc Nolabel None (pvar ~loc sub_n)
+            (call ~loc (Longident.Lident "^")
+               [
+                 call ~loc (Longident.Lident "^")
+                   [ B.estring ~loc ""; B.estring ~loc "." ];
+                 evar ~loc sub_n;
+               ]);
+          evar ~loc local_names;
+        ]
+  | UUsing module_path ->
+      let sub_n = gen_symbol ~prefix:"u_n" () in
+      call ~loc
+        (append_lid module_path "map")
+        [
+          B.pexp_fun ~loc Nolabel None (pvar ~loc sub_n)
+            (call ~loc (Longident.Lident "^")
+               [
+                 call ~loc (Longident.Lident "^")
+                   [ B.estring ~loc ""; B.estring ~loc "." ];
+                 evar ~loc sub_n;
+               ]);
+          evar ~loc (module_path_string module_path ^ ".names");
+        ]
+  | UTuple shapes -> B.pexp_tuple ~loc (List.map unames_expr shapes)
+  | UOption _ | UList _ | UArray _ ->
+      (* names for containers is not statically determinable; skip *)
+      B.estring ~loc ""
+
+(* Helper to extract module path as string for names construction *)
+let module_path_string path =
+  match longident_parts path with
+  | Some parts -> String.concat "." parts
+  | None -> ""
+
+(* — Record / alias codegen for each operation — *)
+
+let uoperation_body ~loc operation ubody =
+  let input = evar ~loc "x" in
+  match (operation, ubody) with
+  | `Umap, UAlias shape -> umap_expr "f" shape input
+  | `Umap, URecord fields ->
+      let bindings =
+        List.map
+          (fun (label, shape) ->
+            let name = gen_symbol ~prefix:("u_" ^ label.pld_name.txt) () in
+            ( label.pld_loc,
+              name,
+              umap_expr "f" shape (field ~loc:label.pld_loc input label),
+              label ))
+          fields
+      in
+      lets_located
+        (List.map (fun (loc, n, e, _) -> (loc, n, e)) bindings)
+        (B.pexp_record ~loc
+           (List.map
+              (fun (_, n, _, label) ->
+                (lident ~loc:label.pld_name.loc label.pld_name.txt, evar ~loc n))
+              bindings)
+           None)
+  | `Umap2, UAlias shape ->
+      umap2_expr ~function_path:"" "f" shape input (evar ~loc "y")
+  | `Umap2, URecord fields ->
+      let left = evar ~loc "x" in
+      let right = evar ~loc "y" in
+      let bindings =
+        List.map
+          (fun (label, shape) ->
+            let name = gen_symbol ~prefix:("u2_" ^ label.pld_name.txt) () in
+            ( label.pld_loc,
+              name,
+              umap2_expr ~function_path:"" "f" shape
+                (field ~loc:label.pld_loc left label)
+                (field ~loc:label.pld_loc right label),
+              label ))
+          fields
+      in
+      lets_located
+        (List.map (fun (loc, n, e, _) -> (loc, n, e)) bindings)
+        (B.pexp_record ~loc
+           (List.map
+              (fun (_, n, _, label) ->
+                (lident ~loc:label.pld_name.loc label.pld_name.txt, evar ~loc n))
+              bindings)
+           None)
+  | `Uiter, UAlias shape -> uiter_expr "f" shape input
+  | `Uiter, URecord fields ->
+      B.esequence ~loc
+        (List.map
+           (fun (label, shape) ->
+             uiter_expr "f" shape (field ~loc:label.pld_loc input label))
+           fields)
+  | `Ufold, UAlias shape ->
+      ufold_expr ~path:(B.estring ~loc "") "f" shape (evar ~loc "y")
+        (evar ~loc "x")
+  | `Ufold, URecord fields ->
+      List.fold_left
+        (fun acc_expr (label, shape) ->
+          ufold_expr
+            ~path:(B.estring ~loc label.pld_name.txt)
+            "f" shape
+            (field ~loc:label.pld_loc (evar ~loc "y") label)
+            acc_expr)
+        (evar ~loc "x") fields
+  | `Ufold2, UAlias shape ->
+      ufold2_expr ~path:(B.estring ~loc "") "f" shape (evar ~loc "y")
+        (evar ~loc "z") (evar ~loc "x")
+  | `Ufold2, URecord fields ->
+      let left = evar ~loc "y" in
+      let right = evar ~loc "z" in
+      List.fold_left
+        (fun acc_expr (label, shape) ->
+          ufold2_expr
+            ~path:(B.estring ~loc label.pld_name.txt)
+            "f" shape
+            (field ~loc:label.pld_loc left label)
+            (field ~loc:label.pld_loc right label)
+            acc_expr)
+        (evar ~loc "x") fields
+  | `Unames, UAlias shape -> unames_expr shape
+  | `Unames, URecord fields ->
+      B.pexp_record ~loc
+        (List.map
+           (fun (label, shape) ->
+             ( lident ~loc:label.pld_name.loc label.pld_name.txt,
+               unames_expr shape ))
+           fields)
+        None
+
+(* FIXME: fvar in map2/map2 refers to "f" hardcoded above but in the
+   callback-type builders we need the *actual* parameter. The code above assumes
+   the callback is named "f" which matches ufunction_expression below. *)
+
+let rec ubody_uses_callback = function
+  | UAlias shape -> ushape_has_payload shape
+  | URecord fields -> List.exists (fun (_, s) -> ushape_has_payload s) fields
+
+and ushape_has_payload shape =
+  match shape.udesc with
+  | UPayload -> true
+  | UStatic -> false
+  | UTuple shapes -> List.exists ushape_has_payload shapes
+  | UOption s | UList s | UArray s -> ushape_has_payload s
+  | ULocal _ | UUsing _ -> true
+
+let ucallback_type ~loc operation var_a var_b var_c =
+  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
+  let string_ty = B.ptyp_constr ~loc (lident ~loc "string") [] in
+  let acc_ty = B.ptyp_var ~loc "acc" in
+  let var_ty name = B.ptyp_var ~loc name in
+  match operation with
+  | `Umap -> arrow (var_ty var_a) (var_ty var_b)
+  | `Umap2 -> arrow (var_ty var_a) (arrow (var_ty var_b) (var_ty var_c))
+  | `Uiter -> arrow (var_ty var_a) (B.ptyp_constr ~loc (lident ~loc "unit") [])
+  | `Ufold -> arrow string_ty (arrow acc_ty (arrow (var_ty var_a) acc_ty))
+  | `Ufold2 ->
+      arrow string_ty
+        (arrow acc_ty (arrow (var_ty var_a) (arrow (var_ty var_b) acc_ty)))
+  | `Unames ->
+      (* names : unit -> string t, i.e., a constant *)
+      arrow
+        (B.ptyp_constr ~loc (lident ~loc "unit") [])
+        (B.ptyp_constr ~loc (lident ~loc "string") [])
+
+(** arity of the function value after the callback: map=1, map2=2, iter=1,
+    fold=2 (tree + acc), fold2=3 (tree + tree + acc), names=1 *)
+let uoperation_arity = function
+  | `Umap | `Uiter | `Unames -> 1
+  | `Umap2 -> 2
+  | `Ufold -> 2
+  | `Ufold2 -> 3
+
+let umake_binding ~module_path operation udecl =
+  let type_decl = udecl.utype_decl in
+  let loc = type_decl.ptype_loc in
+  let names = unames_for_type type_decl.ptype_name.txt in
+  let name = uoperation_name operation names in
+  let var_a = "a" in
+  let var_b = "b" in
+  let var_c = "c" in
+  let cb_ty = ucallback_type ~loc operation var_a var_b var_c in
+  let type_ = declared_type type_decl in
+  let body_expr =
+    match udecl.ubody with
+    | Some ubody -> uoperation_body ~loc operation ubody
+    | None -> assert false
+  in
+  let input_types =
+    match operation with
+    | `Unames -> [ type_ ]
+    | `Ufold -> [ B.ptyp_var ~loc "acc"; type_ ]
+    | `Ufold2 -> [ B.ptyp_var ~loc "acc"; type_; type_ ]
+    | _ -> List.init (uoperation_arity operation) (fun _ -> type_)
+  in
+  let fun_expr =
+    ufunction_expression ~loc ~callback_type:cb_ty ~input_types body_expr
+  in
+  let pat =
+    if operation = `Unames then
+      (* names takes no callback argument; it's a constant. *)
+      pvar ~loc name
+    else pvar ~loc name
+  in
+  B.value_binding ~loc ~pat ~expr:fun_expr
+
+let ucomponent_rec_flag component =
+  match component with
+  | [] -> assert false
+  | [ udecl ] ->
+      if String_set.mem udecl.utype_decl.ptype_name.txt udecl.udependencies then
+        Recursive
+      else Nonrecursive
+  | _ -> Recursive
+
+let ugenerate_operation ~module_path operation components =
+  List.map
+    (fun component ->
+      let loc = (List.hd component).utype_decl.ptype_loc in
+      B.pstr_value ~loc
+        (ucomponent_rec_flag component)
+        (List.map (umake_binding ~module_path operation) component))
+    components
+
+let ustructure_has_payload_param type_decls =
+  match type_decls with
+  | decl :: _ -> (
+      match decl.ptype_params with
+      | [ (p, _) ] -> (
+          match p.ptyp_desc with Ptyp_var _ -> true | _ -> false)
+      | _ -> false)
+  | [] -> false
+
+(* ——— Mirror mode ——— *)
+
+(* Translate a static ptree [shape] into a parameterised ushape. Every [Leaf]
+   becomes the payload param ['a]; [Ignored] stays static; [Using M] becomes
+   [UUsing M] (Gtree.t delegation convention). *)
+
+let rec ushape_of_shape shape =
+  let loc = shape.loc in
+  match shape.desc with
+  | Leaf -> ushape ~loc UPayload
+  | Ignored -> ushape ~loc UStatic
+  | Local name -> ushape ~loc (ULocal name)
+  | Using m -> ushape ~loc (UUsing (append_lid m "Gtree"))
+  | Tuple shapes -> ushape ~loc (UTuple (List.map ushape_of_shape shapes))
+  | Option s -> ushape ~loc (UOption (ushape_of_shape s))
+  | List s -> ushape ~loc (UList (ushape_of_shape s))
+  | Array s -> ushape ~loc (UArray (ushape_of_shape s))
+
+(* Build the core_type for a mirror type position. UPayload → 'a, UStatic → unit
+   (placeholder, replaced at record level), ULocal/UUsing → 'a M.t or 'a
+   M.Gtree.t, containers → recurse. *)
+
+let rec build_mirror_type ~loc shape =
+  match shape.udesc with
+  | UPayload -> B.ptyp_var ~loc "m"
+  | UStatic -> B.ptyp_constr ~loc (lident ~loc "unit") []
+  | ULocal name ->
+      B.ptyp_constr ~loc
+        (located_lid ~loc
+           (Longident.Ldot (Longident.Ldot (Lident name, "Gtree"), "t")))
+        [ B.ptyp_var ~loc "m" ]
+  | UUsing path ->
+      B.ptyp_constr ~loc
+        (located_lid ~loc (append_lid path "t"))
+        [ B.ptyp_var ~loc "m" ]
+  | UTuple shapes ->
+      B.ptyp_tuple ~loc (List.map (build_mirror_type ~loc) shapes)
+  | UOption s ->
+      B.ptyp_constr ~loc (lident ~loc "option") [ build_mirror_type ~loc s ]
+  | UList s ->
+      B.ptyp_constr ~loc (lident ~loc "list") [ build_mirror_type ~loc s ]
+  | UArray s ->
+      B.ptyp_constr ~loc (lident ~loc "array") [ build_mirror_type ~loc s ]
+
+(* Build a synthetic ['a t] type declaration. *)
+
+let synth_mirror_type_decl ~loc name fields : type_declaration =
+  {
+    ptype_name = { txt = name; loc };
+    ptype_params = [ (B.ptyp_var ~loc "m", (Covariant, NoInjectivity)) ];
+    ptype_cstrs = [];
+    ptype_kind = Ptype_record fields;
+    ptype_private = Public;
+    ptype_manifest = None;
+    ptype_attributes = [];
+    ptype_loc = loc;
+  }
+
+let synth_mirror_alias_decl ~loc name alias_type : type_declaration =
+  {
+    ptype_name = { txt = name; loc };
+    ptype_params = [ (B.ptyp_var ~loc "m", (Covariant, NoInjectivity)) ];
+    ptype_cstrs = [];
+    ptype_kind = Ptype_abstract;
+    ptype_private = Public;
+    ptype_manifest = Some alias_type;
+    ptype_attributes = [];
+    ptype_loc = loc;
+  }
+
+(* Generate traversal bindings from a synthetic udeclaration. *)
+
+let mirror_traversals ~module_path udecl : structure =
+  let type_decl = udecl.utype_decl in
+  let loc = type_decl.ptype_loc in
+  List.map
+    (fun op ->
+      let vb = umake_binding ~module_path op udecl in
+      B.pstr_value ~loc Nonrecursive [ vb ])
+    [ `Umap; `Umap2; `Uiter; `Ufold; `Ufold2; `Unames ]
+
+(* Generate [module Gtree = struct ... end]. *)
+
+let generate_gtree_module ~module_path static_decls : structure =
+  let type_decl = (List.hd static_decls).type_decl in
+  let loc = type_decl.ptype_loc in
+  let body = (List.hd static_decls).body in
+  let module_items : structure =
+    match body with
+    | Some (Alias s) ->
+        let us = ushape_of_shape s in
+        let alias_ty = build_mirror_type ~loc us in
+        let synth = synth_mirror_alias_decl ~loc "t" alias_ty in
+        let type_item = B.pstr_type ~loc Nonrecursive [ synth ] in
+        let udecl =
+          {
+            utype_decl = synth;
+            ubody = Some (UAlias us);
+            udependencies = String_set.empty;
+          }
+        in
+        type_item :: mirror_traversals ~module_path udecl
+    | Some (Record fields) ->
+        let ufields =
+          List.map (fun (lbl, sh) -> (lbl, ushape_of_shape sh)) fields
+        in
+        let synth_labels =
+          List.map
+            (fun (lbl, us) -> { lbl with pld_type = build_mirror_type ~loc us })
+            ufields
+        in
+        let synth = synth_mirror_type_decl ~loc "t" synth_labels in
+        let type_item = B.pstr_type ~loc Nonrecursive [ synth ] in
+        let udecl =
+          {
+            utype_decl = synth;
+            ubody = Some (URecord ufields);
+            udependencies = String_set.empty;
+          }
+        in
+        type_item :: mirror_traversals ~module_path udecl
+    | None -> []
+  in
+  let mod_name = { txt = Some "Gtree"; loc } in
+  let mod_expr = B.pmod_structure ~loc module_items in
+  let mb = B.module_binding ~loc ~name:mod_name ~expr:mod_expr in
+  [ B.pstr_module ~loc mb ]
+
+(* ——— dtype extraction for mirror-mode of_gtree ——— *)
+
+(* Maps an Nx type alias base name (without _t suffix) or element type name to
+   the corresponding dtype value name in the Nx module. *)
+let dtype_name_of_nx_name = function
+  | "float16" | "float16_elt" -> Some "float16"
+  | "float32" | "float32_elt" -> Some "float32"
+  | "float64" | "float64_elt" -> Some "float64"
+  | "bfloat16" | "bfloat16_elt" -> Some "bfloat16"
+  | "float8_e4m3" | "float8_e4m3_elt" -> Some "float8_e4m3"
+  | "float8_e5m2" | "float8_e5m2_elt" -> Some "float8_e5m2"
+  | "int4" | "int4_elt" -> Some "int4"
+  | "uint4" | "uint4_elt" -> Some "uint4"
+  | "int8" | "int8_elt" -> Some "int8"
+  | "uint8" | "uint8_elt" -> Some "uint8"
+  | "int16" | "int16_elt" -> Some "int16"
+  | "uint16" | "uint16_elt" -> Some "uint16"
+  | "int32" | "int32_elt" -> Some "int32"
+  | "uint32" | "uint32_elt" -> Some "uint32"
+  | "int64" | "int64_elt" -> Some "int64"
+  | "uint64" | "uint64_elt" -> Some "uint64"
+  | "complex64" | "complex32_elt" -> Some "complex64"
+  | "complex128" | "complex64_elt" -> Some "complex128"
+  | "bool" | "bool_elt" -> Some "bool"
+  | _ -> None
+
+let chop_suffix name suffix =
+  let name_len = String.length name in
+  let suffix_len = String.length suffix in
+  if
+    name_len > suffix_len
+    && String.equal (String.sub name (name_len - suffix_len) suffix_len) suffix
+  then Some (String.sub name 0 (name_len - suffix_len))
+  else None
+
+(** [dtype_expr_of_core_type ~loc core_type] returns an expression that
+    evaluates to the {!Nx_core.Dtype.t} for the Nx tensor type represented by
+    [core_type], or [None] if the dtype cannot be determined. *)
+let rec dtype_expr_of_core_type ~loc core_type =
+  match core_type.ptyp_desc with
+  | Ptyp_constr (path, []) -> (
+      match longident_parts path.txt with
+      | Some [ name ] | Some [ "Nx"; name ] -> (
+          match chop_suffix name "_t" with
+          | Some base -> (
+              match dtype_name_of_nx_name base with
+              | Some dname ->
+                  Some (ident ~loc (Longident.Ldot (Lident "Nx", dname)))
+              | None -> None)
+          | None -> None)
+      | _ -> None)
+  | Ptyp_constr (path, [ _scalar; elt_type ])
+    when is_path path.txt [ "Nx"; "t" ] || is_path path.txt [ "Nx_effect"; "t" ]
+    ->
+      dtype_expr_of_elt_type ~loc elt_type
+  | Ptyp_alias (inner, _) -> dtype_expr_of_core_type ~loc inner
+  | _ -> None
+
+(** [dtype_expr_of_elt_type ~loc core_type] extracts a dtype expression from an
+    element type like [float32_elt] or [complex32_elt]. *)
+and dtype_expr_of_elt_type ~loc core_type =
+  match core_type.ptyp_desc with
+  | Ptyp_constr (path, []) -> (
+      match longident_parts path.txt with
+      | Some [ name ] | Some [ "Nx"; name ] -> (
+          match dtype_name_of_nx_name name with
+          | Some dname ->
+              Some (ident ~loc (Longident.Ldot (Lident "Nx", dname)))
+          | None -> None)
+      | _ -> None)
+  | Ptyp_alias (inner, _) -> dtype_expr_of_elt_type ~loc inner
+  | _ -> None
+
+(* Converters — pack/unpack tensor leaves through the existential. *)
+
+let pack_leaf ~loc expr =
+  (* Nx.Ptree.P expr *)
+  B.pexp_construct ~loc
+    (located_lid ~loc
+       (Longident.Ldot (Longident.Ldot (Lident "Nx", "Ptree"), "P")))
+    (Some expr)
+
+let unpack_leaf ~loc ~dtype expr =
+  call ~loc (Longident.parse "Nx.Ptree.unpack") [ dtype; expr ]
+
+(* Recursively convert a static expression through a ptree [shape] into a gtree
+   mirror expression. *)
+let rec to_gtree_shape ~loc shape expr =
+  match shape.desc with
+  | Leaf -> pack_leaf ~loc expr
+  | Ignored -> expr
+  | Using m -> call ~loc (append_lid m "to_gtree") [ expr ]
+  | Local _ -> expr
+  | Tuple shapes ->
+      let count = List.length shapes in
+      let names = List.init count (fun _ -> gen_symbol ~prefix:"ptree_tg" ()) in
+      let pattern = B.ppat_tuple ~loc (List.map (pvar ~loc) names) in
+      let converted =
+        List.map2
+          (fun shape name ->
+            to_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc name))
+          shapes names
+      in
+      B.pexp_let ~loc Nonrecursive
+        [ B.value_binding ~loc ~pat:pattern ~expr ]
+        (B.pexp_tuple ~loc converted)
+  | Option shape ->
+      let v = gen_symbol ~prefix:"ptree_tg" () in
+      B.pexp_match ~loc expr
+        [
+          B.case
+            ~lhs:(construct_pattern ~loc "None" None)
+            ~guard:None
+            ~rhs:(construct ~loc "None" None);
+          B.case
+            ~lhs:(construct_pattern ~loc "Some" (Some (pvar ~loc v)))
+            ~guard:None
+            ~rhs:
+              (construct ~loc "Some"
+                 (Some
+                    (to_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc v))));
+        ]
+  | List shape ->
+      let v = gen_symbol ~prefix:"ptree_tg" () in
+      call ~loc
+        (Longident.parse "Stdlib.List.map")
+        [
+          B.pexp_fun ~loc Nolabel None (pvar ~loc v)
+            (to_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc v));
+          expr;
+        ]
+  | Array shape ->
+      let v = gen_symbol ~prefix:"ptree_tg" () in
+      call ~loc
+        (Longident.parse "Stdlib.Array.map")
+        [
+          B.pexp_fun ~loc Nolabel None (pvar ~loc v)
+            (to_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc v));
+          expr;
+        ]
+
+(* Recursively convert a gtree mirror expression back through a ptree [shape]
+   into a static expression. *)
+let rec of_gtree_shape ~loc shape expr =
+  match shape.desc with
+  | Leaf -> expr
+  | Ignored -> expr
+  | Using m -> call ~loc (append_lid m "of_gtree") [ expr ]
+  | Local _ -> expr
+  | Tuple shapes ->
+      let count = List.length shapes in
+      let names = List.init count (fun _ -> gen_symbol ~prefix:"ptree_og" ()) in
+      let pattern = B.ppat_tuple ~loc (List.map (pvar ~loc) names) in
+      let converted =
+        List.map2
+          (fun shape name ->
+            of_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc name))
+          shapes names
+      in
+      B.pexp_let ~loc Nonrecursive
+        [ B.value_binding ~loc ~pat:pattern ~expr ]
+        (B.pexp_tuple ~loc converted)
+  | Option shape ->
+      let v = gen_symbol ~prefix:"ptree_og" () in
+      B.pexp_match ~loc expr
+        [
+          B.case
+            ~lhs:(construct_pattern ~loc "None" None)
+            ~guard:None
+            ~rhs:(construct ~loc "None" None);
+          B.case
+            ~lhs:(construct_pattern ~loc "Some" (Some (pvar ~loc v)))
+            ~guard:None
+            ~rhs:
+              (construct ~loc "Some"
+                 (Some
+                    (of_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc v))));
+        ]
+  | List shape ->
+      let v = gen_symbol ~prefix:"ptree_og" () in
+      call ~loc
+        (Longident.parse "Stdlib.List.map")
+        [
+          B.pexp_fun ~loc Nolabel None (pvar ~loc v)
+            (of_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc v));
+          expr;
+        ]
+  | Array shape ->
+      let v = gen_symbol ~prefix:"ptree_og" () in
+      call ~loc
+        (Longident.parse "Stdlib.Array.map")
+        [
+          B.pexp_fun ~loc Nolabel None (pvar ~loc v)
+            (of_gtree_shape ~loc:shape.loc shape (evar ~loc:shape.loc v));
+          expr;
+        ]
+
+let generate_to_gtree ~module_path static_decls : structure =
+  let type_decl = (List.hd static_decls).type_decl in
+  let loc = type_decl.ptype_loc in
+  let body = (List.hd static_decls).body in
+  let rhs =
+    match body with
+    | Some (Alias shape) -> to_gtree_shape ~loc shape (evar ~loc "x")
+    | Some (Record fields) ->
+        let field_exprs =
+          List.map
+            (fun (lbl, sh) ->
+              let access = field ~loc:lbl.pld_loc (evar ~loc "x") lbl in
+              let expr =
+                match sh.desc with
+                | Leaf -> pack_leaf ~loc access
+                | Ignored -> access
+                | Using m -> call ~loc (append_lid m "to_gtree") [ access ]
+                | Local _ -> access
+                | Tuple _ | Option _ | List _ | Array _ ->
+                    to_gtree_shape ~loc:sh.loc sh access
+              in
+              ( located_lid ~loc
+                  (Longident.Ldot (Lident "Gtree", lbl.pld_name.txt)),
+                expr ))
+            fields
+        in
+        B.pexp_record ~loc
+          (List.map (fun (lid, e) -> (lid, e)) field_exprs)
+          None
+    | None -> B.eunit ~loc
+  in
+  [
+    B.pstr_value ~loc Nonrecursive
+      [
+        B.value_binding ~loc ~pat:(pvar ~loc "to_gtree")
+          ~expr:(B.pexp_fun ~loc Nolabel None (pvar ~loc "x") rhs);
+      ];
+  ]
+
+let gtree_field_access ~loc expr name =
+  B.pexp_field ~loc expr
+    (located_lid ~loc (Longident.Ldot (Lident "Gtree", name)))
+
+let generate_of_gtree ~module_path static_decls : structure =
+  let type_decl = (List.hd static_decls).type_decl in
+  let loc = type_decl.ptype_loc in
+  let body = (List.hd static_decls).body in
+  let rhs =
+    match body with
+    | Some (Alias s) -> (
+        match s.desc with
+        | Leaf -> (
+            match type_decl.ptype_manifest with
+            | Some manifest -> (
+                match dtype_expr_of_core_type ~loc manifest with
+                | Some dtype -> unpack_leaf ~loc ~dtype (evar ~loc "u")
+                | None -> evar ~loc "u")
+            | None -> evar ~loc "u")
+        | _ -> of_gtree_shape ~loc s (evar ~loc "u"))
+    | Some (Record fields) ->
+        let field_exprs =
+          List.map
+            (fun (lbl, sh) ->
+              let access =
+                gtree_field_access ~loc (evar ~loc "u") lbl.pld_name.txt
+              in
+              let expr =
+                match sh.desc with
+                | Leaf -> (
+                    match dtype_expr_of_core_type ~loc lbl.pld_type with
+                    | Some dtype -> unpack_leaf ~loc ~dtype access
+                    | None -> access)
+                | Ignored -> access
+                | Using m -> call ~loc (append_lid m "of_gtree") [ access ]
+                | Local _ -> access
+                | Tuple _ | Option _ | List _ | Array _ ->
+                    of_gtree_shape ~loc:sh.loc sh access
+              in
+              (lident ~loc:lbl.pld_name.loc lbl.pld_name.txt, expr))
+            fields
+        in
+        B.pexp_record ~loc field_exprs None
+    | None -> evar ~loc "u"
+  in
+  [
+    B.pstr_value ~loc Nonrecursive
+      [
+        B.value_binding ~loc ~pat:(pvar ~loc "of_gtree")
+          ~expr:(B.pexp_fun ~loc Nolabel None (pvar ~loc "u") rhs);
+      ];
+  ]
+
+let generate_gtree_mirror ~ctxt type_declarations : structure =
+  let ptree_decls, errors = validate ~signature:false type_declarations in
+  if errors <> [] then structure_errors errors
+  else if ptree_decls = [] then []
+  else
+    let module_path =
+      Expansion_context.Deriver.code_path ctxt |> Code_path.fully_qualified_path
+    in
+    let mod_part = generate_gtree_module ~module_path ptree_decls in
+    let to_part = generate_to_gtree ~module_path ptree_decls in
+    let of_part = generate_of_gtree ~module_path ptree_decls in
+    mod_part @ to_part @ of_part
+
+let gtree_structure_generator ~ctxt (_, type_declarations) =
+  let declarations, errors = uvalidate ~signature:false type_declarations in
+  if errors <> [] then structure_errors errors
+  else if declarations = [] then
+    (* Mirror mode *)
+    generate_gtree_mirror ~ctxt type_declarations
+  else
+    let module_path =
+      Expansion_context.Deriver.code_path ctxt |> Code_path.fully_qualified_path
+    in
+    let components = uordered_components declarations in
+    List.concat_map
+      (fun operation -> ugenerate_operation ~module_path operation components)
+      [ `Umap; `Umap2; `Uiter; `Ufold; `Ufold2; `Unames ]
+
+let usignature_type operation type_decl =
+  let loc = type_decl.ptype_loc in
+  let var_a = "a" in
+  let var_b = "b" in
+  let var_c = "c" in
+  let cb_ty = ucallback_type ~loc operation var_a var_b var_c in
+  let type_ = declared_type type_decl in
+  let arrow left right = B.ptyp_arrow ~loc Nolabel left right in
+  let acc_ty = B.ptyp_var ~loc "acc" in
+  match operation with
+  | `Umap -> arrow cb_ty (arrow type_ (B.ptyp_var ~loc "b"))
+  | `Umap2 -> arrow cb_ty (arrow type_ (arrow type_ (B.ptyp_var ~loc "c")))
+  | `Uiter ->
+      arrow cb_ty (arrow type_ (B.ptyp_constr ~loc (lident ~loc "unit") []))
+  | `Ufold -> arrow cb_ty (arrow acc_ty (arrow type_ acc_ty))
+  | `Ufold2 -> arrow cb_ty (arrow acc_ty (arrow type_ (arrow type_ acc_ty)))
+  | `Unames ->
+      arrow
+        (B.ptyp_constr ~loc (lident ~loc "unit") [])
+        (B.ptyp_constr ~loc (lident ~loc "string") [])
+
+let gtree_signature_generator ~ctxt (_, type_declarations) =
+  let declarations, errors = uvalidate ~signature:true type_declarations in
+  if errors <> [] then signature_errors errors
+  else if declarations = [] then []
+  else
+    let add_values udecl =
+      let type_decl = udecl.utype_decl in
+      let names = unames_for_type type_decl.ptype_name.txt in
+      List.map
+        (fun operation ->
+          let name = uoperation_name operation names in
+          let loc = type_decl.ptype_name.loc in
+          B.psig_value ~loc
+            (B.value_description ~loc ~name:{ txt = name; loc }
+               ~type_:(usignature_type operation type_decl)
+               ~prim:[]))
+        [ `Umap; `Umap2; `Uiter; `Ufold; `Ufold2; `Unames ]
+    in
+    Stdlib.ignore ctxt;
+    List.concat_map add_values declarations
+
 let () =
   Deriving.add "ptree"
     ~str_type_decl:
@@ -1192,4 +2929,14 @@ let () =
     ~sig_type_decl:
       (Deriving.Generator.V2.make_noarg ~unused_code_warnings:true
          signature_generator)
+  |> Deriving.ignore
+
+let () =
+  Deriving.add "gtree"
+    ~str_type_decl:
+      (Deriving.Generator.V2.make_noarg ~unused_code_warnings:true
+         gtree_structure_generator)
+    ~sig_type_decl:
+      (Deriving.Generator.V2.make_noarg ~unused_code_warnings:true
+         gtree_signature_generator)
   |> Deriving.ignore

--- a/packages/ppx_ptree/ppx_ptree.mli
+++ b/packages/ppx_ptree/ppx_ptree.mli
@@ -3,4 +3,4 @@
   SPDX-License-Identifier: ISC
   ---------------------------------------------------------------------------*)
 
-(** Deriver registration for [@@deriving ptree]. *)
+(** Deriver registration for [@@deriving ptree] and [@@deriving gtree]. *)

--- a/packages/ppx_ptree/ppx_ptree.mli
+++ b/packages/ppx_ptree/ppx_ptree.mli
@@ -3,4 +3,4 @@
   SPDX-License-Identifier: ISC
   ---------------------------------------------------------------------------*)
 
-(** Deriver registration for [@@deriving ptree] and [@@deriving gtree]. *)
+(** Deriver registration for [@@deriving ptree]. *)

--- a/packages/ppx_ptree/test/cases/mirror_local.ml
+++ b/packages/ppx_ptree/test/cases/mirror_local.ml
@@ -1,0 +1,1 @@
+type t = { next : t option; w : Nx.float32_t } [@@deriving ptree ~mirror]

--- a/packages/ppx_ptree/test/cases/mirror_multi.ml
+++ b/packages/ppx_ptree/test/cases/mirror_multi.ml
@@ -1,0 +1,2 @@
+type sub = { sw : Nx.float32_t }
+and t = { nested : sub; w : Nx.float32_t } [@@deriving ptree ~mirror]

--- a/packages/ppx_ptree/test/cases/mirror_no_leaf.ml
+++ b/packages/ppx_ptree/test/cases/mirror_no_leaf.ml
@@ -1,0 +1,1 @@
+type t = { name : string [@ptree.ignore] } [@@deriving ptree ~mirror]

--- a/packages/ppx_ptree/test/cases/type_variable.ml
+++ b/packages/ppx_ptree/test/cases/type_variable.ml
@@ -1,1 +1,1 @@
-type 'a t = { value : 'a } [@@deriving ptree]
+type ('a, 'b) t = { value : 'a } [@@deriving ptree]

--- a/packages/ppx_ptree/test/cases/uniform_attribute_payload.ml
+++ b/packages/ppx_ptree/test/cases/uniform_attribute_payload.ml
@@ -1,0 +1,1 @@
+type 'a t = { w : 'a; lr : 'a; [@ptree.ignore] scale : 'a } [@@deriving ptree]

--- a/packages/ppx_ptree/test/cases/uniform_bad_delegate_apply.ml
+++ b/packages/ppx_ptree/test/cases/uniform_bad_delegate_apply.ml
@@ -1,0 +1,2 @@
+type 'a sub = { x : 'a }
+and 'a t = { v : 'a option sub; w : 'a } [@@deriving ptree]

--- a/packages/ppx_ptree/test/cases/uniform_mirror_on_uniform.ml
+++ b/packages/ppx_ptree/test/cases/uniform_mirror_on_uniform.ml
@@ -1,0 +1,1 @@
+type 'a t = { w : 'a } [@@deriving ptree ~mirror]

--- a/packages/ppx_ptree/test/cases/uniform_static_helper.ml
+++ b/packages/ppx_ptree/test/cases/uniform_static_helper.ml
@@ -1,0 +1,2 @@
+type 'a t = { w : 'a; meta : 'a meta }
+and 'a meta = { name : string } [@@deriving ptree]

--- a/packages/ppx_ptree/test/compiler_cases/uniform_missing_delegate.expected
+++ b/packages/ppx_ptree/test/compiler_cases/uniform_missing_delegate.expected
@@ -1,0 +1,4 @@
+File "compiler_cases/uniform_missing_delegate.ml", line 5, characters 20-32:
+5 | type 'a t = { sub : 'a Missing.t } [@@deriving ptree]
+                        ^^^^^^^^^^^^
+Error: Unbound value Missing.map

--- a/packages/ppx_ptree/test/compiler_cases/uniform_missing_delegate.ml
+++ b/packages/ppx_ptree/test/compiler_cases/uniform_missing_delegate.ml
@@ -1,0 +1,5 @@
+module Missing = struct
+  type 'a t = { x : 'a }
+end
+
+type 'a t = { sub : 'a Missing.t } [@@deriving ptree]

--- a/packages/ppx_ptree/test/diagnostics.t
+++ b/packages/ppx_ptree/test/diagnostics.t
@@ -110,3 +110,21 @@ Expansion exposes only functions, with one primary name and suffixed helpers.
   let map2
   let iter_helper
   let iter
+
+Uniform (payload-generic) declarations reject rank-2 vocabulary and
+payload-free parameters; mirror mode validates its shape.
+
+  $ ./pp.exe -impl cases/uniform_attribute_payload.ml 2>&1 | grep 'ppx_ptree:'
+        "ppx_ptree: ptree attributes do not apply to payload positions of uniform (parameterised) types; the payload parameter determines the traversal"]
+  $ ./pp.exe -impl cases/uniform_static_helper.ml 2>&1 | grep 'ppx_ptree:'
+        "ppx_ptree: the type parameter ['a] of [meta] never occurs in a payload position"]
+  $ ./pp.exe -impl cases/uniform_mirror_on_uniform.ml 2>&1 | grep 'ppx_ptree:'
+        "ppx_ptree: [~mirror] applies to concrete types; uniform (parameterised) types are their own mirror"]
+  $ ./pp.exe -impl cases/uniform_bad_delegate_apply.ml 2>&1 | grep 'ppx_ptree:'
+        "ppx_ptree: cannot derive a uniform traversal through [sub]; the payload parameter may appear directly, under tuples, [option], [list], [array], or as [M.t] applied to the parameter alone"]
+  $ ./pp.exe -impl cases/mirror_local.ml 2>&1 | grep 'ppx_ptree:'
+        "ppx_ptree: mirror mode does not support locally declared or recursive types; move the sub-structure to its own module deriving [ptree ~mirror]"]
+  $ ./pp.exe -impl cases/mirror_multi.ml 2>&1 | grep 'ppx_ptree:'
+        "ppx_ptree: mirror mode supports a single type declaration"]
+  $ ./pp.exe -impl cases/mirror_no_leaf.ml 2>&1 | grep 'ppx_ptree:'
+        "ppx_ptree: mirror mode requires at least one tensor leaf"]

--- a/packages/ppx_ptree/test/dune
+++ b/packages/ppx_ptree/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_ptree test_signature test_integration)
+ (names test_ptree test_signature test_integration test_uniform)
  (package ppx_ptree)
  (flags
   (:standard -warn-error +a))
@@ -44,7 +44,8 @@
   compiler_leaf.actual
   compiler_missing_delegate.actual
   compiler_illtyped_delegate.actual
-  compiler_ppx_metadata.actual)
+  compiler_ppx_metadata.actual
+  compiler_uniform_missing_delegate.actual)
  (deps
   (:pp pp.exe))
  (action
@@ -121,6 +122,24 @@
       %{dep:compiler_cases/ppx_metadata.ml}
       -o
       ppx_metadata.cmo)))
+   (with-stderr-to
+    compiler_uniform_missing_delegate.actual
+    (with-accepted-exit-codes
+     2
+     (run
+      %{ocamlc}
+      -color
+      never
+      -w
+      +a
+      -warn-error
+      +a
+      -c
+      -ppx
+      "./%{pp} --as-ppx"
+      %{dep:compiler_cases/uniform_missing_delegate.ml}
+      -o
+      uniform_missing_delegate.cmo)))
    (diff compiler_cases/leaf_misuse.expected compiler_leaf.actual)
    (diff
     compiler_cases/missing_delegate.expected
@@ -128,14 +147,19 @@
    (diff
     compiler_cases/illtyped_delegate.expected
     compiler_illtyped_delegate.actual)
-   (diff compiler_cases/ppx_metadata.expected compiler_ppx_metadata.actual))))
+   (diff compiler_cases/ppx_metadata.expected compiler_ppx_metadata.actual)
+   (diff
+    compiler_cases/uniform_missing_delegate.expected
+    compiler_uniform_missing_delegate.actual))))
 
 (rule
  (alias runtest)
  (targets
   expansion_simple.actual
   expansion_generic.actual
-  expansion_recursive.actual)
+  expansion_recursive.actual
+  expansion_uniform.actual
+  expansion_mirror.actual)
  (deps
   (:pp pp.exe))
  (action
@@ -149,6 +173,14 @@
    (with-stdout-to
     expansion_recursive.actual
     (run ./%{pp} -impl %{dep:expansion_cases/recursive.ml}))
+   (with-stdout-to
+    expansion_uniform.actual
+    (run ./%{pp} -impl %{dep:expansion_cases/uniform.ml}))
+   (with-stdout-to
+    expansion_mirror.actual
+    (run ./%{pp} -impl %{dep:expansion_cases/mirror.ml}))
    (diff expansion_cases/simple.expected expansion_simple.actual)
    (diff expansion_cases/generic.expected expansion_generic.actual)
-   (diff expansion_cases/recursive.expected expansion_recursive.actual))))
+   (diff expansion_cases/recursive.expected expansion_recursive.actual)
+   (diff expansion_cases/uniform.expected expansion_uniform.actual)
+   (diff expansion_cases/mirror.expected expansion_mirror.actual))))

--- a/packages/ppx_ptree/test/dune
+++ b/packages/ppx_ptree/test/dune
@@ -3,7 +3,7 @@
  (package ppx_ptree)
  (flags
   (:standard -warn-error +a))
- (modules test_ptree test_signature test_integration)
+ (modules test_ptree test_signature test_integration test_uniform)
  (libraries nx nx.effect rune vega kaun windtrap)
  (preprocess
   (pps ppx_ptree)))

--- a/packages/ppx_ptree/test/expansion_cases/mirror.expected
+++ b/packages/ppx_ptree/test/expansion_cases/mirror.expected
@@ -141,55 +141,51 @@ include
           ()
         let _ = iter
         let fold (f : string -> 'acc -> 'a -> 'acc) (acc : 'acc) (x : 'a t) =
-          Stdlib.List.fold_left
-            (fun ptree_acc__041_ ptree_pair__044_ ->
-               let (ptree_index__042_, ptree_value__043_) = ptree_pair__044_ in
-               f
-                 (Stdlib.(^) "layers."
-                    (Stdlib.string_of_int ptree_index__042_)) ptree_acc__041_
-                 ptree_value__043_)
+          let rec ptree_loop__041_ ptree_index__043_ ptree_acc__042_
+            ptree_list__044_ =
+            match ptree_list__044_ with
+            | [] -> ptree_acc__042_
+            | ptree_value__045_::ptree_rest__046_ ->
+                ptree_loop__041_ (Stdlib.(+) ptree_index__043_ 1)
+                  (f
+                     (Stdlib.(^) "layers."
+                        (Stdlib.string_of_int ptree_index__043_))
+                     ptree_acc__042_ ptree_value__045_) ptree_rest__046_ in
+          ptree_loop__041_ 0
             (let ptree_acc__039_ = f "w" acc x.w in
              match x.b with
              | None -> ptree_acc__039_
              | Some ptree_value__040_ ->
-                 f "b" ptree_acc__039_ ptree_value__040_)
-            (Stdlib.List.mapi
-               (fun ptree_index__042_ ptree_value__043_ ->
-                  (ptree_index__042_, ptree_value__043_)) x.layers)
+                 f "b" ptree_acc__039_ ptree_value__040_) x.layers
         let _ = fold
         let fold2 (f : string -> 'acc -> 'a -> 'b -> 'acc) (acc : 'acc)
           (x : 'a t) (y : 'b t) =
-          let ptree_left__048_ = x.layers in
-          let ptree_right__049_ = y.layers in
-          if
-            Stdlib.(<>) (Stdlib.List.length ptree_left__048_)
-              (Stdlib.List.length ptree_right__049_)
-          then
-            Stdlib.invalid_arg
-              "Mirror.Uniform.fold2: list length mismatch at layers"
-          else
-            Stdlib.List.fold_left2
-              (fun ptree_acc__050_ ptree_pair__054_ ptree_right_value__053_
-                 ->
-                 let (ptree_index__051_, ptree_left_value__052_) =
-                   ptree_pair__054_ in
-                 f
-                   (Stdlib.(^) "layers."
-                      (Stdlib.string_of_int ptree_index__051_))
-                   ptree_acc__050_ ptree_left_value__052_
-                   ptree_right_value__053_)
-              (let ptree_acc__045_ = f "w" acc x.w y.w in
-               match ((x.b), (y.b)) with
-               | (None, None) -> ptree_acc__045_
-               | (Some ptree_left__046_, Some ptree_right__047_) ->
-                   f "b" ptree_acc__045_ ptree_left__046_ ptree_right__047_
-               | _ ->
-                   Stdlib.invalid_arg
-                     "Mirror.Uniform.fold2: option constructor mismatch at b")
-              (Stdlib.List.mapi
-                 (fun ptree_index__051_ ptree_left_value__052_ ->
-                    (ptree_index__051_, ptree_left_value__052_))
-                 ptree_left__048_) ptree_right__049_
+          let rec ptree_loop__050_ ptree_index__054_ ptree_acc__053_
+            ptree_left__051_ ptree_right__052_ =
+            match (ptree_left__051_, ptree_right__052_) with
+            | (ptree_left_value__057_::ptree_left_rest__055_,
+               ptree_right_value__058_::ptree_right_rest__056_) ->
+                ptree_loop__050_ (Stdlib.(+) ptree_index__054_ 1)
+                  (f
+                     (Stdlib.(^) "layers."
+                        (Stdlib.string_of_int ptree_index__054_))
+                     ptree_acc__053_ ptree_left_value__057_
+                     ptree_right_value__058_) ptree_left_rest__055_
+                  ptree_right_rest__056_
+            | ([], []) -> ptree_acc__053_
+            | _ ->
+                Stdlib.invalid_arg
+                  "Mirror.Uniform.fold2: list length mismatch at layers" in
+          ptree_loop__050_ 0
+            (let ptree_acc__047_ = f "w" acc x.w y.w in
+             match ((x.b), (y.b)) with
+             | (None, None) -> ptree_acc__047_
+             | (Some ptree_left__048_, Some ptree_right__049_) ->
+                 f "b" ptree_acc__047_ ptree_left__048_ ptree_right__049_
+             | _ ->
+                 Stdlib.invalid_arg
+                   "Mirror.Uniform.fold2: option constructor mismatch at b")
+            x.layers y.layers
         let _ = fold2
         let names (x : 'a t) =
           ({
@@ -197,9 +193,9 @@ include
              b = (match x.b with | None -> None | Some _ -> Some "b");
              layers =
                (Stdlib.List.mapi
-                  (fun ptree_index__056_ _ ->
+                  (fun ptree_index__060_ _ ->
                      Stdlib.(^) "layers."
-                       (Stdlib.string_of_int ptree_index__056_)) x.layers);
+                       (Stdlib.string_of_int ptree_index__060_)) x.layers);
              dim = (x.dim)
            } : string t)
         let _ = names
@@ -210,10 +206,10 @@ include
          Uniform.b =
            (match x.b with
             | None -> None
-            | Some ptree_value__061_ -> Some (Nx.Ptree.P ptree_value__061_));
+            | Some ptree_value__065_ -> Some (Nx.Ptree.P ptree_value__065_));
          Uniform.layers =
            (Stdlib.List.map
-              (fun ptree_value__062_ -> Nx.Ptree.P ptree_value__062_)
+              (fun ptree_value__066_ -> Nx.Ptree.P ptree_value__066_)
               x.layers);
          Uniform.dim = (x.dim)
        } : Nx.Ptree.tensor Uniform.t)
@@ -224,15 +220,15 @@ include
          b =
            (match u.Uniform.b with
             | None -> None
-            | Some ptree_value__058_ ->
-                Some (Nx.Ptree.unpack ~at:"b" Nx.float32 ptree_value__058_));
+            | Some ptree_value__062_ ->
+                Some (Nx.Ptree.unpack ~at:"b" Nx.float32 ptree_value__062_));
          layers =
            (Stdlib.List.mapi
-              (fun ptree_index__059_ ptree_value__060_ ->
+              (fun ptree_index__063_ ptree_value__064_ ->
                  Nx.Ptree.unpack
                    ~at:(Stdlib.(^) "layers."
-                          (Stdlib.string_of_int ptree_index__059_))
-                   Nx.float32 ptree_value__060_) u.Uniform.layers);
+                          (Stdlib.string_of_int ptree_index__063_))
+                   Nx.float32 ptree_value__064_) u.Uniform.layers);
          dim = (u.Uniform.dim)
        } : t)
     let _ = of_uniform

--- a/packages/ppx_ptree/test/expansion_cases/mirror.expected
+++ b/packages/ppx_ptree/test/expansion_cases/mirror.expected
@@ -1,0 +1,132 @@
+type t = {
+  w: Nx.float32_t ;
+  b: Nx.float32_t option ;
+  dim: int [@ptree.ignore ]}[@@deriving ptree ~mirror]
+include struct let _ = fun (_ : t) -> () end[@@ocaml.doc "@inline"][@@merlin.hide
+                                                                    ]
+include
+  struct
+    [@@@ocaml.warning "-60"]
+    let map
+      (f :
+        'ptree_a 'ptree_b .
+          ('ptree_a, 'ptree_b) Nx.t -> ('ptree_a, 'ptree_b) Nx.t)
+      (x : t) =
+      let ptree_w__001_ = f x.w in
+      let ptree_b__002_ =
+        match x.b with
+        | None -> None
+        | Some ptree_value__003_ -> Some (f ptree_value__003_) in
+      let ptree_dim__004_ = x.dim in
+      { w = ptree_w__001_; b = ptree_b__002_; dim = ptree_dim__004_ }
+    let _ = map
+    let map2
+      (f :
+        'ptree_a 'ptree_b .
+          ('ptree_a, 'ptree_b) Nx.t ->
+            ('ptree_a, 'ptree_b) Nx.t -> ('ptree_a, 'ptree_b) Nx.t)
+      (x : t) (y : t) =
+      let ptree_w__005_ = f x.w y.w in
+      let ptree_b__006_ =
+        match ((x.b), (y.b)) with
+        | (None, None) -> None
+        | (Some ptree_left__007_, Some ptree_right__008_) ->
+            Some (f ptree_left__007_ ptree_right__008_)
+        | _ ->
+            Stdlib.invalid_arg
+              "Mirror.map2: option constructor mismatch at b" in
+      let ptree_dim__009_ = x.dim in
+      { w = ptree_w__005_; b = ptree_b__006_; dim = ptree_dim__009_ }
+    let _ = map2
+    let iter (f : 'ptree_a 'ptree_b . ('ptree_a, 'ptree_b) Nx.t -> unit)
+      (x : t) =
+      f x.w;
+      (match x.b with
+       | None -> ()
+       | Some ptree_value__010_ -> f ptree_value__010_);
+      ()
+    let _ = iter
+    module Uniform =
+      struct
+        type nonrec 'm t = {
+          w: 'm ;
+          b: 'm option ;
+          dim: int }
+        let map (f : 'a -> 'b) (x : 'a t) =
+          (let ptree_w__011_ = f x.w in
+           let ptree_b__013_ =
+             match x.b with
+             | None -> None
+             | Some ptree_value__012_ -> Some (f ptree_value__012_) in
+           let ptree_dim__014_ = x.dim in
+           { w = ptree_w__011_; b = ptree_b__013_; dim = ptree_dim__014_ } : 
+          'b t)
+        let _ = map
+        let map2 (f : 'a -> 'b -> 'c) (x : 'a t) (y : 'b t) =
+          (let ptree_w__015_ = f x.w y.w in
+           let ptree_b__018_ =
+             match ((x.b), (y.b)) with
+             | (None, None) -> None
+             | (Some ptree_left__016_, Some ptree_right__017_) ->
+                 Some (f ptree_left__016_ ptree_right__017_)
+             | _ ->
+                 Stdlib.invalid_arg
+                   "Mirror.Uniform.map2: option constructor mismatch" in
+           let ptree_dim__019_ = x.dim in
+           { w = ptree_w__015_; b = ptree_b__018_; dim = ptree_dim__019_ } : 
+          'c t)
+        let _ = map2
+        let iter (f : 'a -> unit) (x : 'a t) =
+          f x.w;
+          (match x.b with
+           | None -> ()
+           | Some ptree_value__020_ -> f ptree_value__020_);
+          ()
+        let _ = iter
+        let fold (f : string -> 'acc -> 'a -> 'acc) (acc : 'acc) (x : 'a t) =
+          let ptree_acc__021_ = f "w" acc x.w in
+          match x.b with
+          | None -> ptree_acc__021_
+          | Some ptree_value__022_ -> f "b" ptree_acc__021_ ptree_value__022_
+        let _ = fold
+        let fold2 (f : string -> 'acc -> 'a -> 'b -> 'acc) (acc : 'acc)
+          (x : 'a t) (y : 'b t) =
+          let ptree_acc__023_ = f "w" acc x.w y.w in
+          match ((x.b), (y.b)) with
+          | (None, None) -> ptree_acc__023_
+          | (Some ptree_left__024_, Some ptree_right__025_) ->
+              f "b" ptree_acc__023_ ptree_left__024_ ptree_right__025_
+          | _ ->
+              Stdlib.invalid_arg
+                "Mirror.Uniform.fold2: option constructor mismatch"
+        let _ = fold2
+        let names (x : 'a t) =
+          ({
+             w = "w";
+             b = (match x.b with | None -> None | Some _ -> Some "b");
+             dim = (x.dim)
+           } : string t)
+        let _ = names
+      end
+    let to_uniform (x : t) =
+      ({
+         Uniform.w = (Nx.Ptree.P (x.w));
+         Uniform.b =
+           (match x.b with
+            | None -> None
+            | Some ptree_value__028_ -> Some (Nx.Ptree.P ptree_value__028_));
+         Uniform.dim = (x.dim)
+       } : Nx.Ptree.tensor Uniform.t)
+    let _ = to_uniform
+    let of_uniform (u : Nx.Ptree.tensor Uniform.t) =
+      ({
+         w = (Nx.Ptree.unpack ~at:"w" Nx.float32 u.Uniform.w);
+         b =
+           (match u.Uniform.b with
+            | None -> None
+            | Some ptree_value__027_ ->
+                Some (Nx.Ptree.unpack ~at:"b" Nx.float32 ptree_value__027_));
+         dim = (u.Uniform.dim)
+       } : t)
+    let _ = of_uniform
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/packages/ppx_ptree/test/expansion_cases/mirror.expected
+++ b/packages/ppx_ptree/test/expansion_cases/mirror.expected
@@ -1,6 +1,8 @@
-type t = {
+type t =
+  {
   w: Nx.float32_t ;
   b: Nx.float32_t option ;
+  layers: Nx.float32_t list ;
   dim: int [@ptree.ignore ]}[@@deriving ptree ~mirror]
 include struct let _ = fun (_ : t) -> () end[@@ocaml.doc "@inline"][@@merlin.hide
                                                                     ]
@@ -17,8 +19,16 @@ include
         match x.b with
         | None -> None
         | Some ptree_value__003_ -> Some (f ptree_value__003_) in
-      let ptree_dim__004_ = x.dim in
-      { w = ptree_w__001_; b = ptree_b__002_; dim = ptree_dim__004_ }
+      let ptree_layers__004_ =
+        Stdlib.List.map (fun ptree_value__005_ -> f ptree_value__005_)
+          x.layers in
+      let ptree_dim__006_ = x.dim in
+      {
+        w = ptree_w__001_;
+        b = ptree_b__002_;
+        layers = ptree_layers__004_;
+        dim = ptree_dim__006_
+      }
     let _ = map
     let map2
       (f :
@@ -26,24 +36,43 @@ include
           ('ptree_a, 'ptree_b) Nx.t ->
             ('ptree_a, 'ptree_b) Nx.t -> ('ptree_a, 'ptree_b) Nx.t)
       (x : t) (y : t) =
-      let ptree_w__005_ = f x.w y.w in
-      let ptree_b__006_ =
+      let ptree_w__007_ = f x.w y.w in
+      let ptree_b__008_ =
         match ((x.b), (y.b)) with
         | (None, None) -> None
-        | (Some ptree_left__007_, Some ptree_right__008_) ->
-            Some (f ptree_left__007_ ptree_right__008_)
+        | (Some ptree_left__009_, Some ptree_right__010_) ->
+            Some (f ptree_left__009_ ptree_right__010_)
         | _ ->
             Stdlib.invalid_arg
               "Mirror.map2: option constructor mismatch at b" in
-      let ptree_dim__009_ = x.dim in
-      { w = ptree_w__005_; b = ptree_b__006_; dim = ptree_dim__009_ }
+      let ptree_layers__011_ =
+        let ptree_left__012_ = x.layers in
+        let ptree_right__013_ = y.layers in
+        let ptree_left_length__014_ = Stdlib.List.length ptree_left__012_ in
+        let ptree_right_length__015_ = Stdlib.List.length ptree_right__013_ in
+        if Stdlib.(<>) ptree_left_length__014_ ptree_right_length__015_
+        then Stdlib.invalid_arg "Mirror.map2: list length mismatch at layers"
+        else
+          Stdlib.List.map2
+            (fun ptree_left_value__016_ ptree_right_value__017_ ->
+               f ptree_left_value__016_ ptree_right_value__017_)
+            ptree_left__012_ ptree_right__013_ in
+      let ptree_dim__018_ = x.dim in
+      {
+        w = ptree_w__007_;
+        b = ptree_b__008_;
+        layers = ptree_layers__011_;
+        dim = ptree_dim__018_
+      }
     let _ = map2
     let iter (f : 'ptree_a 'ptree_b . ('ptree_a, 'ptree_b) Nx.t -> unit)
       (x : t) =
       f x.w;
       (match x.b with
        | None -> ()
-       | Some ptree_value__010_ -> f ptree_value__010_);
+       | Some ptree_value__019_ -> f ptree_value__019_);
+      Stdlib.List.iter (fun ptree_value__020_ -> f ptree_value__020_)
+        x.layers;
       ()
     let _ = iter
     module Uniform =
@@ -51,59 +80,126 @@ include
         type nonrec 'm t = {
           w: 'm ;
           b: 'm option ;
+          layers: 'm list ;
           dim: int }
         let map (f : 'a -> 'b) (x : 'a t) =
-          (let ptree_w__011_ = f x.w in
-           let ptree_b__013_ =
+          (let ptree_w__021_ = f x.w in
+           let ptree_b__023_ =
              match x.b with
              | None -> None
-             | Some ptree_value__012_ -> Some (f ptree_value__012_) in
-           let ptree_dim__014_ = x.dim in
-           { w = ptree_w__011_; b = ptree_b__013_; dim = ptree_dim__014_ } : 
-          'b t)
+             | Some ptree_value__022_ -> Some (f ptree_value__022_) in
+           let ptree_layers__025_ =
+             Stdlib.List.map (fun ptree_value__024_ -> f ptree_value__024_)
+               x.layers in
+           let ptree_dim__026_ = x.dim in
+           {
+             w = ptree_w__021_;
+             b = ptree_b__023_;
+             layers = ptree_layers__025_;
+             dim = ptree_dim__026_
+           } : 'b t)
         let _ = map
         let map2 (f : 'a -> 'b -> 'c) (x : 'a t) (y : 'b t) =
-          (let ptree_w__015_ = f x.w y.w in
-           let ptree_b__018_ =
+          (let ptree_w__027_ = f x.w y.w in
+           let ptree_b__030_ =
              match ((x.b), (y.b)) with
              | (None, None) -> None
-             | (Some ptree_left__016_, Some ptree_right__017_) ->
-                 Some (f ptree_left__016_ ptree_right__017_)
+             | (Some ptree_left__028_, Some ptree_right__029_) ->
+                 Some (f ptree_left__028_ ptree_right__029_)
              | _ ->
                  Stdlib.invalid_arg
-                   "Mirror.Uniform.map2: option constructor mismatch" in
-           let ptree_dim__019_ = x.dim in
-           { w = ptree_w__015_; b = ptree_b__018_; dim = ptree_dim__019_ } : 
-          'c t)
+                   "Mirror.Uniform.map2: option constructor mismatch at b" in
+           let ptree_layers__035_ =
+             let ptree_left__031_ = x.layers in
+             let ptree_right__032_ = y.layers in
+             if
+               Stdlib.(<>) (Stdlib.List.length ptree_left__031_)
+                 (Stdlib.List.length ptree_right__032_)
+             then
+               Stdlib.invalid_arg
+                 "Mirror.Uniform.map2: list length mismatch at layers"
+             else
+               Stdlib.List.map2
+                 (fun ptree_left_value__033_ ptree_right_value__034_ ->
+                    f ptree_left_value__033_ ptree_right_value__034_)
+                 ptree_left__031_ ptree_right__032_ in
+           let ptree_dim__036_ = x.dim in
+           {
+             w = ptree_w__027_;
+             b = ptree_b__030_;
+             layers = ptree_layers__035_;
+             dim = ptree_dim__036_
+           } : 'c t)
         let _ = map2
         let iter (f : 'a -> unit) (x : 'a t) =
           f x.w;
           (match x.b with
            | None -> ()
-           | Some ptree_value__020_ -> f ptree_value__020_);
+           | Some ptree_value__037_ -> f ptree_value__037_);
+          Stdlib.List.iter (fun ptree_value__038_ -> f ptree_value__038_)
+            x.layers;
           ()
         let _ = iter
         let fold (f : string -> 'acc -> 'a -> 'acc) (acc : 'acc) (x : 'a t) =
-          let ptree_acc__021_ = f "w" acc x.w in
-          match x.b with
-          | None -> ptree_acc__021_
-          | Some ptree_value__022_ -> f "b" ptree_acc__021_ ptree_value__022_
+          Stdlib.List.fold_left
+            (fun ptree_acc__041_ ptree_pair__044_ ->
+               let (ptree_index__042_, ptree_value__043_) = ptree_pair__044_ in
+               f
+                 (Stdlib.(^) "layers."
+                    (Stdlib.string_of_int ptree_index__042_)) ptree_acc__041_
+                 ptree_value__043_)
+            (let ptree_acc__039_ = f "w" acc x.w in
+             match x.b with
+             | None -> ptree_acc__039_
+             | Some ptree_value__040_ ->
+                 f "b" ptree_acc__039_ ptree_value__040_)
+            (Stdlib.List.mapi
+               (fun ptree_index__042_ ptree_value__043_ ->
+                  (ptree_index__042_, ptree_value__043_)) x.layers)
         let _ = fold
         let fold2 (f : string -> 'acc -> 'a -> 'b -> 'acc) (acc : 'acc)
           (x : 'a t) (y : 'b t) =
-          let ptree_acc__023_ = f "w" acc x.w y.w in
-          match ((x.b), (y.b)) with
-          | (None, None) -> ptree_acc__023_
-          | (Some ptree_left__024_, Some ptree_right__025_) ->
-              f "b" ptree_acc__023_ ptree_left__024_ ptree_right__025_
-          | _ ->
-              Stdlib.invalid_arg
-                "Mirror.Uniform.fold2: option constructor mismatch"
+          let ptree_left__048_ = x.layers in
+          let ptree_right__049_ = y.layers in
+          if
+            Stdlib.(<>) (Stdlib.List.length ptree_left__048_)
+              (Stdlib.List.length ptree_right__049_)
+          then
+            Stdlib.invalid_arg
+              "Mirror.Uniform.fold2: list length mismatch at layers"
+          else
+            Stdlib.List.fold_left2
+              (fun ptree_acc__050_ ptree_pair__054_ ptree_right_value__053_
+                 ->
+                 let (ptree_index__051_, ptree_left_value__052_) =
+                   ptree_pair__054_ in
+                 f
+                   (Stdlib.(^) "layers."
+                      (Stdlib.string_of_int ptree_index__051_))
+                   ptree_acc__050_ ptree_left_value__052_
+                   ptree_right_value__053_)
+              (let ptree_acc__045_ = f "w" acc x.w y.w in
+               match ((x.b), (y.b)) with
+               | (None, None) -> ptree_acc__045_
+               | (Some ptree_left__046_, Some ptree_right__047_) ->
+                   f "b" ptree_acc__045_ ptree_left__046_ ptree_right__047_
+               | _ ->
+                   Stdlib.invalid_arg
+                     "Mirror.Uniform.fold2: option constructor mismatch at b")
+              (Stdlib.List.mapi
+                 (fun ptree_index__051_ ptree_left_value__052_ ->
+                    (ptree_index__051_, ptree_left_value__052_))
+                 ptree_left__048_) ptree_right__049_
         let _ = fold2
         let names (x : 'a t) =
           ({
              w = "w";
              b = (match x.b with | None -> None | Some _ -> Some "b");
+             layers =
+               (Stdlib.List.mapi
+                  (fun ptree_index__056_ _ ->
+                     Stdlib.(^) "layers."
+                       (Stdlib.string_of_int ptree_index__056_)) x.layers);
              dim = (x.dim)
            } : string t)
         let _ = names
@@ -114,7 +210,11 @@ include
          Uniform.b =
            (match x.b with
             | None -> None
-            | Some ptree_value__028_ -> Some (Nx.Ptree.P ptree_value__028_));
+            | Some ptree_value__061_ -> Some (Nx.Ptree.P ptree_value__061_));
+         Uniform.layers =
+           (Stdlib.List.map
+              (fun ptree_value__062_ -> Nx.Ptree.P ptree_value__062_)
+              x.layers);
          Uniform.dim = (x.dim)
        } : Nx.Ptree.tensor Uniform.t)
     let _ = to_uniform
@@ -124,8 +224,15 @@ include
          b =
            (match u.Uniform.b with
             | None -> None
-            | Some ptree_value__027_ ->
-                Some (Nx.Ptree.unpack ~at:"b" Nx.float32 ptree_value__027_));
+            | Some ptree_value__058_ ->
+                Some (Nx.Ptree.unpack ~at:"b" Nx.float32 ptree_value__058_));
+         layers =
+           (Stdlib.List.mapi
+              (fun ptree_index__059_ ptree_value__060_ ->
+                 Nx.Ptree.unpack
+                   ~at:(Stdlib.(^) "layers."
+                          (Stdlib.string_of_int ptree_index__059_))
+                   Nx.float32 ptree_value__060_) u.Uniform.layers);
          dim = (u.Uniform.dim)
        } : t)
     let _ = of_uniform

--- a/packages/ppx_ptree/test/expansion_cases/mirror.ml
+++ b/packages/ppx_ptree/test/expansion_cases/mirror.ml
@@ -1,0 +1,6 @@
+type t = {
+  w : Nx.float32_t;
+  b : Nx.float32_t option;
+  dim : int; [@ptree.ignore]
+}
+[@@deriving ptree ~mirror]

--- a/packages/ppx_ptree/test/expansion_cases/mirror.ml
+++ b/packages/ppx_ptree/test/expansion_cases/mirror.ml
@@ -1,6 +1,7 @@
 type t = {
   w : Nx.float32_t;
   b : Nx.float32_t option;
+  layers : Nx.float32_t list;
   dim : int; [@ptree.ignore]
 }
 [@@deriving ptree ~mirror]

--- a/packages/ppx_ptree/test/expansion_cases/uniform.expected
+++ b/packages/ppx_ptree/test/expansion_cases/uniform.expected
@@ -102,99 +102,95 @@ include
       | Some ptree_value__036_ -> f "lb" ptree_acc__035_ ptree_value__036_
     let _ = fold_layer
     let fold (f : string -> 'acc -> 'a0 -> 'acc) (acc : 'acc) (x : 'a0 t) =
-      let (ptree_tuple__048_, ptree_tuple__049_) = x.pair in
+      let (ptree_tuple__050_, ptree_tuple__051_) = x.pair in
       f "pair.1"
         (f "pair.0"
            (fold_layer
-              (fun ptree_path__045_ ptree_arg__046_ ptree_arg__047_ ->
+              (fun ptree_path__047_ ptree_arg__048_ ptree_arg__049_ ->
                  f
-                   (if Stdlib.String.equal ptree_path__045_ ""
+                   (if Stdlib.String.equal ptree_path__047_ ""
                     then "head"
-                    else Stdlib.(^) "head." ptree_path__045_) ptree_arg__046_
-                   ptree_arg__047_)
-              (Stdlib.List.fold_left
-                 (fun ptree_acc__037_ ptree_pair__040_ ->
-                    let (ptree_index__038_, ptree_value__039_) =
-                      ptree_pair__040_ in
-                    fold_layer
-                      (fun ptree_path__041_ ptree_arg__042_ ptree_arg__043_
-                         ->
-                         f
-                           (let ptree_prefix__044_ =
-                              Stdlib.(^) "layers."
-                                (Stdlib.string_of_int ptree_index__038_) in
-                            if Stdlib.String.equal ptree_path__041_ ""
-                            then ptree_prefix__044_
-                            else
-                              Stdlib.(^) (Stdlib.(^) ptree_prefix__044_ ".")
-                                ptree_path__041_) ptree_arg__042_
-                           ptree_arg__043_) ptree_acc__037_ ptree_value__039_)
-                 acc
-                 (Stdlib.List.mapi
-                    (fun ptree_index__038_ ptree_value__039_ ->
-                       (ptree_index__038_, ptree_value__039_)) x.layers))
-              x.head) ptree_tuple__048_) ptree_tuple__049_
+                    else Stdlib.(^) "head." ptree_path__047_) ptree_arg__048_
+                   ptree_arg__049_)
+              (let rec ptree_loop__037_ ptree_index__039_ ptree_acc__038_
+                 ptree_list__040_ =
+                 match ptree_list__040_ with
+                 | [] -> ptree_acc__038_
+                 | ptree_value__041_::ptree_rest__042_ ->
+                     ptree_loop__037_ (Stdlib.(+) ptree_index__039_ 1)
+                       (fold_layer
+                          (fun ptree_path__043_ ptree_arg__044_
+                             ptree_arg__045_ ->
+                             f
+                               (let ptree_prefix__046_ =
+                                  Stdlib.(^) "layers."
+                                    (Stdlib.string_of_int ptree_index__039_) in
+                                if Stdlib.String.equal ptree_path__043_ ""
+                                then ptree_prefix__046_
+                                else
+                                  Stdlib.(^)
+                                    (Stdlib.(^) ptree_prefix__046_ ".")
+                                    ptree_path__043_) ptree_arg__044_
+                               ptree_arg__045_) ptree_acc__038_
+                          ptree_value__041_) ptree_rest__042_ in
+               ptree_loop__037_ 0 acc x.layers) x.head) ptree_tuple__050_)
+        ptree_tuple__051_
     let _ = fold
     let fold2_layer (f : string -> 'acc -> 'a0 -> 'b -> 'acc) (acc : 'acc)
       (x : 'a0 layer) (y : 'b layer) =
-      let ptree_acc__050_ = f "lw" acc x.lw y.lw in
+      let ptree_acc__052_ = f "lw" acc x.lw y.lw in
       match ((x.lb), (y.lb)) with
-      | (None, None) -> ptree_acc__050_
-      | (Some ptree_left__051_, Some ptree_right__052_) ->
-          f "lb" ptree_acc__050_ ptree_left__051_ ptree_right__052_
+      | (None, None) -> ptree_acc__052_
+      | (Some ptree_left__053_, Some ptree_right__054_) ->
+          f "lb" ptree_acc__052_ ptree_left__053_ ptree_right__054_
       | _ ->
           Stdlib.invalid_arg
             "Uniform.fold2_layer: option constructor mismatch at lb"
     let _ = fold2_layer
     let fold2 (f : string -> 'acc -> 'a0 -> 'b -> 'acc) (acc : 'acc)
       (x : 'a0 t) (y : 'b t) =
-      let (ptree_tuple__069_, ptree_tuple__070_) = x.pair in
-      let (ptree_tuple__071_, ptree_tuple__072_) = y.pair in
+      let (ptree_tuple__073_, ptree_tuple__074_) = x.pair in
+      let (ptree_tuple__075_, ptree_tuple__076_) = y.pair in
       f "pair.1"
         (f "pair.0"
            (fold2_layer
-              (fun ptree_path__065_ ptree_arg__066_ ptree_arg__067_
-                 ptree_arg__068_ ->
+              (fun ptree_path__069_ ptree_arg__070_ ptree_arg__071_
+                 ptree_arg__072_ ->
                  f
-                   (if Stdlib.String.equal ptree_path__065_ ""
+                   (if Stdlib.String.equal ptree_path__069_ ""
                     then "head"
-                    else Stdlib.(^) "head." ptree_path__065_) ptree_arg__066_
-                   ptree_arg__067_ ptree_arg__068_)
-              (let ptree_left__053_ = x.layers in
-               let ptree_right__054_ = y.layers in
-               if
-                 Stdlib.(<>) (Stdlib.List.length ptree_left__053_)
-                   (Stdlib.List.length ptree_right__054_)
-               then
-                 Stdlib.invalid_arg
-                   "Uniform.fold2: list length mismatch at layers"
-               else
-                 Stdlib.List.fold_left2
-                   (fun ptree_acc__055_ ptree_pair__059_
-                      ptree_right_value__058_ ->
-                      let (ptree_index__056_, ptree_left_value__057_) =
-                        ptree_pair__059_ in
-                      fold2_layer
-                        (fun ptree_path__060_ ptree_arg__061_ ptree_arg__062_
-                           ptree_arg__063_ ->
-                           f
-                             (let ptree_prefix__064_ =
-                                Stdlib.(^) "layers."
-                                  (Stdlib.string_of_int ptree_index__056_) in
-                              if Stdlib.String.equal ptree_path__060_ ""
-                              then ptree_prefix__064_
-                              else
-                                Stdlib.(^)
-                                  (Stdlib.(^) ptree_prefix__064_ ".")
-                                  ptree_path__060_) ptree_arg__061_
-                             ptree_arg__062_ ptree_arg__063_) ptree_acc__055_
-                        ptree_left_value__057_ ptree_right_value__058_) acc
-                   (Stdlib.List.mapi
-                      (fun ptree_index__056_ ptree_left_value__057_ ->
-                         (ptree_index__056_, ptree_left_value__057_))
-                      ptree_left__053_) ptree_right__054_) x.head y.head)
-           ptree_tuple__069_ ptree_tuple__071_) ptree_tuple__070_
-        ptree_tuple__072_
+                    else Stdlib.(^) "head." ptree_path__069_) ptree_arg__070_
+                   ptree_arg__071_ ptree_arg__072_)
+              (let rec ptree_loop__055_ ptree_index__059_ ptree_acc__058_
+                 ptree_left__056_ ptree_right__057_ =
+                 match (ptree_left__056_, ptree_right__057_) with
+                 | (ptree_left_value__062_::ptree_left_rest__060_,
+                    ptree_right_value__063_::ptree_right_rest__061_) ->
+                     ptree_loop__055_ (Stdlib.(+) ptree_index__059_ 1)
+                       (fold2_layer
+                          (fun ptree_path__064_ ptree_arg__065_
+                             ptree_arg__066_ ptree_arg__067_ ->
+                             f
+                               (let ptree_prefix__068_ =
+                                  Stdlib.(^) "layers."
+                                    (Stdlib.string_of_int ptree_index__059_) in
+                                if Stdlib.String.equal ptree_path__064_ ""
+                                then ptree_prefix__068_
+                                else
+                                  Stdlib.(^)
+                                    (Stdlib.(^) ptree_prefix__068_ ".")
+                                    ptree_path__064_) ptree_arg__065_
+                               ptree_arg__066_ ptree_arg__067_)
+                          ptree_acc__058_ ptree_left_value__062_
+                          ptree_right_value__063_) ptree_left_rest__060_
+                       ptree_right_rest__061_
+                 | ([], []) -> ptree_acc__058_
+                 | _ ->
+                     Stdlib.invalid_arg
+                       "Uniform.fold2: list length mismatch at layers" in
+               ptree_loop__055_ 0 acc x.layers y.layers) x.head y.head)
+           ptree_tuple__073_ ptree_tuple__075_) ptree_tuple__074_
+        ptree_tuple__076_
     let _ = fold2
     let names_layer (x : 'a0 layer) =
       ({
@@ -206,24 +202,24 @@ include
       ({
          layers =
            (Stdlib.List.mapi
-              (fun ptree_index__074_ ptree_value__075_ ->
+              (fun ptree_index__078_ ptree_value__079_ ->
                  map_layer
-                   (fun ptree_path__076_ ->
-                      let ptree_prefix__077_ =
+                   (fun ptree_path__080_ ->
+                      let ptree_prefix__081_ =
                         Stdlib.(^) "layers."
-                          (Stdlib.string_of_int ptree_index__074_) in
-                      if Stdlib.String.equal ptree_path__076_ ""
-                      then ptree_prefix__077_
+                          (Stdlib.string_of_int ptree_index__078_) in
+                      if Stdlib.String.equal ptree_path__080_ ""
+                      then ptree_prefix__081_
                       else
-                        Stdlib.(^) (Stdlib.(^) ptree_prefix__077_ ".")
-                          ptree_path__076_) (names_layer ptree_value__075_))
+                        Stdlib.(^) (Stdlib.(^) ptree_prefix__081_ ".")
+                          ptree_path__080_) (names_layer ptree_value__079_))
               x.layers);
          head =
            (map_layer
-              (fun ptree_path__078_ ->
-                 if Stdlib.String.equal ptree_path__078_ ""
+              (fun ptree_path__082_ ->
+                 if Stdlib.String.equal ptree_path__082_ ""
                  then "head"
-                 else Stdlib.(^) "head." ptree_path__078_)
+                 else Stdlib.(^) "head." ptree_path__082_)
               (names_layer x.head));
          pair = (let (_, _) = x.pair in ("pair.0", "pair.1"));
          tag = (x.tag)

--- a/packages/ppx_ptree/test/expansion_cases/uniform.expected
+++ b/packages/ppx_ptree/test/expansion_cases/uniform.expected
@@ -48,7 +48,7 @@ include
              Some (f ptree_left__014_ ptree_right__015_)
          | _ ->
              Stdlib.invalid_arg
-               "Uniform.map2_layer: option constructor mismatch" in
+               "Uniform.map2_layer: option constructor mismatch at lb" in
        { lw = ptree_lw__013_; lb = ptree_lb__016_ } : 'c layer)
     let _ = map2_layer
     let map2 (f : 'a0 -> 'b -> 'c) (x : 'a0 t) (y : 'b t) =
@@ -56,9 +56,10 @@ include
          let ptree_left__017_ = x.layers in
          let ptree_right__018_ = y.layers in
          if
-           (Stdlib.List.length ptree_left__017_) <>
+           Stdlib.(<>) (Stdlib.List.length ptree_left__017_)
              (Stdlib.List.length ptree_right__018_)
-         then Stdlib.invalid_arg "Uniform.map2: list length mismatch"
+         then
+           Stdlib.invalid_arg "Uniform.map2: list length mismatch at layers"
          else
            Stdlib.List.map2
              (fun ptree_left_value__019_ ptree_right_value__020_ ->
@@ -101,13 +102,16 @@ include
       | Some ptree_value__036_ -> f "lb" ptree_acc__035_ ptree_value__036_
     let _ = fold_layer
     let fold (f : string -> 'acc -> 'a0 -> 'acc) (acc : 'acc) (x : 'a0 t) =
-      let (ptree_tuple__047_, ptree_tuple__048_) = x.pair in
-      f (("pair" ^ ".") ^ "1")
-        (f (("pair" ^ ".") ^ "0")
+      let (ptree_tuple__048_, ptree_tuple__049_) = x.pair in
+      f "pair.1"
+        (f "pair.0"
            (fold_layer
-              (fun ptree_path__044_ ptree_arg__045_ ptree_arg__046_ ->
-                 f (("head" ^ ".") ^ ptree_path__044_) ptree_arg__045_
-                   ptree_arg__046_)
+              (fun ptree_path__045_ ptree_arg__046_ ptree_arg__047_ ->
+                 f
+                   (if Stdlib.String.equal ptree_path__045_ ""
+                    then "head"
+                    else Stdlib.(^) "head." ptree_path__045_) ptree_arg__046_
+                   ptree_arg__047_)
               (Stdlib.List.fold_left
                  (fun ptree_acc__037_ ptree_pair__040_ ->
                     let (ptree_index__038_, ptree_value__039_) =
@@ -116,67 +120,81 @@ include
                       (fun ptree_path__041_ ptree_arg__042_ ptree_arg__043_
                          ->
                          f
-                           (((("layers" ^ ".") ^
-                                (Stdlib.string_of_int ptree_index__038_))
-                               ^ ".")
-                              ^ ptree_path__041_) ptree_arg__042_
+                           (let ptree_prefix__044_ =
+                              Stdlib.(^) "layers."
+                                (Stdlib.string_of_int ptree_index__038_) in
+                            if Stdlib.String.equal ptree_path__041_ ""
+                            then ptree_prefix__044_
+                            else
+                              Stdlib.(^) (Stdlib.(^) ptree_prefix__044_ ".")
+                                ptree_path__041_) ptree_arg__042_
                            ptree_arg__043_) ptree_acc__037_ ptree_value__039_)
                  acc
                  (Stdlib.List.mapi
                     (fun ptree_index__038_ ptree_value__039_ ->
                        (ptree_index__038_, ptree_value__039_)) x.layers))
-              x.head) ptree_tuple__047_) ptree_tuple__048_
+              x.head) ptree_tuple__048_) ptree_tuple__049_
     let _ = fold
     let fold2_layer (f : string -> 'acc -> 'a0 -> 'b -> 'acc) (acc : 'acc)
       (x : 'a0 layer) (y : 'b layer) =
-      let ptree_acc__049_ = f "lw" acc x.lw y.lw in
+      let ptree_acc__050_ = f "lw" acc x.lw y.lw in
       match ((x.lb), (y.lb)) with
-      | (None, None) -> ptree_acc__049_
-      | (Some ptree_left__050_, Some ptree_right__051_) ->
-          f "lb" ptree_acc__049_ ptree_left__050_ ptree_right__051_
+      | (None, None) -> ptree_acc__050_
+      | (Some ptree_left__051_, Some ptree_right__052_) ->
+          f "lb" ptree_acc__050_ ptree_left__051_ ptree_right__052_
       | _ ->
           Stdlib.invalid_arg
-            "Uniform.fold2_layer: option constructor mismatch"
+            "Uniform.fold2_layer: option constructor mismatch at lb"
     let _ = fold2_layer
     let fold2 (f : string -> 'acc -> 'a0 -> 'b -> 'acc) (acc : 'acc)
       (x : 'a0 t) (y : 'b t) =
-      let (ptree_tuple__067_, ptree_tuple__068_) = x.pair in
-      let (ptree_tuple__069_, ptree_tuple__070_) = y.pair in
-      f (("pair" ^ ".") ^ "1")
-        (f (("pair" ^ ".") ^ "0")
+      let (ptree_tuple__069_, ptree_tuple__070_) = x.pair in
+      let (ptree_tuple__071_, ptree_tuple__072_) = y.pair in
+      f "pair.1"
+        (f "pair.0"
            (fold2_layer
-              (fun ptree_path__063_ ptree_arg__064_ ptree_arg__065_
-                 ptree_arg__066_ ->
-                 f (("head" ^ ".") ^ ptree_path__063_) ptree_arg__064_
-                   ptree_arg__065_ ptree_arg__066_)
-              (let ptree_left__052_ = x.layers in
-               let ptree_right__053_ = y.layers in
+              (fun ptree_path__065_ ptree_arg__066_ ptree_arg__067_
+                 ptree_arg__068_ ->
+                 f
+                   (if Stdlib.String.equal ptree_path__065_ ""
+                    then "head"
+                    else Stdlib.(^) "head." ptree_path__065_) ptree_arg__066_
+                   ptree_arg__067_ ptree_arg__068_)
+              (let ptree_left__053_ = x.layers in
+               let ptree_right__054_ = y.layers in
                if
-                 (Stdlib.List.length ptree_left__052_) <>
-                   (Stdlib.List.length ptree_right__053_)
-               then Stdlib.invalid_arg "Uniform.fold2: list length mismatch"
+                 Stdlib.(<>) (Stdlib.List.length ptree_left__053_)
+                   (Stdlib.List.length ptree_right__054_)
+               then
+                 Stdlib.invalid_arg
+                   "Uniform.fold2: list length mismatch at layers"
                else
                  Stdlib.List.fold_left2
-                   (fun ptree_acc__054_ ptree_pair__058_
-                      ptree_right_value__057_ ->
-                      let (ptree_index__055_, ptree_left_value__056_) =
-                        ptree_pair__058_ in
+                   (fun ptree_acc__055_ ptree_pair__059_
+                      ptree_right_value__058_ ->
+                      let (ptree_index__056_, ptree_left_value__057_) =
+                        ptree_pair__059_ in
                       fold2_layer
-                        (fun ptree_path__059_ ptree_arg__060_ ptree_arg__061_
-                           ptree_arg__062_ ->
+                        (fun ptree_path__060_ ptree_arg__061_ ptree_arg__062_
+                           ptree_arg__063_ ->
                            f
-                             (((("layers" ^ ".") ^
-                                  (Stdlib.string_of_int ptree_index__055_))
-                                 ^ ".")
-                                ^ ptree_path__059_) ptree_arg__060_
-                             ptree_arg__061_ ptree_arg__062_) ptree_acc__054_
-                        ptree_left_value__056_ ptree_right_value__057_) acc
+                             (let ptree_prefix__064_ =
+                                Stdlib.(^) "layers."
+                                  (Stdlib.string_of_int ptree_index__056_) in
+                              if Stdlib.String.equal ptree_path__060_ ""
+                              then ptree_prefix__064_
+                              else
+                                Stdlib.(^)
+                                  (Stdlib.(^) ptree_prefix__064_ ".")
+                                  ptree_path__060_) ptree_arg__061_
+                             ptree_arg__062_ ptree_arg__063_) ptree_acc__055_
+                        ptree_left_value__057_ ptree_right_value__058_) acc
                    (Stdlib.List.mapi
-                      (fun ptree_index__055_ ptree_left_value__056_ ->
-                         (ptree_index__055_, ptree_left_value__056_))
-                      ptree_left__052_) ptree_right__053_) x.head y.head)
-           ptree_tuple__067_ ptree_tuple__069_) ptree_tuple__068_
-        ptree_tuple__070_
+                      (fun ptree_index__056_ ptree_left_value__057_ ->
+                         (ptree_index__056_, ptree_left_value__057_))
+                      ptree_left__053_) ptree_right__054_) x.head y.head)
+           ptree_tuple__069_ ptree_tuple__071_) ptree_tuple__070_
+        ptree_tuple__072_
     let _ = fold2
     let names_layer (x : 'a0 layer) =
       ({
@@ -188,21 +206,26 @@ include
       ({
          layers =
            (Stdlib.List.mapi
-              (fun ptree_index__072_ ptree_value__073_ ->
+              (fun ptree_index__074_ ptree_value__075_ ->
                  map_layer
-                   (fun ptree_path__074_ ->
-                      ((("layers" ^ ".") ^
-                          (Stdlib.string_of_int ptree_index__072_))
-                         ^ ".")
-                        ^ ptree_path__074_) (names_layer ptree_value__073_))
+                   (fun ptree_path__076_ ->
+                      let ptree_prefix__077_ =
+                        Stdlib.(^) "layers."
+                          (Stdlib.string_of_int ptree_index__074_) in
+                      if Stdlib.String.equal ptree_path__076_ ""
+                      then ptree_prefix__077_
+                      else
+                        Stdlib.(^) (Stdlib.(^) ptree_prefix__077_ ".")
+                          ptree_path__076_) (names_layer ptree_value__075_))
               x.layers);
          head =
            (map_layer
-              (fun ptree_path__075_ -> ("head" ^ ".") ^ ptree_path__075_)
+              (fun ptree_path__078_ ->
+                 if Stdlib.String.equal ptree_path__078_ ""
+                 then "head"
+                 else Stdlib.(^) "head." ptree_path__078_)
               (names_layer x.head));
-         pair =
-           (let (_, _) = x.pair in
-            ((("pair" ^ ".") ^ "0"), (("pair" ^ ".") ^ "1")));
+         pair = (let (_, _) = x.pair in ("pair.0", "pair.1"));
          tag = (x.tag)
        } : string t)
     let _ = names

--- a/packages/ppx_ptree/test/expansion_cases/uniform.expected
+++ b/packages/ppx_ptree/test/expansion_cases/uniform.expected
@@ -1,0 +1,209 @@
+type 'a layer = {
+  lw: 'a ;
+  lb: 'a option }
+and 'a t =
+  {
+  layers: 'a layer list ;
+  head: 'a layer ;
+  pair: ('a * 'a) ;
+  tag: string }[@@deriving ptree]
+include
+  struct let _ = fun (_ : 'a layer) -> ()
+         let _ = fun (_ : 'a t) -> () end[@@ocaml.doc "@inline"][@@merlin.hide
+                                                                  ]
+include
+  struct
+    let map_layer (f : 'a0 -> 'b) (x : 'a0 layer) =
+      (let ptree_lw__001_ = f x.lw in
+       let ptree_lb__003_ =
+         match x.lb with
+         | None -> None
+         | Some ptree_value__002_ -> Some (f ptree_value__002_) in
+       { lw = ptree_lw__001_; lb = ptree_lb__003_ } : 'b layer)
+    let _ = map_layer
+    let map (f : 'a0 -> 'b) (x : 'a0 t) =
+      (let ptree_layers__005_ =
+         Stdlib.List.map
+           (fun ptree_value__004_ -> map_layer f ptree_value__004_) x.layers in
+       let ptree_head__006_ = map_layer f x.head in
+       let ptree_pair__011_ =
+         let (ptree_tuple__007_, ptree_tuple__008_) = x.pair in
+         let ptree_mapped__009_ = f ptree_tuple__007_ in
+         let ptree_mapped__010_ = f ptree_tuple__008_ in
+         (ptree_mapped__009_, ptree_mapped__010_) in
+       let ptree_tag__012_ = x.tag in
+       {
+         layers = ptree_layers__005_;
+         head = ptree_head__006_;
+         pair = ptree_pair__011_;
+         tag = ptree_tag__012_
+       } : 'b t)
+    let _ = map
+    let map2_layer (f : 'a0 -> 'b -> 'c) (x : 'a0 layer) (y : 'b layer) =
+      (let ptree_lw__013_ = f x.lw y.lw in
+       let ptree_lb__016_ =
+         match ((x.lb), (y.lb)) with
+         | (None, None) -> None
+         | (Some ptree_left__014_, Some ptree_right__015_) ->
+             Some (f ptree_left__014_ ptree_right__015_)
+         | _ ->
+             Stdlib.invalid_arg
+               "Uniform.map2_layer: option constructor mismatch" in
+       { lw = ptree_lw__013_; lb = ptree_lb__016_ } : 'c layer)
+    let _ = map2_layer
+    let map2 (f : 'a0 -> 'b -> 'c) (x : 'a0 t) (y : 'b t) =
+      (let ptree_layers__021_ =
+         let ptree_left__017_ = x.layers in
+         let ptree_right__018_ = y.layers in
+         if
+           (Stdlib.List.length ptree_left__017_) <>
+             (Stdlib.List.length ptree_right__018_)
+         then Stdlib.invalid_arg "Uniform.map2: list length mismatch"
+         else
+           Stdlib.List.map2
+             (fun ptree_left_value__019_ ptree_right_value__020_ ->
+                map2_layer f ptree_left_value__019_ ptree_right_value__020_)
+             ptree_left__017_ ptree_right__018_ in
+       let ptree_head__022_ = map2_layer f x.head y.head in
+       let ptree_pair__029_ =
+         let (ptree_tuple__023_, ptree_tuple__024_) = x.pair in
+         let (ptree_tuple__025_, ptree_tuple__026_) = y.pair in
+         let ptree_mapped__027_ = f ptree_tuple__023_ ptree_tuple__025_ in
+         let ptree_mapped__028_ = f ptree_tuple__024_ ptree_tuple__026_ in
+         (ptree_mapped__027_, ptree_mapped__028_) in
+       let ptree_tag__030_ = x.tag in
+       {
+         layers = ptree_layers__021_;
+         head = ptree_head__022_;
+         pair = ptree_pair__029_;
+         tag = ptree_tag__030_
+       } : 'c t)
+    let _ = map2
+    let iter_layer (f : 'a0 -> unit) (x : 'a0 layer) =
+      f x.lw;
+      (match x.lb with
+       | None -> ()
+       | Some ptree_value__031_ -> f ptree_value__031_)
+    let _ = iter_layer
+    let iter (f : 'a0 -> unit) (x : 'a0 t) =
+      Stdlib.List.iter
+        (fun ptree_value__032_ -> iter_layer f ptree_value__032_) x.layers;
+      iter_layer f x.head;
+      (let (ptree_tuple__033_, ptree_tuple__034_) = x.pair in
+       f ptree_tuple__033_; f ptree_tuple__034_);
+      ()
+    let _ = iter
+    let fold_layer (f : string -> 'acc -> 'a0 -> 'acc) (acc : 'acc)
+      (x : 'a0 layer) =
+      let ptree_acc__035_ = f "lw" acc x.lw in
+      match x.lb with
+      | None -> ptree_acc__035_
+      | Some ptree_value__036_ -> f "lb" ptree_acc__035_ ptree_value__036_
+    let _ = fold_layer
+    let fold (f : string -> 'acc -> 'a0 -> 'acc) (acc : 'acc) (x : 'a0 t) =
+      let (ptree_tuple__047_, ptree_tuple__048_) = x.pair in
+      f (("pair" ^ ".") ^ "1")
+        (f (("pair" ^ ".") ^ "0")
+           (fold_layer
+              (fun ptree_path__044_ ptree_arg__045_ ptree_arg__046_ ->
+                 f (("head" ^ ".") ^ ptree_path__044_) ptree_arg__045_
+                   ptree_arg__046_)
+              (Stdlib.List.fold_left
+                 (fun ptree_acc__037_ ptree_pair__040_ ->
+                    let (ptree_index__038_, ptree_value__039_) =
+                      ptree_pair__040_ in
+                    fold_layer
+                      (fun ptree_path__041_ ptree_arg__042_ ptree_arg__043_
+                         ->
+                         f
+                           (((("layers" ^ ".") ^
+                                (Stdlib.string_of_int ptree_index__038_))
+                               ^ ".")
+                              ^ ptree_path__041_) ptree_arg__042_
+                           ptree_arg__043_) ptree_acc__037_ ptree_value__039_)
+                 acc
+                 (Stdlib.List.mapi
+                    (fun ptree_index__038_ ptree_value__039_ ->
+                       (ptree_index__038_, ptree_value__039_)) x.layers))
+              x.head) ptree_tuple__047_) ptree_tuple__048_
+    let _ = fold
+    let fold2_layer (f : string -> 'acc -> 'a0 -> 'b -> 'acc) (acc : 'acc)
+      (x : 'a0 layer) (y : 'b layer) =
+      let ptree_acc__049_ = f "lw" acc x.lw y.lw in
+      match ((x.lb), (y.lb)) with
+      | (None, None) -> ptree_acc__049_
+      | (Some ptree_left__050_, Some ptree_right__051_) ->
+          f "lb" ptree_acc__049_ ptree_left__050_ ptree_right__051_
+      | _ ->
+          Stdlib.invalid_arg
+            "Uniform.fold2_layer: option constructor mismatch"
+    let _ = fold2_layer
+    let fold2 (f : string -> 'acc -> 'a0 -> 'b -> 'acc) (acc : 'acc)
+      (x : 'a0 t) (y : 'b t) =
+      let (ptree_tuple__067_, ptree_tuple__068_) = x.pair in
+      let (ptree_tuple__069_, ptree_tuple__070_) = y.pair in
+      f (("pair" ^ ".") ^ "1")
+        (f (("pair" ^ ".") ^ "0")
+           (fold2_layer
+              (fun ptree_path__063_ ptree_arg__064_ ptree_arg__065_
+                 ptree_arg__066_ ->
+                 f (("head" ^ ".") ^ ptree_path__063_) ptree_arg__064_
+                   ptree_arg__065_ ptree_arg__066_)
+              (let ptree_left__052_ = x.layers in
+               let ptree_right__053_ = y.layers in
+               if
+                 (Stdlib.List.length ptree_left__052_) <>
+                   (Stdlib.List.length ptree_right__053_)
+               then Stdlib.invalid_arg "Uniform.fold2: list length mismatch"
+               else
+                 Stdlib.List.fold_left2
+                   (fun ptree_acc__054_ ptree_pair__058_
+                      ptree_right_value__057_ ->
+                      let (ptree_index__055_, ptree_left_value__056_) =
+                        ptree_pair__058_ in
+                      fold2_layer
+                        (fun ptree_path__059_ ptree_arg__060_ ptree_arg__061_
+                           ptree_arg__062_ ->
+                           f
+                             (((("layers" ^ ".") ^
+                                  (Stdlib.string_of_int ptree_index__055_))
+                                 ^ ".")
+                                ^ ptree_path__059_) ptree_arg__060_
+                             ptree_arg__061_ ptree_arg__062_) ptree_acc__054_
+                        ptree_left_value__056_ ptree_right_value__057_) acc
+                   (Stdlib.List.mapi
+                      (fun ptree_index__055_ ptree_left_value__056_ ->
+                         (ptree_index__055_, ptree_left_value__056_))
+                      ptree_left__052_) ptree_right__053_) x.head y.head)
+           ptree_tuple__067_ ptree_tuple__069_) ptree_tuple__068_
+        ptree_tuple__070_
+    let _ = fold2
+    let names_layer (x : 'a0 layer) =
+      ({
+         lw = "lw";
+         lb = (match x.lb with | None -> None | Some _ -> Some "lb")
+       } : string layer)
+    let _ = names_layer
+    let names (x : 'a0 t) =
+      ({
+         layers =
+           (Stdlib.List.mapi
+              (fun ptree_index__072_ ptree_value__073_ ->
+                 map_layer
+                   (fun ptree_path__074_ ->
+                      ((("layers" ^ ".") ^
+                          (Stdlib.string_of_int ptree_index__072_))
+                         ^ ".")
+                        ^ ptree_path__074_) (names_layer ptree_value__073_))
+              x.layers);
+         head =
+           (map_layer
+              (fun ptree_path__075_ -> ("head" ^ ".") ^ ptree_path__075_)
+              (names_layer x.head));
+         pair =
+           (let (_, _) = x.pair in
+            ((("pair" ^ ".") ^ "0"), (("pair" ^ ".") ^ "1")));
+         tag = (x.tag)
+       } : string t)
+    let _ = names
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/packages/ppx_ptree/test/expansion_cases/uniform.ml
+++ b/packages/ppx_ptree/test/expansion_cases/uniform.ml
@@ -1,0 +1,9 @@
+type 'a layer = { lw : 'a; lb : 'a option }
+
+and 'a t = {
+  layers : 'a layer list;
+  head : 'a layer;
+  pair : 'a * 'a;
+  tag : string;
+}
+[@@deriving ptree]

--- a/packages/ppx_ptree/test/test_integration.ml
+++ b/packages/ppx_ptree/test/test_integration.ml
@@ -52,7 +52,7 @@ let test_pmap_axes_and_tuple_output () =
       (module Pmap_input)
       (fun value -> Nx.add value.rows (Nx.transpose value.columns))
   in
-  equal (array (float 0.)) (Nx.to_array eager) (Nx.to_array (parallel input));
+  equal (array float_exact) (Nx.to_array eager) (Nx.to_array (parallel input));
   let tuple_parallel =
     Rune.pmap2 ~devices ~in_axes:axes
       (module Pmap_input)
@@ -60,9 +60,9 @@ let test_pmap_axes_and_tuple_output () =
       (fun value -> (value.rows, Nx.transpose value.columns))
   in
   let rows_result, columns_result = tuple_parallel input in
-  equal (array (float 0.)) (Nx.to_array rows) (Nx.to_array rows_result);
+  equal (array float_exact) (Nx.to_array rows) (Nx.to_array rows_result);
   equal
-    (array (float 0.))
+    (array float_exact)
     (Nx.to_array (Nx.transpose columns))
     (Nx.to_array columns_result)
 
@@ -91,7 +91,7 @@ let test_vega_optimizer_step () =
   equal (array (float 1e-6)) [| 2.; -4. |] (Nx.to_array state.velocity.weight)
 
 let test_nested_kaun_model_and_checkpoint_order () =
-  Nx.Rng.run ~seed:7 @@ fun () ->
+  Nx.Rng.with_key (Nx.Rng.key 7) @@ fun () ->
   let model =
     Model.
       {

--- a/packages/ppx_ptree/test/test_integration.ml
+++ b/packages/ppx_ptree/test/test_integration.ml
@@ -24,50 +24,20 @@ module Optimizer_params = struct
   [@@deriving ptree]
 end
 
-(* A key is a tensor, and it belongs in the structure whenever a compiled step
-   draws from it — that is how the draw reaches the trace as an input rather
-   than a frozen constant. Spelled [Nx.Rng.key], not [(int32, int32_elt) Nx.t].
-*)
-module Stepper = struct
-  type t = { weight : Nx.float32_t; key : Nx.Rng.key } [@@deriving ptree]
-end
-
+(* A uniform user model nesting the hand-written kaun layers: the derived
+   traversals delegate to [Kaun.Linear]'s, and checkpoint names come from the
+   derived [fold]. *)
 module Block = struct
-  type t = { projection : Kaun.Linear.t } [@@deriving ptree]
+  type 'a t = { projection : 'a Kaun.Linear.t } [@@deriving ptree]
 end
 
 module Model = struct
-  type t = {
-    stem : Kaun.Linear.t;
-    blocks : Block.t list;
-    head : Kaun.Linear.t option;
+  type 'a t = {
+    stem : 'a Kaun.Linear.t;
+    blocks : 'a Block.t list;
+    head : 'a Kaun.Linear.t option;
   }
   [@@deriving ptree]
-end
-
-module Model_named = struct
-  include Model
-
-  let linear_names prefix linear =
-    List.map (fun name -> prefix ^ "." ^ name) (Kaun.Linear.names linear)
-
-  let names model =
-    let stem = linear_names "stem" model.stem in
-    let blocks =
-      List.mapi
-        (fun index block ->
-          linear_names
-            (Printf.sprintf "blocks.%d.projection" index)
-            block.Block.projection)
-        model.blocks
-      |> List.concat
-    in
-    let head =
-      match model.head with
-      | None -> []
-      | Some linear -> linear_names "head" linear
-    in
-    stem @ blocks @ head
 end
 
 let test_pmap_axes_and_tuple_output () =
@@ -82,7 +52,7 @@ let test_pmap_axes_and_tuple_output () =
       (module Pmap_input)
       (fun value -> Nx.add value.rows (Nx.transpose value.columns))
   in
-  equal (array float_exact) (Nx.to_array eager) (Nx.to_array (parallel input));
+  equal (array (float 0.)) (Nx.to_array eager) (Nx.to_array (parallel input));
   let tuple_parallel =
     Rune.pmap2 ~devices ~in_axes:axes
       (module Pmap_input)
@@ -90,9 +60,9 @@ let test_pmap_axes_and_tuple_output () =
       (fun value -> (value.rows, Nx.transpose value.columns))
   in
   let rows_result, columns_result = tuple_parallel input in
-  equal (array float_exact) (Nx.to_array rows) (Nx.to_array rows_result);
+  equal (array (float 0.)) (Nx.to_array rows) (Nx.to_array rows_result);
   equal
-    (array float_exact)
+    (array (float 0.))
     (Nx.to_array (Nx.transpose columns))
     (Nx.to_array columns_result)
 
@@ -121,7 +91,7 @@ let test_vega_optimizer_step () =
   equal (array (float 1e-6)) [| 2.; -4. |] (Nx.to_array state.velocity.weight)
 
 let test_nested_kaun_model_and_checkpoint_order () =
-  Nx.Rng.with_key (Nx.Rng.key 7) @@ fun () ->
+  Nx.Rng.run ~seed:7 @@ fun () ->
   let model =
     Model.
       {
@@ -140,7 +110,7 @@ let test_nested_kaun_model_and_checkpoint_order () =
       Stdlib.ignore tensor;
       incr traversal_count)
     model;
-  let names = Model_named.names model in
+  let names = List.rev (Model.fold (fun path acc _ -> path :: acc) [] model) in
   equal ~msg:"one checkpoint name per generated traversal leaf" int
     (List.length names) !traversal_count;
   equal (list string)
@@ -155,7 +125,7 @@ let test_nested_kaun_model_and_checkpoint_order () =
       "head.b";
     ]
     names;
-  let checkpoint = Kaun.Checkpoint.of_params (module Model_named) model in
+  let checkpoint = Kaun.Checkpoint.of_params (module Model) model in
   List.iter
     (fun name ->
       is_some
@@ -163,29 +133,8 @@ let test_nested_kaun_model_and_checkpoint_order () =
         (Kaun.Checkpoint.find name checkpoint))
     names
 
-(* The key must traverse as a leaf, and — the point of putting it there — reach
-   a jitted step as an input, so the draw follows the key it is handed instead
-   of replaying one baked in at trace time. *)
-let test_rng_key_field_is_a_leaf () =
-  let params =
-    Stepper.{ weight = f32 [| 2 |] [| 1.0; 2.0 |]; key = Nx.Rng.key 5 }
-  in
-  let leaves = ref 0 in
-  Stepper.iter (fun _ -> incr leaves) params;
-  equal ~msg:"the key traverses alongside the weight" int 2 !leaves;
-  let step =
-    Rune.jit
-      (module Stepper)
-      (fun p -> Nx.mul p.Stepper.weight (Nx.Rng.uniform p.Stepper.key Nx.float32 [| 2 |]))
-  in
-  let at k = Nx.to_array (step { params with Stepper.key = Nx.Rng.key k }) in
-  is_true ~msg:"a compiled draw follows the key it is given" (at 5 <> at 6);
-  equal ~msg:"and replays for the same key" (array float_exact) (at 5) (at 5)
-
 let tests =
   [
-    test "derives a traversal over an Nx.Rng.key field"
-      test_rng_key_field_is_a_leaf;
     test "preserves derived leaf order through pmap axes and tuple output"
       test_pmap_axes_and_tuple_output;
     test "runs a Vega optimizer step over a derived module"

--- a/packages/ppx_ptree/test/test_ptree.ml
+++ b/packages/ppx_ptree/test/test_ptree.ml
@@ -232,15 +232,7 @@ module Integration = struct
     bias : Nx.float64_t;
     label : string; [@ptree.ignore]
   }
-  [@@deriving ptree]
-end
-
-module Integration_named = struct
-  include Integration
-
-  let names value =
-    Stdlib.ignore value;
-    [ "weight"; "bias" ]
+  [@@deriving ptree ~mirror]
 end
 
 module Jit_structure = struct
@@ -544,7 +536,9 @@ let test_rune_and_vega_integration () =
   equal (array float_exact) [| 1. |] (Nx.to_array gradients.bias);
   is_true (Vega.global_norm (module Integration) gradients > 0.);
   let checkpoint =
-    Kaun.Checkpoint.of_params (module Integration_named) params
+    Kaun.Checkpoint.of_packed
+      (module Integration.Uniform)
+      (Integration.to_uniform params)
   in
   equal (list string) [ "bias"; "weight" ] (Kaun.Checkpoint.names checkpoint);
   let jitted =

--- a/packages/ppx_ptree/test/test_signature.ml
+++ b/packages/ppx_ptree/test/test_signature.ml
@@ -21,3 +21,18 @@ let () =
       visited := true)
     value;
   if not !visited then failwith "abstract signature traversal did not run"
+
+type 'p uniform_pair = { first : 'p; second : 'p } [@@deriving ptree]
+type dense = { dense_w : Nx.float32_t } [@@deriving ptree ~mirror]
+
+let () =
+  let doubled =
+    map2_uniform_pair ( + ) { first = 1; second = 2 }
+      { first = 10; second = 20 }
+  in
+  if doubled.second <> 22 then failwith "uniform signature traversal is wrong";
+  let names = names_uniform_pair { first = (); second = () } in
+  if names.first <> "first" then failwith "uniform signature names are wrong";
+  let d = { dense_w = Nx.zeros Nx.float32 [| 2 |] } in
+  let restored = of_uniform (to_uniform d) in
+  if Nx.numel restored.dense_w <> 2 then failwith "mirror round trip is wrong"

--- a/packages/ppx_ptree/test/test_signature.mli
+++ b/packages/ppx_ptree/test/test_signature.mli
@@ -5,3 +5,5 @@
 
 type t [@@deriving ptree]
 type !'tag wrapped [@@deriving ptree]
+type 'p uniform_pair = { first : 'p; second : 'p } [@@deriving ptree]
+type dense = { dense_w : Nx.float32_t } [@@deriving ptree ~mirror]

--- a/packages/ppx_ptree/test/test_uniform.ml
+++ b/packages/ppx_ptree/test/test_uniform.ml
@@ -1,0 +1,225 @@
+(*---------------------------------------------------------------------------
+  Copyright (c) 2026 The Raven authors. All rights reserved.
+  SPDX-License-Identifier: ISC
+  ---------------------------------------------------------------------------*)
+
+(* Uniform mode and mirror mode of [@@deriving ptree], through the ppx. *)
+
+open Windtrap
+
+(* ——— uniform declarations ——— *)
+
+module Params = struct
+  type 'a layer = { lw : 'a; lb : 'a option }
+
+  and 'a t = {
+    layers : 'a layer list;
+    head : 'a layer;
+    pair : 'a * 'a;
+    tag : string;
+  }
+  [@@deriving ptree]
+end
+
+module Params_as_uniform : Nx.Ptree.Uniform with type 'a t = 'a Params.t =
+  Params
+
+let params =
+  {
+    Params.layers =
+      [ { Params.lw = 1; lb = Some 2 }; { Params.lw = 3; lb = None } ];
+    head = { Params.lw = 4; lb = Some 5 };
+    pair = (6, 7);
+    tag = "model";
+  }
+
+let leaf_paths =
+  [
+    "layers.0.lw";
+    "layers.0.lb";
+    "layers.1.lw";
+    "head.lw";
+    "head.lb";
+    "pair.0";
+    "pair.1";
+  ]
+
+let test_map () =
+  let strings = Params.map string_of_int params in
+  equal ~msg:"payloads change type" string "1" (List.hd strings.layers).lw;
+  equal ~msg:"option payloads map" (option string) (Some "2")
+    (List.hd strings.layers).lb;
+  equal ~msg:"absent payloads stay absent" (option string) None
+    (List.nth strings.layers 1).lb;
+  equal ~msg:"tuple payloads map" (pair string string) ("6", "7") strings.pair;
+  equal ~msg:"static fields are preserved" string "model" strings.tag
+
+let test_map2_heterogeneous () =
+  let strings = Params.map string_of_int params in
+  let zipped = Params.map2 (fun n s -> (n, s)) params strings in
+  equal ~msg:"map2 zips trees of different payload types" (pair int string)
+    (4, "4") zipped.head.lw;
+  equal ~msg:"map2 keeps the left static fields" string "model" zipped.tag
+
+let test_map2_mismatch () =
+  let shorter = { params with Params.layers = [] } in
+  raises_invalid_arg "Test_uniform.Params.map2: list length mismatch" (fun () ->
+      Stdlib.ignore (Params.map2 (fun a _ -> a) params shorter));
+  let absent = { params with Params.head = { Params.lw = 4; lb = None } } in
+  raises_invalid_arg
+    "Test_uniform.Params.map2_layer: option constructor mismatch" (fun () ->
+      Stdlib.ignore (Params.map2 (fun a _ -> a) params absent))
+
+let test_iter () =
+  let visited = ref [] in
+  Params.iter (fun n -> visited := n :: !visited) params;
+  equal ~msg:"iter visits every payload in declaration order" (list int)
+    [ 1; 2; 3; 4; 5; 6; 7 ] (List.rev !visited)
+
+let test_fold_paths () =
+  let folded =
+    Params.fold (fun path acc n -> (path, n) :: acc) [] params |> List.rev
+  in
+  equal ~msg:"fold threads dot-joined paths in traversal order"
+    (list (pair string int))
+    (List.combine leaf_paths [ 1; 2; 3; 4; 5; 6; 7 ])
+    folded
+
+let test_fold2 () =
+  let doubled = Params.map (fun n -> n * 10) params in
+  let folded =
+    Params.fold2 (fun path acc a b -> (path, a, b) :: acc) [] params doubled
+    |> List.rev
+  in
+  equal ~msg:"fold2 pairs corresponding payloads with paths"
+    (list (triple string int int))
+    (List.map
+       (fun (p, n) -> (p, n, n * 10))
+       (List.combine leaf_paths [ 1; 2; 3; 4; 5; 6; 7 ]))
+    folded
+
+let test_names () =
+  let names = Params.names params in
+  equal ~msg:"names mirrors the value's structure" (option string)
+    (Some "head.lb") names.head.lb;
+  equal ~msg:"names copies static fields" string "model" names.tag;
+  let collected =
+    Params.fold (fun _ acc path -> path :: acc) [] names |> List.rev
+  in
+  equal ~msg:"names agrees with fold's paths" (list string) leaf_paths collected
+
+(* ——— Ptree.S bridge and differentiation ——— *)
+
+module Lin = struct
+  type 'a t = { w : 'a; b : 'a } [@@deriving ptree]
+end
+
+module P = Nx.Ptree.Make (Lin)
+
+let vec32 values = Nx.create Nx.float32 [| Array.length values |] values
+let raw tensor = Nx.to_array (Nx.reshape [| -1 |] (Nx.contiguous tensor))
+
+let check_arr ~msg expected tensor =
+  let actual = raw tensor in
+  equal ~msg int (Array.length expected) (Array.length actual);
+  Array.iteri
+    (fun i x ->
+      equal ~msg:(Printf.sprintf "%s[%d]" msg i) (float 1e-5) x actual.(i))
+    expected
+
+let test_grad_through_bridge () =
+  let p : P.t =
+    {
+      Lin.w = Nx.Ptree.P (vec32 [| 1.0; -2.0; 3.0 |]);
+      b = Nx.Ptree.P (vec32 [| 0.5 |]);
+    }
+  in
+  let loss (t : P.t) =
+    let w = Nx.Ptree.unpack Nx.float32 t.Lin.w in
+    let b = Nx.Ptree.unpack Nx.float32 t.Lin.b in
+    Nx.add (Nx.sum (Nx.mul w w)) (Nx.mul_s (Nx.sum b) 3.0)
+  in
+  let g = Rune.grad (module P) loss p in
+  check_arr ~msg:"dw" [| 2.0; -4.0; 6.0 |] (Nx.Ptree.unpack Nx.float32 g.Lin.w);
+  check_arr ~msg:"db" [| 3.0 |] (Nx.Ptree.unpack Nx.float32 g.Lin.b)
+
+(* ——— mirror mode ——— *)
+
+module Dense = struct
+  type t = {
+    w : Nx.float32_t;
+    b : Nx.float32_t option;
+    dim : int; [@ptree.ignore]
+  }
+  [@@deriving ptree ~mirror]
+end
+
+let dense =
+  { Dense.w = vec32 [| 1.0; 2.0 |]; b = Some (vec32 [| 3.0 |]); dim = 2 }
+
+let test_mirror_paths () =
+  let paths =
+    Dense.Uniform.fold
+      (fun path acc _ -> path :: acc)
+      [] (Dense.to_uniform dense)
+    |> List.rev
+  in
+  equal ~msg:"the mirror folds over packed leaves with paths" (list string)
+    [ "w"; "b" ] paths
+
+let test_mirror_round_trip () =
+  let restored = Dense.of_uniform (Dense.to_uniform dense) in
+  check_arr ~msg:"w survives the round trip" [| 1.0; 2.0 |] restored.Dense.w;
+  check_arr ~msg:"b survives the round trip" [| 3.0 |]
+    (Option.get restored.Dense.b);
+  equal ~msg:"static fields survive the round trip" int 2 restored.Dense.dim
+
+let test_mirror_metadata_zip () =
+  let scales = { Dense.Uniform.w = 2.0; b = Some 0.5; dim = 2 } in
+  let scaled =
+    Dense.Uniform.map2
+      (fun (Nx.Ptree.P x) scale -> float_of_int (Nx.numel x) *. scale)
+      (Dense.to_uniform dense) scales
+  in
+  equal ~msg:"map2 zips the mirror against metadata" (float 1e-9) 4.0
+    scaled.Dense.Uniform.w;
+  equal ~msg:"optional metadata zips leafwise"
+    (option (float 1e-9))
+    (Some 0.5) scaled.Dense.Uniform.b
+
+let test_mirror_dtype_mismatch () =
+  let forged =
+    let u = Dense.to_uniform dense in
+    { u with Dense.Uniform.w = Nx.Ptree.P (Nx.zeros Nx.float64 [| 2 |]) }
+  in
+  raises_invalid_arg "Ptree.unpack: dtype mismatch at w" (fun () ->
+      Stdlib.ignore (Dense.of_uniform forged))
+
+let tests =
+  [
+    group "uniform traversals"
+      [
+        test "map changes the payload type" test_map;
+        test "map2 zips heterogeneous trees" test_map2_heterogeneous;
+        test "map2 rejects structural mismatches" test_map2_mismatch;
+        test "iter visits payloads in order" test_iter;
+      ];
+    group "uniform paths"
+      [
+        test "fold threads leaf paths" test_fold_paths;
+        test "fold2 pairs payloads with paths" test_fold2;
+        test "names is the tree of paths" test_names;
+      ];
+    group "Ptree.S bridge"
+      [ test "grad through Nx.Ptree.Make" test_grad_through_bridge ];
+    group "mirror"
+      [
+        test "fold over the packed mirror" test_mirror_paths;
+        test "to_uniform/of_uniform round trip" test_mirror_round_trip;
+        test "map2 against a metadata tree" test_mirror_metadata_zip;
+        test "of_uniform reports dtype mismatches with paths"
+          test_mirror_dtype_mismatch;
+      ];
+  ]
+
+let () = run "ppx_ptree uniform" tests

--- a/packages/ppx_ptree/test/test_uniform.ml
+++ b/packages/ppx_ptree/test/test_uniform.ml
@@ -63,16 +63,16 @@ let test_map2_heterogeneous () =
 
 let test_map2_mismatch () =
   let shorter = { params with Params.layers = [] } in
-  raises_invalid_arg "Test_uniform.Params.map2: list length mismatch at layers"
+  raises (Invalid_argument "Test_uniform.Params.map2: list length mismatch at layers")
     (fun () -> Stdlib.ignore (Params.map2 (fun a _ -> a) params shorter));
   let absent = { params with Params.head = { Params.lw = 4; lb = None } } in
-  raises_invalid_arg
-    "Test_uniform.Params.map2_layer: option constructor mismatch at lb"
+  raises
+    (Invalid_argument "Test_uniform.Params.map2_layer: option constructor mismatch at lb")
     (fun () -> Stdlib.ignore (Params.map2 (fun a _ -> a) params absent))
 
 let test_fold2_mismatch () =
   let shorter = { params with Params.layers = [] } in
-  raises_invalid_arg "Test_uniform.Params.fold2: list length mismatch at layers"
+  raises (Invalid_argument "Test_uniform.Params.fold2: list length mismatch at layers")
     (fun () ->
       Stdlib.ignore (Params.fold2 (fun _ acc _ _ -> acc) 0 params shorter))
 
@@ -172,7 +172,7 @@ let test_nested_container_paths () =
 
 let test_nested_container_mismatch () =
   let shorter = { deep with Deep.rows = [| [ 1 ]; [ 3 ] |] } in
-  raises_invalid_arg "Test_uniform.Deep.fold2: list length mismatch at rows.0"
+  raises (Invalid_argument "Test_uniform.Deep.fold2: list length mismatch at rows.0")
     (fun () -> Stdlib.ignore (Deep.fold2 (fun _ acc _ _ -> acc) 0 deep shorter))
 
 (* ——— Ptree.S bridge and differentiation ——— *)
@@ -292,7 +292,7 @@ let test_mirror_dtype_mismatch () =
     let u = Dense.to_uniform dense in
     { u with Dense.Uniform.w = Nx.Ptree.P (Nx.zeros Nx.float64 [| 2 |]) }
   in
-  raises_invalid_arg "Ptree.unpack: dtype mismatch at w" (fun () ->
+  raises (Invalid_argument "Ptree.unpack: dtype mismatch at w") (fun () ->
       Stdlib.ignore (Dense.of_uniform forged))
 
 (* ——— mirror over containers ——— *)
@@ -339,7 +339,7 @@ let test_mirror_container_dtype_mismatch () =
         ];
     }
   in
-  raises_invalid_arg "Ptree.unpack: dtype mismatch at layers.1" (fun () ->
+  raises (Invalid_argument "Ptree.unpack: dtype mismatch at layers.1") (fun () ->
       Stdlib.ignore (Stack.of_uniform forged))
 
 let tests =

--- a/packages/ppx_ptree/test/test_uniform.ml
+++ b/packages/ppx_ptree/test/test_uniform.ml
@@ -210,6 +210,39 @@ let test_grad_through_bridge () =
   check_arr ~msg:"dw" [| 2.0; -4.0; 6.0 |] (Nx.Ptree.unpack Nx.float32 g.Lin.w);
   check_arr ~msg:"db" [| 3.0 |] (Nx.Ptree.unpack Nx.float32 g.Lin.b)
 
+(* ——— rank-2 records nesting a uniform module ——— *)
+
+(* A concrete record whose field is a uniform module's concrete alias. The
+   rank-2 traversals delegate through the alias to the module's rank-1 uniform
+   traversals, which accept the rank-2 callback at the alias's leaf type. This
+   is the shape Kaun layers take once they are payload-generic. *)
+module Gain = struct
+  type 'a params = { g : 'a; label : string } [@@deriving ptree]
+  type t = Nx.float32_t params
+end
+
+module Head = struct
+  type t = { bias : Nx.float32_t; gain : Gain.t } [@@deriving ptree]
+end
+
+let head () =
+  {
+    Head.bias = vec32 [| 1.0; 2.0 |];
+    gain = { Gain.g = vec32 [| 3.0 |]; label = "gain" };
+  }
+
+let test_rank2_delegates_to_uniform () =
+  let doubled = Head.map (fun x -> Nx.add x x) (head ()) in
+  check_arr ~msg:"own leaves map" [| 2.0; 4.0 |] doubled.Head.bias;
+  check_arr ~msg:"delegated leaves map" [| 6.0 |] doubled.Head.gain.Gain.g;
+  equal ~msg:"delegated static fields are preserved" string "gain"
+    doubled.Head.gain.Gain.label;
+  let summed = Head.map2 (fun x y -> Nx.add x y) (head ()) doubled in
+  check_arr ~msg:"map2 delegates leafwise" [| 9.0 |] summed.Head.gain.Gain.g;
+  let count = ref 0 in
+  Head.iter (fun _ -> incr count) (head ());
+  equal ~msg:"iter visits delegated leaves" int 2 !count
+
 (* ——— mirror mode ——— *)
 
 module Dense = struct
@@ -331,6 +364,11 @@ let tests =
       ];
     group "Ptree.S bridge"
       [ test "grad through Nx.Ptree.Make" test_grad_through_bridge ];
+    group "rank-2 delegation"
+      [
+        test "a concrete record delegates to a uniform module"
+          test_rank2_delegates_to_uniform;
+      ];
     group "mirror"
       [
         test "fold over the packed mirror" test_mirror_paths;

--- a/packages/ppx_ptree/test/test_uniform.ml
+++ b/packages/ppx_ptree/test/test_uniform.ml
@@ -63,12 +63,18 @@ let test_map2_heterogeneous () =
 
 let test_map2_mismatch () =
   let shorter = { params with Params.layers = [] } in
-  raises_invalid_arg "Test_uniform.Params.map2: list length mismatch" (fun () ->
-      Stdlib.ignore (Params.map2 (fun a _ -> a) params shorter));
+  raises_invalid_arg "Test_uniform.Params.map2: list length mismatch at layers"
+    (fun () -> Stdlib.ignore (Params.map2 (fun a _ -> a) params shorter));
   let absent = { params with Params.head = { Params.lw = 4; lb = None } } in
   raises_invalid_arg
-    "Test_uniform.Params.map2_layer: option constructor mismatch" (fun () ->
-      Stdlib.ignore (Params.map2 (fun a _ -> a) params absent))
+    "Test_uniform.Params.map2_layer: option constructor mismatch at lb"
+    (fun () -> Stdlib.ignore (Params.map2 (fun a _ -> a) params absent))
+
+let test_fold2_mismatch () =
+  let shorter = { params with Params.layers = [] } in
+  raises_invalid_arg "Test_uniform.Params.fold2: list length mismatch at layers"
+    (fun () ->
+      Stdlib.ignore (Params.fold2 (fun _ acc _ _ -> acc) 0 params shorter))
 
 let test_iter () =
   let visited = ref [] in
@@ -107,6 +113,67 @@ let test_names () =
     Params.fold (fun _ acc path -> path :: acc) [] names |> List.rev
   in
   equal ~msg:"names agrees with fold's paths" (list string) leaf_paths collected
+
+(* ——— delegates whose payload sits at their own root ——— *)
+
+module Nested = struct
+  type 'a leaf = 'a
+
+  and 'a t = { root : 'a leaf; items : 'a leaf list; grid : 'a leaf array }
+  [@@deriving ptree]
+end
+
+let nested = { Nested.root = 1; items = [ 2; 3 ]; grid = [| 4; 5 |] }
+let nested_paths = [ "root"; "items.0"; "items.1"; "grid.0"; "grid.1" ]
+
+let test_delegate_root_paths () =
+  let folded =
+    Nested.fold (fun path acc n -> (path, n) :: acc) [] nested |> List.rev
+  in
+  equal ~msg:"a delegate's root payload contributes no segment"
+    (list (pair string int))
+    (List.combine nested_paths [ 1; 2; 3; 4; 5 ])
+    folded;
+  let zipped =
+    Nested.fold2 (fun path acc _ _ -> path :: acc) [] nested nested |> List.rev
+  in
+  equal ~msg:"fold2 agrees with fold" (list string) nested_paths zipped;
+  let names = Nested.names nested in
+  equal ~msg:"names agrees with fold" (list string) nested_paths
+    (Nested.fold (fun _ acc path -> path :: acc) [] names |> List.rev)
+
+(* ——— nested containers ——— *)
+
+module Deep = struct
+  type 'a t = { rows : 'a list array; cells : ('a * 'a option) list }
+  [@@deriving ptree]
+end
+
+let deep =
+  { Deep.rows = [| [ 1; 2 ]; [ 3 ] |]; cells = [ (4, Some 5); (6, None) ] }
+
+let deep_paths =
+  [ "rows.0.0"; "rows.0.1"; "rows.1.0"; "cells.0.0"; "cells.0.1"; "cells.1.0" ]
+
+let test_nested_container_paths () =
+  let folded =
+    Deep.fold (fun path acc n -> (path, n) :: acc) [] deep |> List.rev
+  in
+  equal ~msg:"indices nest through arrays and lists"
+    (list (pair string int))
+    (List.combine deep_paths [ 1; 2; 3; 4; 5; 6 ])
+    folded;
+  let zipped =
+    Deep.fold2 (fun path acc _ _ -> path :: acc) [] deep deep |> List.rev
+  in
+  equal ~msg:"fold2 agrees with fold" (list string) deep_paths zipped;
+  equal ~msg:"names agrees with fold" (list string) deep_paths
+    (Deep.fold (fun _ acc path -> path :: acc) [] (Deep.names deep) |> List.rev)
+
+let test_nested_container_mismatch () =
+  let shorter = { deep with Deep.rows = [| [ 1 ]; [ 3 ] |] } in
+  raises_invalid_arg "Test_uniform.Deep.fold2: list length mismatch at rows.0"
+    (fun () -> Stdlib.ignore (Deep.fold2 (fun _ acc _ _ -> acc) 0 deep shorter))
 
 (* ——— Ptree.S bridge and differentiation ——— *)
 
@@ -195,6 +262,45 @@ let test_mirror_dtype_mismatch () =
   raises_invalid_arg "Ptree.unpack: dtype mismatch at w" (fun () ->
       Stdlib.ignore (Dense.of_uniform forged))
 
+(* ——— mirror over containers ——— *)
+
+module Stack = struct
+  type t = { layers : Nx.float32_t list; grid : Nx.float32_t array }
+  [@@deriving ptree ~mirror]
+end
+
+let stack =
+  {
+    Stack.layers = [ vec32 [| 1.0 |]; vec32 [| 2.0 |] ];
+    grid = [| vec32 [| 3.0 |] |];
+  }
+
+let test_mirror_container_paths () =
+  let paths =
+    Stack.Uniform.fold
+      (fun path acc _ -> path :: acc)
+      [] (Stack.to_uniform stack)
+    |> List.rev
+  in
+  equal ~msg:"container elements carry their index" (list string)
+    [ "layers.0"; "layers.1"; "grid.0" ]
+    paths
+
+let test_mirror_container_dtype_mismatch () =
+  let forged =
+    let u = Stack.to_uniform stack in
+    {
+      u with
+      Stack.Uniform.layers =
+        [
+          List.hd u.Stack.Uniform.layers;
+          Nx.Ptree.P (Nx.zeros Nx.float64 [| 1 |]);
+        ];
+    }
+  in
+  raises_invalid_arg "Ptree.unpack: dtype mismatch at layers.1" (fun () ->
+      Stdlib.ignore (Stack.of_uniform forged))
+
 let tests =
   [
     group "uniform traversals"
@@ -208,7 +314,12 @@ let tests =
       [
         test "fold threads leaf paths" test_fold_paths;
         test "fold2 pairs payloads with paths" test_fold2;
+        test "fold2 rejects structural mismatches" test_fold2_mismatch;
         test "names is the tree of paths" test_names;
+        test "delegates keep the parent path intact" test_delegate_root_paths;
+        test "nested containers nest their indices" test_nested_container_paths;
+        test "a nested mismatch names its position"
+          test_nested_container_mismatch;
       ];
     group "Ptree.S bridge"
       [ test "grad through Nx.Ptree.Make" test_grad_through_bridge ];
@@ -219,6 +330,10 @@ let tests =
         test "map2 against a metadata tree" test_mirror_metadata_zip;
         test "of_uniform reports dtype mismatches with paths"
           test_mirror_dtype_mismatch;
+        test "container elements fold with their index"
+          test_mirror_container_paths;
+        test "of_uniform locates a mismatch inside a container"
+          test_mirror_container_dtype_mismatch;
       ];
   ]
 

--- a/packages/ppx_ptree/test/test_uniform.ml
+++ b/packages/ppx_ptree/test/test_uniform.ml
@@ -286,6 +286,14 @@ let test_mirror_container_paths () =
     [ "layers.0"; "layers.1"; "grid.0" ]
     paths
 
+let test_mirror_container_round_trip () =
+  let restored = Stack.of_uniform (Stack.to_uniform stack) in
+  equal ~msg:"list length survives" int 2 (List.length restored.Stack.layers);
+  equal ~msg:"array length survives" int 1 (Array.length restored.Stack.grid);
+  check_arr ~msg:"element 0" [| 1.0 |] (List.nth restored.Stack.layers 0);
+  check_arr ~msg:"element 1" [| 2.0 |] (List.nth restored.Stack.layers 1);
+  check_arr ~msg:"grid element" [| 3.0 |] restored.Stack.grid.(0)
+
 let test_mirror_container_dtype_mismatch () =
   let forged =
     let u = Stack.to_uniform stack in
@@ -332,6 +340,8 @@ let tests =
           test_mirror_dtype_mismatch;
         test "container elements fold with their index"
           test_mirror_container_paths;
+        test "containers survive to_uniform/of_uniform"
+          test_mirror_container_round_trip;
         test "of_uniform locates a mismatch inside a container"
           test_mirror_container_dtype_mismatch;
       ];

--- a/packages/quill/examples/mnist.md
+++ b/packages/quill/examples/mnist.md
@@ -61,15 +61,15 @@ leaves — no special layer type:
 <!-- quill:cell id="c_mnist_model_code" -->
 ```ocaml
 module Model = struct
-  type t = { l1 : Linear.t; l2 : Linear.t }
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) { l1; l2 } =
+  let map f { l1; l2 } =
     { l1 = Linear.map f l1; l2 = Linear.map f l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) p q =
+  let map2 f p q =
     { l1 = Linear.map2 f p.l1 q.l1; l2 = Linear.map2 f p.l2 q.l2 }
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) { l1; l2 } =
+  let iter f { l1; l2 } =
     Linear.iter f l1;
     Linear.iter f l2
 
@@ -77,6 +77,8 @@ module Model = struct
     let x = Nx.reshape [| (Nx.shape x).(0); 784 |] x in
     Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
+
+let model = Kaun.ptree (module Model)
 ```
 
 <!-- quill:cell id="c_mnist_trainer_text" -->
@@ -94,7 +96,7 @@ let params =
   Model.{ l1 = Linear.init ~inputs:784 ~outputs:128;
           l2 = Linear.init ~inputs:128 ~outputs:10 }
 
-let st = ref (params, Vega.adam_init (module Model) params)
+let st = ref (params, Vega.adam_init model params)
 ```
 
 <!-- quill:cell id="c_mnist_train_text" -->
@@ -118,11 +120,11 @@ let () =
     |> Seq.iter (fun (x, y) ->
         let params, ostate = !st in
         let loss, grads =
-          Rune.value_and_grad (module Model)
+          Rune.value_and_grad model
             (fun p -> Loss.softmax_cross_entropy_sparse (Model.apply p x) y)
             params
         in
-        st := Vega.adam_step (module Model) ~lr:0.001 ostate ~params ~grads;
+        st := Vega.adam_step model ~lr:0.001 ostate ~params ~grads;
         incr step;
         Printf.printf "\r  epoch %d  batch %d/%d  loss: %.4f%!" epoch !step
           num_batches (Nx.item [] loss));

--- a/packages/rune/README.md
+++ b/packages/rune/README.md
@@ -64,6 +64,8 @@ nest into records, so models compose structurally — see
   finite differences
 - **Control flow** — `scan`, `cond`, `while_loop` combinators with
   staging-ready signatures
+- **Compilation** — `jit` traces a function once and replays it as
+  fused kernels, on CPU (the default), CUDA, or Metal via `~device`
 - **Debugging** — `with_debug` logs every tensor operation; `detach`
   and `no_grad` stop gradient flow
 - **Structured outputs** — `vjp2`, `jvp2`, `vmap2` for functions
@@ -126,8 +128,8 @@ Current gaps:
   mapped inputs instead.
 - **In-place mutation** (`set_item`, `set_slice`, `blit`, `assign`)
   raises during differentiation; write the update functionally.
-- **No JIT yet.** Everything runs eagerly; `scan`/`cond`/`while_loop`
-  are designed so a future `jit` can stage them without unrolling.
+- **`jit` unrolls `scan`**, so a recurrence's compile time grows with
+  its sequence length.
 
 ## Contributing
 

--- a/packages/rune/doc/02-transformations.md
+++ b/packages/rune/doc/02-transformations.md
@@ -353,7 +353,7 @@ The check is directional, not per-element: it validates gradients cheaply rather
 
 ## Control Flow
 
-Ordinary OCaml control flow — `if`, `match`, loops, recursion — works inside every transformation, because rune runs eagerly and intercepts operations as they execute. The `scan`, `cond`, and `while_loop` combinators exist for a different reason: their signatures are staging-ready, so code written with them differentiates and vectorizes today, and a future `jit` can stage them as structured control flow instead of unrolled traces.
+Ordinary OCaml control flow — `if`, `match`, loops, recursion — works inside every transformation, because rune runs eagerly and intercepts operations as they execute. The `scan`, `cond`, and `while_loop` combinators exist for a different reason: their signatures are staging-ready, so code written with them differentiates and vectorizes today, and a future staging `jit` can trace them as structured control flow (today `Rune.jit` unrolls `scan` and rejects data-dependent `cond`/`while_loop` predicates).
 
 ### scan
 
@@ -428,7 +428,7 @@ Rune fails loudly rather than returning wrong gradients:
 - **Ops without differentiation rules raise.** Reverse mode has no rule for `svd`, `eig`, `eigh`, `rfft`, `irfft`, `psum`, and `mod`; forward mode additionally lacks `qr`. Differentiating through them raises `Invalid_argument` — `detach` the input if gradients should not flow through. (`cholesky` and reverse-mode `qr` are supported.)
 - **`vmap` has no rule for `fft`-family and decomposition ops** (`fft`, `ifft`, `rfft`, `irfft`, `cholesky`, `qr`, `svd`, `eig`, `eigh`) over batched inputs.
 - **In-place mutation** (`set_item`, `set_slice`, `blit`, `assign`) raises during differentiation; write the update functionally.
-- **No JIT yet.** Everything runs eagerly; `scan`/`cond`/`while_loop` are designed so a future `jit` can stage them without unrolling.
+- **`Rune.jit` unrolls `scan`** and rejects data-dependent `cond`/`while_loop` predicates, so a recurrence's compile time grows with its sequence length.
 
 ## Summary
 

--- a/packages/rune/doc/03-how-it-works.md
+++ b/packages/rune/doc/03-how-it-works.md
@@ -110,7 +110,7 @@ The intent is that rune never returns a wrong gradient quietly.
 
 ## Implications for Users
 
-**No graph construction step.** Everything runs eagerly. Every operation happens immediately, and transformations intercept operations as they execute. `if`, `match`, `for`, recursion, and higher-order functions all work inside differentiated code — there is no "graph-compatible" subset of the language. (The `scan`/`cond`/`while_loop` combinators exist for a future `jit` that could stage them; they are not required today.)
+**No graph construction step.** Everything runs eagerly. Every operation happens immediately, and transformations intercept operations as they execute. `if`, `match`, `for`, recursion, and higher-order functions all work inside differentiated code — there is no "graph-compatible" subset of the language. (The `scan`/`cond`/`while_loop` combinators exist for a future staging `jit` that could trace them as structured control flow; they are not required today.)
 
 **Side effects run in the forward pass.** Printing or logging inside a differentiated function executes during the forward pass. The backward pass runs the recorded pull thunks; it does not re-execute your function — unless you asked for that with `remat`.
 

--- a/packages/rune/doc/04-jax-comparison.md
+++ b/packages/rune/doc/04-jax-comparison.md
@@ -30,7 +30,7 @@ If you already use JAX, this should be enough to become productive in rune quick
 | Gradient stopping | `jax.lax.stop_gradient` | `detach`, `no_grad` |
 | Gradient checking | `jax.test_util.check_grads` | `check_grads` |
 | Randomness | Explicit splittable keys (`jax.random`) | Implicit scoped RNG (`Nx.Rng.with_key`) |
-| JIT compilation | `jax.jit` | Not yet implemented |
+| JIT compilation | `jax.jit` | `jit` — traces once per leaf signature; CPU, CUDA, or Metal |
 | Devices | `jax.device_put`, GPU/TPU | CPU only |
 
 ---
@@ -276,7 +276,7 @@ let () =
   ignore (Rune.grad' f (Nx.scalar Nx.float32 2.0))
 ```
 
-Rune still provides `scan`, `cond`, and `while_loop` — not because you need them today, but because their signatures are staging-ready: code written with them differentiates and vectorizes now, and a future `jit` can stage them as structured control flow instead of unrolled traces. `lax.scan`'s carry-and-stacked-outputs contract translates directly:
+Rune still provides `scan`, `cond`, and `while_loop` — not because you need them today, but because their signatures are staging-ready: code written with them differentiates and vectorizes now, and a future staging `jit` can trace them as structured control flow. Today `jit` unrolls `scan` and rejects data-dependent `cond`/`while_loop` predicates. `lax.scan`'s carry-and-stacked-outputs contract translates directly:
 
 ```python
 final, ys = jax.lax.scan(f, init, xs)
@@ -351,13 +351,13 @@ The trade-off surfaces under `vmap`: with explicit keys you would pass one key p
 
 | JAX feature | Status in rune |
 | --- | --- |
-| `jax.jit` | Not implemented. Everything runs eagerly; `scan`/`cond`/`while_loop` are designed so a future `jit` can stage them. |
-| GPU/TPU, `jax.device_put` | Not implemented. CPU only. |
+| `jax.jit` | `jit (module P) f` compiles to fused kernels, cached per leaf signature. It unrolls `scan` and rejects data-dependent `cond`/`while_loop` predicates. |
+| GPU/TPU, `jax.device_put` | Eager execution is CPU-only; `jit ~device:"CUDA"`/`"METAL"` runs compiled steps on GPU. |
 | `jax.pmap` / distributed | Not implemented. |
 | Full op coverage under AD | Reverse mode raises on `svd`, `eig`, `eigh`, `rfft`, `irfft`, `psum`, `mod`; forward mode additionally on `qr`. `detach` inputs where gradients should not flow. |
 | Full op coverage under `vmap` | The `fft` family and decompositions raise on batched inputs. |
 | `jax.random` keys | Implicit scoped RNG instead; see §11. |
-| Donation, sharding, `pjit` | Not applicable without a compiler. |
+| Donation, sharding, `pjit` | `jit ~donate:true` reuses input storage; no sharding or `pjit`. |
 
 Rune's failure model is deliberate: operations without a rule raise `Invalid_argument` rather than silently producing zero or wrong gradients.
 
@@ -389,4 +389,4 @@ Rune's failure model is deliberate: operations without a rule raise `Invalid_arg
 | Block region from AD | — | `no_grad (fun () -> ...)` |
 | Gradient check | `check_grads(f, (x,), 1)` | `check_grads (module P) f params` |
 | Debug tracing | `jax.debug.print` | `with_debug (fun () -> ...)` |
-| JIT | `jax.jit(f)` | Not yet available |
+| JIT | `jax.jit(f)` | `jit (module P) f` |

--- a/packages/rune/lib/custom.ml
+++ b/packages/rune/lib/custom.ml
@@ -40,7 +40,7 @@ type _ Effect.t +=
   | E_custom_vjp : ('c, 'd) vjp_call -> ('c, 'd) Nx.t Effect.t
   | E_custom_jvp : ('c, 'd) jvp_call -> ('c, 'd) Nx.t Effect.t
 
-let custom_vjp (type c d) (module P : Nx.Ptree.S)
+let custom_vjp (type p c d) (module P : Nx.Ptree.S with type t = p)
     ~(fwd : P.t -> (c, d) Nx.t * 'res) ~(bwd : 'res -> (c, d) Nx.t -> P.t)
     (params : P.t) : (c, d) Nx.t =
   try
@@ -48,7 +48,7 @@ let custom_vjp (type c d) (module P : Nx.Ptree.S)
       (E_custom_vjp (Vjp_call { tree = (module P); params; fwd; bwd }))
   with Effect.Unhandled _ -> fst (fwd params)
 
-let custom_jvp (type c d) (module P : Nx.Ptree.S) ~(f : P.t -> (c, d) Nx.t)
+let custom_jvp (type p c d) (module P : Nx.Ptree.S with type t = p) ~(f : P.t -> (c, d) Nx.t)
     ~(jvp : P.t -> P.t -> (c, d) Nx.t * (c, d) Nx.t) (params : P.t) :
     (c, d) Nx.t =
   try

--- a/packages/rune/lib/jit.ml
+++ b/packages/rune/lib/jit.ml
@@ -1227,7 +1227,7 @@ type 'q compiled = {
   cp_scratch : scratch; (* staging bytes reused across replays *)
 }
 
-let signature_of (module P : Nx.Ptree.S) (params : P.t) =
+let signature_of (type p) (module P : Nx.Ptree.S with type t = p) (params : P.t) =
   let acc = ref [] in
   P.iter
     (fun leaf ->
@@ -1235,8 +1235,8 @@ let signature_of (module P : Nx.Ptree.S) (params : P.t) =
     params;
   List.rev !acc
 
-let trace_compile ~device:dev ~zero_copy ~const_cache ?multi
-    (module P : Nx.Ptree.S) (module Q : Nx.Ptree.S) (f : P.t -> Q.t)
+let trace_compile (type p q) ~device:dev ~zero_copy ~const_cache ?multi
+    (module P : Nx.Ptree.S with type t = p) (module Q : Nx.Ptree.S with type t = q) (f : P.t -> Q.t)
     (params : P.t) : Q.t compiled =
   let st =
     {
@@ -1618,7 +1618,7 @@ let trace_compile ~device:dev ~zero_copy ~const_cache ?multi
     cp_scratch = scratch;
   }
 
-let replay ~donate (module P : Nx.Ptree.S) (module Q : Nx.Ptree.S)
+let replay (type p q) ~donate (module P : Nx.Ptree.S with type t = p) (module Q : Nx.Ptree.S with type t = q)
     (c : Q.t compiled) (params : P.t) : Q.t =
   drain_releases ();
   let in0 = !bytes_to_device and out0 = !bytes_from_device in
@@ -1908,8 +1908,8 @@ let replay ~donate (module P : Nx.Ptree.S) (module Q : Nx.Ptree.S)
 
 (* Public entry points *)
 
-let jit2 ?(device = "CPU") ?(donate = false) (module P : Nx.Ptree.S)
-    (module Q : Nx.Ptree.S) (f : P.t -> Q.t) : P.t -> Q.t =
+let jit2 (type p q) ?(device = "CPU") ?(donate = false) (module P : Nx.Ptree.S with type t = p)
+    (module Q : Nx.Ptree.S with type t = q) (f : P.t -> Q.t) : P.t -> Q.t =
   let dev = get_device device in
   let zero_copy = is_cpu device && not (force_copy ()) in
   let cache : (_, Q.t compiled) Hashtbl.t = Hashtbl.create 4 in
@@ -1935,7 +1935,7 @@ let jit2 ?(device = "CPU") ?(donate = false) (module P : Nx.Ptree.S)
       in
       replay ~donate (module P) (module Q) c params
 
-let jit (type c d) ?device ?donate (module P : Nx.Ptree.S)
+let jit (type p c d) ?device ?donate (module P : Nx.Ptree.S with type t = p)
     (f : P.t -> (c, d) Nx_effect.t) : P.t -> (c, d) Nx_effect.t =
   let module Q = struct
     type t = (c, d) Nx_effect.t
@@ -1996,8 +1996,8 @@ let pmap_names devices =
     names;
   names
 
-let pmap2 ~devices ?in_axes ?(donate = false) (module P : Nx.Ptree.S)
-    (module Q : Nx.Ptree.S) (f : P.t -> Q.t) : P.t -> Q.t =
+let pmap2 (type p q) ~devices ?in_axes ?(donate = false) (module P : Nx.Ptree.S with type t = p)
+    (module Q : Nx.Ptree.S with type t = q) (f : P.t -> Q.t) : P.t -> Q.t =
   let names = pmap_names devices in
   (* Multi-device buffers resolve through the tolk device registry; route it to
      the same factory the single-device jit uses. *)
@@ -2069,7 +2069,7 @@ let pmap2 ~devices ?in_axes ?(donate = false) (module P : Nx.Ptree.S)
       replay ~donate (module P) (module Q) c params
     end
 
-let pmap (type c d) ~devices ?in_axes ?donate (module P : Nx.Ptree.S)
+let pmap (type p c d) ~devices ?in_axes ?donate (module P : Nx.Ptree.S with type t = p)
     (f : P.t -> (c, d) Nx_effect.t) : P.t -> (c, d) Nx_effect.t =
   let module Q = struct
     type t = (c, d) Nx_effect.t

--- a/packages/rune/lib/rune.ml
+++ b/packages/rune/lib/rune.ml
@@ -45,7 +45,7 @@ let require_float_leaf name leaf =
 
 (* Run [f params] under the reverse handler with the leaves of [params] tracked,
    seed the output cotangent, and pull gradients back to the leaves. *)
-let run_reverse (type c d) (module P : Ptree.S) (f : P.t -> (c, d) Nx.t)
+let run_reverse (type p c d) (module P : Ptree.S with type t = p) (f : P.t -> (c, d) Nx.t)
     (params : P.t) ~(seed : (c, d) Nx.t -> (c, d) Nx.t) : (c, d) Nx.t * P.t =
   let tape = Tape.create () in
   P.iter (fun leaf -> if differentiable_leaf leaf then Tape.track tape leaf) params;
@@ -54,7 +54,7 @@ let run_reverse (type c d) (module P : Ptree.S) (f : P.t -> (c, d) Nx.t)
   Tape.backward tape;
   (y, P.map (fun leaf -> Tape.cotangent tape leaf) params)
 
-let value_and_grad (type c d) (module P : Ptree.S) (f : P.t -> (c, d) Nx.t)
+let value_and_grad (type p c d) (module P : Ptree.S with type t = p) (f : P.t -> (c, d) Nx.t)
     (params : P.t) : (c, d) Nx.t * P.t =
   let y, grads =
     run_reverse
@@ -66,11 +66,11 @@ let value_and_grad (type c d) (module P : Ptree.S) (f : P.t -> (c, d) Nx.t)
   in
   (y, grads)
 
-let grad (type c d) (module P : Ptree.S) (f : P.t -> (c, d) Nx.t) (params : P.t)
+let grad (type c d) (module P : Ptree.S with type t = p) (f : P.t -> (c, d) Nx.t) (params : P.t)
     : P.t =
   snd (value_and_grad (module P) f params)
 
-let value_and_grad_aux (type c d) (module P : Ptree.S)
+let value_and_grad_aux (type p c d) (module P : Ptree.S with type t = p)
     (f : P.t -> (c, d) Nx.t * 'aux) (params : P.t) : (c, d) Nx.t * P.t * 'aux =
   let aux = ref None in
   let f' ps =
@@ -83,7 +83,7 @@ let value_and_grad_aux (type c d) (module P : Ptree.S)
   | Some a -> (y, grads, a)
   | None -> assert false (* [f'] completed, so [aux] was set. *)
 
-let vjp (type c d) (module P : Ptree.S) (f : P.t -> (c, d) Nx.t) (params : P.t)
+let vjp (type p c d) (module P : Ptree.S with type t = p) (f : P.t -> (c, d) Nx.t) (params : P.t)
     (cotangent : (c, d) Nx.t) : (c, d) Nx.t * P.t =
   run_reverse (module P) f params ~seed:(fun _ -> cotangent)
 
@@ -94,7 +94,7 @@ let err_cotangent_shape leaf cotangent =
        (shape_string (Nx.shape cotangent))
        (shape_string (Nx.shape leaf)))
 
-let vjp2 (module P : Ptree.S) (module Q : Ptree.S) (f : P.t -> Q.t)
+let vjp2 (type p q) (module P : Ptree.S with type t = p) (module Q : Ptree.S with type t = q) (f : P.t -> Q.t)
     (params : P.t) (cotangents : Q.t) : Q.t * P.t =
   let tape = Tape.create () in
   P.iter (fun leaf -> if differentiable_leaf leaf then Tape.track tape leaf) params;
@@ -110,7 +110,7 @@ let vjp2 (module P : Ptree.S) (module Q : Ptree.S) (f : P.t -> Q.t)
   Tape.backward tape;
   (y, P.map (fun leaf -> Tape.cotangent tape leaf) params)
 
-let vjp_fun (type c d) (module P : Ptree.S) (f : P.t -> (c, d) Nx.t)
+let vjp_fun (type p c d) (module P : Ptree.S with type t = p) (f : P.t -> (c, d) Nx.t)
     (params : P.t) : (c, d) Nx.t * ((c, d) Nx.t -> P.t) =
   let tape = Tape.create () in
   P.iter (fun leaf -> if differentiable_leaf leaf then Tape.track tape leaf) params;
@@ -154,7 +154,7 @@ let err_tangent_shape name leaf tangent =
 let output_tangent store y =
   match Tensor_map.find store y with Some dy -> dy | None -> Nx.zeros_like y
 
-let jvp (type c d) (module P : Ptree.S) (f : P.t -> (c, d) Nx.t) (params : P.t)
+let jvp (type p c d) (module P : Ptree.S with type t = p) (f : P.t -> (c, d) Nx.t) (params : P.t)
     (tangents : P.t) : (c, d) Nx.t * (c, d) Nx.t =
   let store = Tensor_map.create () in
   let (_ : P.t) =
@@ -169,7 +169,7 @@ let jvp (type c d) (module P : Ptree.S) (f : P.t -> (c, d) Nx.t) (params : P.t)
   let y = run_transform f params (Forward.handler store) in
   (y, output_tangent store y)
 
-let jvp_aux (type c d) (module P : Ptree.S) (f : P.t -> (c, d) Nx.t * 'aux)
+let jvp_aux (type p c d) (module P : Ptree.S with type t = p) (f : P.t -> (c, d) Nx.t * 'aux)
     (params : P.t) (tangents : P.t) : (c, d) Nx.t * (c, d) Nx.t * 'aux =
   let aux = ref None in
   let f' ps =
@@ -182,7 +182,7 @@ let jvp_aux (type c d) (module P : Ptree.S) (f : P.t -> (c, d) Nx.t * 'aux)
   | Some a -> (y, dy, a)
   | None -> assert false (* [f'] completed, so [aux] was set. *)
 
-let jvp2 (module P : Ptree.S) (module Q : Ptree.S) (f : P.t -> Q.t)
+let jvp2 (type p q) (module P : Ptree.S with type t = p) (module Q : Ptree.S with type t = q) (f : P.t -> Q.t)
     (params : P.t) (tangents : P.t) : Q.t * Q.t =
   let store = Tensor_map.create () in
   let (_ : P.t) =
@@ -209,7 +209,7 @@ let broadcast_output st y =
 
 (* Validate in_axes, determine the batch size, move mapped axes to the front and
    mark those leaves: shared by [vmap] and [vmap2]. *)
-let prepare_vmap ?in_axes (module P : Ptree.S) (params : P.t) : Vmap.state * P.t
+let prepare_vmap (type p) ?in_axes (module P : Ptree.S with type t = p) (params : P.t) : Vmap.state * P.t
     =
   let leaves = ref 0 in
   P.iter (fun _ -> incr leaves) params;
@@ -287,13 +287,13 @@ let finalize_vmap st out_axis y =
   let y = broadcast_output st y in
   if out_axis = 0 then y else Nx.moveaxis 0 out_axis y
 
-let vmap (type c d) ?in_axes ?(out_axis = 0) (module P : Ptree.S)
+let vmap (type p c d) ?in_axes ?(out_axis = 0) (module P : Ptree.S with type t = p)
     (f : P.t -> (c, d) Nx.t) (params : P.t) : (c, d) Nx.t =
   let st, params = prepare_vmap ?in_axes (module P) params in
   let y = run_transform f params (Vmap.handler st) in
   finalize_vmap st out_axis y
 
-let vmap2 ?in_axes ?(out_axis = 0) (module P : Ptree.S) (module Q : Ptree.S)
+let vmap2 (type p q) ?in_axes ?(out_axis = 0) (module P : Ptree.S with type t = p) (module Q : Ptree.S with type t = q)
     (f : P.t -> Q.t) (params : P.t) : Q.t =
   let st, params = prepare_vmap ?in_axes (module P) params in
   let y = run_transform f params (Vmap.handler st) in
@@ -341,7 +341,7 @@ let jvp' (type a b c d) (f : (a, b) Nx.t -> (c, d) Nx.t) (x : (a, b) Nx.t)
 
 (* Gradient checkpointing *)
 
-let remat (module P : Ptree.S) (f : P.t -> ('c, 'd) Nx.t) (params : P.t) :
+let remat (type p) (module P : Ptree.S with type t = p) (f : P.t -> ('c, 'd) Nx.t) (params : P.t) :
     ('c, 'd) Nx.t =
   Custom.custom_vjp
     (module P)
@@ -381,7 +381,7 @@ let hessian' (type a b) (f : (a, b) Nx.t -> (a, b) Nx.t) (x : (a, b) Nx.t) :
     (a, b) Nx.t =
   jacfwd' (grad' f) x
 
-let hvp (module P : Ptree.S) (f : P.t -> ('c, 'd) Nx.t) (params : P.t) (v : P.t)
+let hvp (type p) (module P : Ptree.S with type t = p) (f : P.t -> ('c, 'd) Nx.t) (params : P.t) (v : P.t)
     : P.t =
   snd (jvp2 (module P) (module P) (grad (module P) f) params v)
 
@@ -391,7 +391,7 @@ let hvp' (type a b c d) (f : (a, b) Nx.t -> (c, d) Nx.t) (x : (a, b) Nx.t)
 
 (* Gradient checking *)
 
-let check_grads ?(eps = 1e-4) ?(tol = 1e-2) (module P : Ptree.S)
+let check_grads (type p) ?(eps = 1e-4) ?(tol = 1e-2) (module P : Ptree.S with type t = p)
     (f : P.t -> ('c, 'd) Nx.t) (params : P.t) : (unit, string) result =
   let scalar_f64 t = Nx.item [] (Nx.reshape [||] (Nx.cast Nx.float64 t)) in
   let g = grad (module P) f params in

--- a/packages/rune/lib/rune.ml
+++ b/packages/rune/lib/rune.ml
@@ -442,7 +442,8 @@ let check_grads (type p) ?(eps = 1e-4) ?(tol = 1e-2) (module P : Ptree.S with ty
 (* Control flow. Eager implementations with staging-ready signatures: a future
    jit stages these as structured control flow instead of unrolled traces. *)
 
-let scan (module C : Ptree.S) ~(f : C.t -> ('a, 'b) Nx.t -> C.t * ('c, 'd) Nx.t)
+let scan (type p) (module C : Ptree.S with type t = p)
+    ~(f : C.t -> ('a, 'b) Nx.t -> C.t * ('c, 'd) Nx.t)
     ~(init : C.t) (xs : ('a, 'b) Nx.t) : C.t * ('c, 'd) Nx.t =
   let shape = Nx.shape xs in
   if Array.length shape = 0 then
@@ -462,7 +463,8 @@ let cond (pred : (bool, Nx.bool_elt) Nx.t) ~(then_ : unit -> 'r)
     ~(else_ : unit -> 'r) : 'r =
   if Nx.item [] pred then then_ () else else_ ()
 
-let while_loop (module C : Ptree.S) ~(cond : C.t -> (bool, Nx.bool_elt) Nx.t)
+let while_loop (type p) (module C : Ptree.S with type t = p)
+    ~(cond : C.t -> (bool, Nx.bool_elt) Nx.t)
     ~(body : C.t -> C.t) (init : C.t) : C.t =
   let rec go c = if Nx.item [] (cond c) then go (body c) else c in
   go init

--- a/packages/rune/lib/rune.ml
+++ b/packages/rune/lib/rune.ml
@@ -66,7 +66,7 @@ let value_and_grad (type p c d) (module P : Ptree.S with type t = p) (f : P.t ->
   in
   (y, grads)
 
-let grad (type c d) (module P : Ptree.S with type t = p) (f : P.t -> (c, d) Nx.t) (params : P.t)
+let grad (type p c d) (module P : Ptree.S with type t = p) (f : P.t -> (c, d) Nx.t) (params : P.t)
     : P.t =
   snd (value_and_grad (module P) f params)
 

--- a/packages/rune/lib/rune.mli
+++ b/packages/rune/lib/rune.mli
@@ -571,11 +571,11 @@ val reset_jit_stats : unit -> unit
     {!while_loop} predicates. *)
 
 val scan :
-  (module C : Ptree.S) ->
-  f:(C.t -> ('a, 'b) Nx.t -> C.t * ('c, 'd) Nx.t) ->
-  init:C.t ->
+  (module Ptree.S with type t = 'p) ->
+  f:('p -> ('a, 'b) Nx.t -> 'p * ('c, 'd) Nx.t) ->
+  init:'p ->
   ('a, 'b) Nx.t ->
-  C.t * ('c, 'd) Nx.t
+  'p * ('c, 'd) Nx.t
 (** [scan (module C) ~f ~init xs] folds [f] over slices of [xs] along axis 0:
     [f carry x] returns the next carry and a per-step output. The result is the
     final carry and the outputs stacked along a new axis 0. Differentiating
@@ -590,8 +590,8 @@ val cond :
     on the mapped inputs raises, since the lanes could diverge. *)
 
 val while_loop :
-  (module C : Ptree.S) ->
-  cond:(C.t -> (bool, Nx.bool_elt) Nx.t) -> body:(C.t -> C.t) -> C.t -> C.t
+  (module Ptree.S with type t = 'p) ->
+  cond:('p -> (bool, Nx.bool_elt) Nx.t) -> body:('p -> 'p) -> 'p -> 'p
 (** [while_loop (module C) ~cond ~body init] iterates [body] on the carry while
     [cond] holds. Reading the predicate concretizes it, with the same
     {!val-vmap} caveat as {!cond}. Differentiating traces every iteration

--- a/packages/rune/lib/rune.mli
+++ b/packages/rune/lib/rune.mli
@@ -42,7 +42,7 @@ module Ptree = Nx.Ptree
 
 (** {1:reverse Reverse-mode differentiation} *)
 
-val grad : (module P : Ptree.S) -> (P.t -> ('c, 'd) Nx.t) -> P.t -> P.t
+val grad : (module Ptree.S with type t = 'p) -> ('p -> ('c, 'd) Nx.t) -> 'p -> 'p
 (** [grad (module P) f params] is the gradient of [f] at [params], with the same
     structure and leaf types as [params]. Leaves of [params] that do not
     contribute to the result have all-zero gradients.
@@ -60,29 +60,29 @@ val grad : (module P : Ptree.S) -> (P.t -> ('c, 'd) Nx.t) -> P.t -> P.t
     an explicit cotangent. *)
 
 val value_and_grad :
-  (module P : Ptree.S) -> (P.t -> ('c, 'd) Nx.t) -> P.t -> ('c, 'd) Nx.t * P.t
+  (module Ptree.S with type t = 'p) -> ('p -> ('c, 'd) Nx.t) -> 'p -> ('c, 'd) Nx.t * 'p
 (** [value_and_grad (module P) f params] is
     [(f params, grad (module P) f params)], computed in a single forward and
     backward pass. *)
 
 val value_and_grad_aux :
-  (module P : Ptree.S) ->
-  (P.t -> ('c, 'd) Nx.t * 'aux) -> P.t -> ('c, 'd) Nx.t * P.t * 'aux
+  (module Ptree.S with type t = 'p) ->
+  ('p -> ('c, 'd) Nx.t * 'aux) -> 'p -> ('c, 'd) Nx.t * 'p * 'aux
 (** [value_and_grad_aux (module P) f params] is like {!value_and_grad} for an
     objective returning auxiliary data alongside its result. The auxiliary value
     is returned as-is and does not contribute to the gradient. *)
 
 val vjp :
-  (module P : Ptree.S) ->
-  (P.t -> ('c, 'd) Nx.t) -> P.t -> ('c, 'd) Nx.t -> ('c, 'd) Nx.t * P.t
+  (module Ptree.S with type t = 'p) ->
+  ('p -> ('c, 'd) Nx.t) -> 'p -> ('c, 'd) Nx.t -> ('c, 'd) Nx.t * 'p
 (** [vjp (module P) f params cotangent] is [(f params, grads)] where [grads] is
     the vector-Jacobian product of [f] at [params] against [cotangent], with the
     same structure and leaf types as [params]. [cotangent] must have
     [f params]'s shape and dtype. *)
 
 val vjp2 :
-  (module P : Ptree.S) ->
-  (module Q : Ptree.S) -> (P.t -> Q.t) -> P.t -> Q.t -> Q.t * P.t
+  (module Ptree.S with type t = 'p) ->
+  (module Ptree.S with type t = 'q) -> ('p -> 'q) -> 'p -> 'q -> 'q * 'p
 (** [vjp2 (module P) (module Q) f params cotangents] is like {!vjp} for an
     objective returning a structured output: [cotangents] provides one cotangent
     per output leaf, each with its output leaf's shape and dtype, and the
@@ -92,8 +92,8 @@ val vjp2 :
     output leaf's shape. *)
 
 val vjp_fun :
-  (module P : Ptree.S) ->
-  (P.t -> ('c, 'd) Nx.t) -> P.t -> ('c, 'd) Nx.t * (('c, 'd) Nx.t -> P.t)
+  (module Ptree.S with type t = 'p) ->
+  ('p -> ('c, 'd) Nx.t) -> 'p -> ('c, 'd) Nx.t * (('c, 'd) Nx.t -> 'p)
 (** [vjp_fun (module P) f params] is [(f params, pullback)]. [pullback ct] is
     the vector-Jacobian product of [f] at [params] against [ct]; it may be
     called any number of times with different cotangents, each call running one
@@ -112,8 +112,8 @@ val vjp_fun' :
 (** {1:forward Forward-mode differentiation} *)
 
 val jvp :
-  (module P : Ptree.S) ->
-  (P.t -> ('c, 'd) Nx.t) -> P.t -> P.t -> ('c, 'd) Nx.t * ('c, 'd) Nx.t
+  (module Ptree.S with type t = 'p) ->
+  ('p -> ('c, 'd) Nx.t) -> 'p -> 'p -> ('c, 'd) Nx.t * ('c, 'd) Nx.t
 (** [jvp (module P) f params tangents] is [(f params, df)] where [df] is the
     Jacobian-vector product of [f] at [params] against [tangents], computed in a
     single forward pass. [tangents] must be structurally equal to [params]; each
@@ -124,18 +124,18 @@ val jvp :
     parameter leaf's shape. *)
 
 val jvp_aux :
-  (module P : Ptree.S) ->
-  (P.t -> ('c, 'd) Nx.t * 'aux) ->
-  P.t ->
-  P.t ->
+  (module Ptree.S with type t = 'p) ->
+  ('p -> ('c, 'd) Nx.t * 'aux) ->
+  'p ->
+  'p ->
   ('c, 'd) Nx.t * ('c, 'd) Nx.t * 'aux
 (** [jvp_aux (module P) f params tangents] is like {!jvp} for an objective
     returning auxiliary data alongside its result. The auxiliary value is
     returned as-is and does not contribute to the tangent. *)
 
 val jvp2 :
-  (module P : Ptree.S) ->
-  (module Q : Ptree.S) -> (P.t -> Q.t) -> P.t -> P.t -> Q.t * Q.t
+  (module Ptree.S with type t = 'p) ->
+  (module Ptree.S with type t = 'q) -> ('p -> 'q) -> 'p -> 'p -> 'q * 'q
 (** [jvp2 (module P) (module Q) f params tangents] is like {!jvp} for an
     objective returning a structured output: the result tangent has the output's
     structure, one tangent per output leaf. *)
@@ -178,7 +178,7 @@ val jvp2 :
 val vmap :
   ?in_axes:int option list ->
   ?out_axis:int ->
-  (module P : Ptree.S) -> (P.t -> ('c, 'd) Nx.t) -> P.t -> ('c, 'd) Nx.t
+  (module Ptree.S with type t = 'p) -> ('p -> ('c, 'd) Nx.t) -> 'p -> ('c, 'd) Nx.t
 (** [vmap ?in_axes ?out_axis (module P) f params] maps [f] over the tensor
     leaves of [params]. [f] is written for unbatched values: it observes each
     mapped leaf without its mapped axis, and its result gains a batch axis at
@@ -209,7 +209,7 @@ val vmap :
 val vmap2 :
   ?in_axes:int option list ->
   ?out_axis:int ->
-  (module P : Ptree.S) -> (module Q : Ptree.S) -> (P.t -> Q.t) -> P.t -> Q.t
+  (module Ptree.S with type t = 'p) -> (module Ptree.S with type t = 'q) -> ('p -> 'q) -> 'p -> 'q
 (** [vmap2 ?in_axes ?out_axis (module P) (module Q) f params] is like
     {!val-vmap} for a mapped function returning a structured output: every
     output leaf gains a batch axis at [out_axis], and output leaves that do not
@@ -228,10 +228,10 @@ val vmap' :
 (** {1:custom Custom differentiation rules} *)
 
 val custom_vjp :
-  (module P : Ptree.S) ->
-  fwd:(P.t -> ('c, 'd) Nx.t * 'res) ->
-  bwd:('res -> ('c, 'd) Nx.t -> P.t) ->
-  P.t ->
+  (module Ptree.S with type t = 'p) ->
+  fwd:('p -> ('c, 'd) Nx.t * 'res) ->
+  bwd:('res -> ('c, 'd) Nx.t -> 'p) ->
+  'p ->
   ('c, 'd) Nx.t
 (** [custom_vjp (module P) ~fwd ~bwd params] is [fst (fwd params)], with a
     user-defined reverse rule. Under the innermost reverse-mode transformation,
@@ -245,10 +245,10 @@ val custom_vjp :
     define a {!custom_jvp} rule for that. *)
 
 val custom_jvp :
-  (module P : Ptree.S) ->
-  f:(P.t -> ('c, 'd) Nx.t) ->
-  jvp:(P.t -> P.t -> ('c, 'd) Nx.t * ('c, 'd) Nx.t) ->
-  P.t ->
+  (module Ptree.S with type t = 'p) ->
+  f:('p -> ('c, 'd) Nx.t) ->
+  jvp:('p -> 'p -> ('c, 'd) Nx.t * ('c, 'd) Nx.t) ->
+  'p ->
   ('c, 'd) Nx.t
 (** [custom_jvp (module P) ~f ~jvp params] is [f params], with a user-defined
     forward rule. Under the innermost forward-mode transformation,
@@ -287,7 +287,7 @@ val jvp' :
 (** {1:remat Gradient checkpointing} *)
 
 val remat :
-  (module P : Ptree.S) -> (P.t -> ('c, 'd) Nx.t) -> P.t -> ('c, 'd) Nx.t
+  (module Ptree.S with type t = 'p) -> ('p -> ('c, 'd) Nx.t) -> 'p -> ('c, 'd) Nx.t
 (** [remat (module P) f params] is [f params], recomputed during the backward
     pass instead of having its intermediate results retained by the tape:
     reverse-mode differentiation of a [remat]ed function trades compute for
@@ -315,7 +315,7 @@ val hessian' :
 (** [hessian' f x] is the Hessian of the scalar objective [f] at [x], with shape
     [shape x @ shape x] (forward over reverse). *)
 
-val hvp : (module P : Ptree.S) -> (P.t -> ('c, 'd) Nx.t) -> P.t -> P.t -> P.t
+val hvp : (module Ptree.S with type t = 'p) -> ('p -> ('c, 'd) Nx.t) -> 'p -> 'p -> 'p
 (** [hvp (module P) f params v] is the Hessian-vector product of the scalar
     objective [f] at [params] against [v], with [params]' structure, computed
     without materializing the Hessian (forward over reverse). *)
@@ -332,7 +332,7 @@ val hvp' :
 val check_grads :
   ?eps:float ->
   ?tol:float ->
-  (module P : Ptree.S) -> (P.t -> ('c, 'd) Nx.t) -> P.t -> (unit, string) result
+  (module Ptree.S with type t = 'p) -> ('p -> ('c, 'd) Nx.t) -> 'p -> (unit, string) result
 (** [check_grads (module P) f params] compares the reverse-mode gradient of the
     scalar objective [f] at [params] against central-difference directional
     derivatives along deterministic directions. [Ok ()] means they agree within
@@ -375,7 +375,7 @@ exception Jit_error of string
 val jit :
   ?device:string ->
   ?donate:bool ->
-  (module P : Ptree.S) -> (P.t -> ('c, 'd) Nx.t) -> P.t -> ('c, 'd) Nx.t
+  (module Ptree.S with type t = 'p) -> ('p -> ('c, 'd) Nx.t) -> 'p -> ('c, 'd) Nx.t
 (** [jit (module P) f] is [f] compiled. The first application traces [f],
     compiles the traced computation into fused kernels, and runs them; later
     applications with the same leaf signature — dtypes and shapes, in traversal
@@ -482,7 +482,7 @@ val jit :
 val jit2 :
   ?device:string ->
   ?donate:bool ->
-  (module P : Ptree.S) -> (module Q : Ptree.S) -> (P.t -> Q.t) -> P.t -> Q.t
+  (module Ptree.S with type t = 'p) -> (module Ptree.S with type t = 'q) -> ('p -> 'q) -> 'p -> 'q
 (** [jit2 (module P) (module Q) f] is like {!val-jit} for a function returning a
     structured output. *)
 
@@ -498,7 +498,7 @@ val pmap :
   devices:string list ->
   ?in_axes:int option list ->
   ?donate:bool ->
-  (module P : Ptree.S) -> (P.t -> ('c, 'd) Nx.t) -> P.t -> ('c, 'd) Nx.t
+  (module Ptree.S with type t = 'p) -> ('p -> ('c, 'd) Nx.t) -> 'p -> ('c, 'd) Nx.t
 (** [pmap ~devices (module P) f] is [f] compiled to run in parallel across
     [devices] — {!val-jit} whose inputs are placed on a device tuple instead of
     one device. Device names are as in {!val-jit}, with an instance suffix to
@@ -541,7 +541,7 @@ val pmap2 :
   devices:string list ->
   ?in_axes:int option list ->
   ?donate:bool ->
-  (module P : Ptree.S) -> (module Q : Ptree.S) -> (P.t -> Q.t) -> P.t -> Q.t
+  (module Ptree.S with type t = 'p) -> (module Ptree.S with type t = 'q) -> ('p -> 'q) -> 'p -> 'q
 (** [pmap2 (module P) (module Q) f] is like {!val-pmap} for a function returning
     a structured output. *)
 

--- a/packages/rune/test/dune
+++ b/packages/rune/test/dune
@@ -14,7 +14,7 @@
   test_pmap
   test_rng
   test_half
-  test_gtree)
+  test_uniform)
  (modules
   test_grad
   test_ops
@@ -30,7 +30,7 @@
   test_pmap
   test_rng
   test_half
-  test_gtree)
+  test_uniform)
  (package rune)
  (libraries rune nx nx.core unix windtrap rune_test_support))
 

--- a/packages/rune/test/dune
+++ b/packages/rune/test/dune
@@ -13,7 +13,8 @@
   test_jit
   test_pmap
   test_rng
-  test_half)
+  test_half
+  test_gtree)
  (modules
   test_grad
   test_ops
@@ -28,7 +29,8 @@
   test_jit
   test_pmap
   test_rng
-  test_half)
+  test_half
+  test_gtree)
  (package rune)
  (libraries rune nx nx.core unix windtrap rune_test_support))
 

--- a/packages/rune/test/test_gtree.ml
+++ b/packages/rune/test/test_gtree.ml
@@ -1,0 +1,102 @@
+(*---------------------------------------------------------------------------
+  Copyright (c) 2026 The Raven authors. All rights reserved.
+  SPDX-License-Identifier: ISC
+  ---------------------------------------------------------------------------*)
+
+(* Gtree → Ptree.S bridge: differentiation and JIT through Tensor_tree. *)
+
+open Windtrap
+open Rune_test_support.Support
+
+(* Hand-written gtree, copied from nx test so this test is self-contained (the
+   ppx Phase 1 will eliminate the duplication). *)
+module U = struct
+  type 'a t = { w : 'a; b : 'a }
+
+  let map (f : 'a -> 'b) { w; b } = { w = f w; b = f b }
+  let map2 (f : 'a -> 'b -> 'c) a b = { w = f a.w b.w; b = f a.b b.b }
+
+  let iter (f : 'a -> unit) { w; b } =
+    f w;
+    f b
+
+  let fold (f : string -> 'acc -> 'a -> 'acc) acc { w; b } =
+    f "b" (f "w" acc w) b
+
+  let fold2 (f : string -> 'acc -> 'a -> 'b -> 'acc) acc a b =
+    f "b" (f "w" acc a.w b.w) a.b b.b
+end
+
+module T = Nx.Ptree.Tensor_tree (U)
+
+let pack x = Nx.Ptree.P x
+
+let params () =
+  { U.w = pack (vec32 [| 1.0; -2.0; 3.0 |]); b = pack (vec32 [| 0.5 |]) }
+
+(* Loss: sum(w^2) + 2*sum(b). Scalar output to use Rune.grad. *)
+let loss (t : T.t) : Nx.float32_t =
+  let { U.w = Nx.Ptree.P w; b = Nx.Ptree.P b } = t in
+  let w = as_f32 w and b = as_f32 b in
+  Nx.add (Nx.sum (Nx.mul w w)) (Nx.mul_s (Nx.sum b) 3.0)
+
+let test_grad_over_gtree () =
+  let p : T.t = params () in
+  let g = Rune.grad (module T) loss p in
+  match g with
+  | { U.w = Nx.Ptree.P gw; b = Nx.Ptree.P gb } ->
+      check_arr ~msg:"dw" [| 2.0; -4.0; 6.0 |] (as_f32 gw);
+      check_arr ~msg:"db" [| 3.0 |] (as_f32 gb)
+
+let test_value_and_grad () =
+  let p : T.t = params () in
+  let v, g = Rune.value_and_grad (module T) loss p in
+  (* loss = 1+4+9 + 3*0.5 = 14 + 1.5 = 15.5 *)
+  equal ~msg:"value" (float 1e-5) 15.5 (scalar v);
+  match g with
+  | { U.w = Nx.Ptree.P gw; _ } ->
+      check_arr ~msg:"dw" [| 2.0; -4.0; 6.0 |] (as_f32 gw)
+
+let test_jit_cache () =
+  let p : T.t = params () in
+  let f_jit = Rune.jit (module T) loss in
+  let v1 = f_jit p in
+  let v2 = f_jit p in
+  equal ~msg:"cached jit" (float 1e-5) 15.5 (scalar v1);
+  equal ~msg:"cached jit again" (float 1e-5) 15.5 (scalar v2)
+
+let test_gtree_fold_paths_in_grad () =
+  (* Fold over the gradient tree with paths, verifying the paths are the same as
+     the gtree's fold would give. *)
+  let g = Rune.grad (module T) loss (params ()) in
+  let paths = ref [] in
+  let _ =
+    U.fold
+      (fun path acc _ ->
+        paths := path :: !paths;
+        acc)
+      0 g
+  in
+  let paths = List.rev !paths in
+  equal ~msg:"leaf count" int 2 (List.length paths);
+  equal ~msg:"first path" string "w" (List.nth paths 0);
+  equal ~msg:"second path" string "b" (List.nth paths 1)
+
+let tests =
+  [
+    group "differentiation"
+      [
+        test "grad works over a gtree-backed Tensor_tree" test_grad_over_gtree;
+        test "value_and_grad returns correct value and gradient"
+          test_value_and_grad;
+      ];
+    group "JIT"
+      [ test "jit-cached loss function returns correct values" test_jit_cache ];
+    group "fold"
+      [
+        test "fold over gradient tree produces correct paths"
+          test_gtree_fold_paths_in_grad;
+      ];
+  ]
+
+let () = run "rune gtree" tests

--- a/packages/rune/test/test_ptree.ml
+++ b/packages/rune/test/test_ptree.ml
@@ -19,14 +19,14 @@ let tree () =
 
 let test_map_preserves_structure () =
   match P.map (fun t -> Nx.mul t t) (tree ()) with
-  | P.Dict [ ("w", P.Tensor (P.P w)); ("b", P.Tensor (P.P b)) ] ->
+  | P.Tree.Dict [ ("w", P.Tree.Leaf (P.P w)); ("b", P.Tree.Leaf (P.P b)) ] ->
       check_arr ~msg:"w" [| 1.0; 4.0; 9.0 |] (as_f32 w);
       check_arr ~msg:"b" [| 0.25 |] (as_f32 b)
   | _ -> fail "map changed the tree structure"
 
 let test_map2_combines_leafwise () =
   match P.map2 (fun a b -> Nx.add a b) (tree ()) (tree ()) with
-  | P.Dict [ ("w", P.Tensor (P.P w)); _ ] ->
+  | P.Tree.Dict [ ("w", P.Tree.Leaf (P.P w)); _ ] ->
       check_arr ~msg:"w" [| 2.0; -4.0; 6.0 |] (as_f32 w)
   | _ -> fail "map2 changed the tree structure"
 
@@ -53,14 +53,14 @@ let test_map2_dtype_mismatch () =
 let test_grad_over_ptree () =
   let f tree =
     match tree with
-    | P.Dict [ ("w", P.Tensor (P.P w)); ("b", P.Tensor (P.P b)) ] ->
+    | P.Tree.Dict [ ("w", P.Tree.Leaf (P.P w)); ("b", P.Tree.Leaf (P.P b)) ] ->
         let w = as_f32 w and b = as_f32 b in
         Nx.add (Nx.sum (Nx.mul w w)) (Nx.mul_s (Nx.sum b) 3.0)
     | _ -> assert false
   in
   let g = Rune.grad (module P) f (tree ()) in
   match g with
-  | P.Dict [ ("w", P.Tensor (P.P gw)); ("b", P.Tensor (P.P gb)) ] ->
+  | P.Tree.Dict [ ("w", P.Tree.Leaf (P.P gw)); ("b", P.Tree.Leaf (P.P gb)) ] ->
       check_arr ~msg:"dw" [| 2.0; -4.0; 6.0 |] (as_f32 gw);
       check_arr ~msg:"db" [| 3.0 |] (as_f32 gb)
   | _ -> fail "gradient tree does not match parameter tree structure"

--- a/packages/rune/test/test_uniform.ml
+++ b/packages/rune/test/test_uniform.ml
@@ -86,7 +86,8 @@ let tests =
   [
     group "differentiation"
       [
-        test "grad works over a uniform-backed Ptree.Make" test_grad_over_uniform;
+        test "grad works over a uniform-backed Ptree.Make"
+          test_grad_over_uniform;
         test "value_and_grad returns correct value and gradient"
           test_value_and_grad;
       ];

--- a/packages/rune/test/test_uniform.ml
+++ b/packages/rune/test/test_uniform.ml
@@ -84,6 +84,19 @@ let test_uniform_fold_paths_in_grad () =
   equal ~msg:"first path" string "w" (List.nth paths 0);
   equal ~msg:"second path" string "b" (List.nth paths 1)
 
+(* Typed instance via Ptree.typed: leaves stay typed, no packing. *)
+
+let typed_params () = { U.w = vec32 [| 1.0; -2.0; 3.0 |]; b = vec32 [| 0.5 |] }
+
+let typed_loss (t : Nx.float32_t U.t) : Nx.float32_t =
+  Nx.add (Nx.sum (Nx.mul t.U.w t.U.w)) (Nx.mul_s (Nx.sum t.U.b) 3.0)
+
+let test_grad_through_typed () =
+  let u = Nx.Ptree.typed (module U) in
+  let g = Rune.grad u typed_loss (typed_params ()) in
+  check_arr ~msg:"dw" [| 2.0; -4.0; 6.0 |] g.U.w;
+  check_arr ~msg:"db" [| 3.0 |] g.U.b
+
 let tests =
   [
     group "differentiation"
@@ -92,6 +105,7 @@ let tests =
           test_grad_over_uniform;
         test "value_and_grad returns correct value and gradient"
           test_value_and_grad;
+        test "grad works over a typed uniform instance" test_grad_through_typed;
       ];
     group "JIT"
       [ test "jit-cached loss function returns correct values" test_jit_cache ];

--- a/packages/rune/test/test_uniform.ml
+++ b/packages/rune/test/test_uniform.ml
@@ -84,7 +84,7 @@ let test_uniform_fold_paths_in_grad () =
   equal ~msg:"first path" string "w" (List.nth paths 0);
   equal ~msg:"second path" string "b" (List.nth paths 1)
 
-(* Typed instance via Ptree.typed: leaves stay typed, no packing. *)
+(* Typed instance via Ptree.instantiate: leaves stay typed, no packing. *)
 
 let typed_params () = { U.w = vec32 [| 1.0; -2.0; 3.0 |]; b = vec32 [| 0.5 |] }
 
@@ -92,7 +92,7 @@ let typed_loss (t : Nx.float32_t U.t) : Nx.float32_t =
   Nx.add (Nx.sum (Nx.mul t.U.w t.U.w)) (Nx.mul_s (Nx.sum t.U.b) 3.0)
 
 let test_grad_through_typed () =
-  let u = Nx.Ptree.typed (module U) in
+  let u = Nx.Ptree.instantiate (module U) in
   let g = Rune.grad u typed_loss (typed_params ()) in
   check_arr ~msg:"dw" [| 2.0; -4.0; 6.0 |] g.U.w;
   check_arr ~msg:"db" [| 3.0 |] g.U.b

--- a/packages/rune/test/test_uniform.ml
+++ b/packages/rune/test/test_uniform.ml
@@ -3,13 +3,13 @@
   SPDX-License-Identifier: ISC
   ---------------------------------------------------------------------------*)
 
-(* Gtree → Ptree.S bridge: differentiation and JIT through Tensor_tree. *)
+(* Uniform → Ptree.S bridge: differentiation and JIT through Ptree.Make. *)
 
 open Windtrap
 open Rune_test_support.Support
 
-(* Hand-written gtree, copied from nx test so this test is self-contained (the
-   ppx Phase 1 will eliminate the duplication). *)
+(* Hand-written uniform structure, copied from the nx test so this test is
+   self-contained. *)
 module U = struct
   type 'a t = { w : 'a; b : 'a }
 
@@ -27,7 +27,7 @@ module U = struct
     f "b" (f "w" acc a.w b.w) a.b b.b
 end
 
-module T = Nx.Ptree.Tensor_tree (U)
+module T = Nx.Ptree.Make (U)
 
 let pack x = Nx.Ptree.P x
 
@@ -40,7 +40,7 @@ let loss (t : T.t) : Nx.float32_t =
   let w = as_f32 w and b = as_f32 b in
   Nx.add (Nx.sum (Nx.mul w w)) (Nx.mul_s (Nx.sum b) 3.0)
 
-let test_grad_over_gtree () =
+let test_grad_over_uniform () =
   let p : T.t = params () in
   let g = Rune.grad (module T) loss p in
   match g with
@@ -65,9 +65,9 @@ let test_jit_cache () =
   equal ~msg:"cached jit" (float 1e-5) 15.5 (scalar v1);
   equal ~msg:"cached jit again" (float 1e-5) 15.5 (scalar v2)
 
-let test_gtree_fold_paths_in_grad () =
+let test_uniform_fold_paths_in_grad () =
   (* Fold over the gradient tree with paths, verifying the paths are the same as
-     the gtree's fold would give. *)
+     the structure's own fold would give. *)
   let g = Rune.grad (module T) loss (params ()) in
   let paths = ref [] in
   let _ =
@@ -86,7 +86,7 @@ let tests =
   [
     group "differentiation"
       [
-        test "grad works over a gtree-backed Tensor_tree" test_grad_over_gtree;
+        test "grad works over a uniform-backed Ptree.Make" test_grad_over_uniform;
         test "value_and_grad returns correct value and gradient"
           test_value_and_grad;
       ];
@@ -95,8 +95,8 @@ let tests =
     group "fold"
       [
         test "fold over gradient tree produces correct paths"
-          test_gtree_fold_paths_in_grad;
+          test_uniform_fold_paths_in_grad;
       ];
   ]
 
-let () = run "rune gtree" tests
+let () = run "rune uniform" tests

--- a/packages/rune/test/test_uniform.ml
+++ b/packages/rune/test/test_uniform.ml
@@ -25,6 +25,8 @@ module U = struct
 
   let fold2 (f : string -> 'acc -> 'a -> 'b -> 'acc) acc a b =
     f "b" (f "w" acc a.w b.w) a.b b.b
+
+  let names _ = { w = "w"; b = "b" }
 end
 
 module T = Nx.Ptree.Make (U)

--- a/packages/vega/doc/04-optax-comparison.md
+++ b/packages/vega/doc/04-optax-comparison.md
@@ -119,6 +119,6 @@ let tx =
 | Learning rate | Float or schedule | Always `Schedule.t` (`int -> float`) |
 | Weight decay rate | Float | `Schedule.t` (dynamic decay) |
 | Noise eta | Float | `Schedule.t` (dynamic noise) |
-| Gradient clipping | Global norm across all params | Per-tensor norm |
-| Parameter trees | Built-in (JAX pytrees) | Handled by Kaun's `Ptree.t` |
+| Gradient clipping | Global norm across all params | Per-tensor `clip_by_norm`; structural `clip_by_global_norm` |
+| Parameter trees | Built-in (JAX pytrees) | Structural steps (`adam_step`, ...) over any `Nx.Ptree.S` structure |
 | `centralize` | Function call `centralize()` | Value `centralize` (no arguments) |

--- a/packages/vega/lib/vega.ml
+++ b/packages/vega/lib/vega.ml
@@ -734,7 +734,7 @@ let state_of_tensors tx ~count tensors =
 
 (* Gradient transformations *)
 
-let global_norm (module P : Nx.Ptree.S) (grads : P.t) : float =
+let global_norm (type p) (module P : Nx.Ptree.S with type t = p) (grads : P.t) : float =
   let acc = ref 0.0 in
   P.iter
     (fun g ->
@@ -742,7 +742,7 @@ let global_norm (module P : Nx.Ptree.S) (grads : P.t) : float =
     grads;
   Stdlib.sqrt !acc
 
-let clip_by_global_norm (module P : Nx.Ptree.S) ~max_norm (grads : P.t) : P.t =
+let clip_by_global_norm (type p) (module P : Nx.Ptree.S with type t = p) ~max_norm (grads : P.t) : P.t =
   validate_positive "Vega.clip_by_global_norm" "max_norm" max_norm;
   let norm = global_norm (module P) grads in
   if norm <= max_norm then grads
@@ -750,7 +750,7 @@ let clip_by_global_norm (module P : Nx.Ptree.S) ~max_norm (grads : P.t) : P.t =
     let c = max_norm /. norm in
     P.map (fun g -> Nx.mul g (scalar (Nx.dtype g) c)) grads
 
-let clip_by_value (module P : Nx.Ptree.S) ~max (grads : P.t) : P.t =
+let clip_by_value (type p) (module P : Nx.Ptree.S with type t = p) ~max (grads : P.t) : P.t =
   validate_positive "Vega.clip_by_value" "max" max;
   P.map
     (fun g ->
@@ -788,10 +788,10 @@ module Loss_scale = struct
 
   let scale t x = Nx.mul x (Nx.cast (Nx.dtype x) t.scale)
 
-  let unscale (module P : Nx.Ptree.S) t (grads : P.t) : P.t =
+  let unscale (type p) (module P : Nx.Ptree.S with type t = p) t (grads : P.t) : P.t =
     P.map (fun g -> Nx.div g (Nx.cast (Nx.dtype g) t.scale)) grads
 
-  let grads_finite (module P : Nx.Ptree.S) (grads : P.t) =
+  let grads_finite (type p) (module P : Nx.Ptree.S with type t = p) (grads : P.t) =
     let acc = ref (Nx.scalar Nx.bool true) in
     P.iter (fun g -> acc := Nx.logical_and !acc (Nx.all (Nx.isfinite g))) grads;
     !acc
@@ -821,10 +821,10 @@ end
 
 type 'p sgd_state = { velocity : 'p }
 
-let sgd_init (module P : Nx.Ptree.S) (params : P.t) : P.t sgd_state =
+let sgd_init (type p) (module P : Nx.Ptree.S with type t = p) (params : P.t) : P.t sgd_state =
   { velocity = P.map (fun leaf -> Nx.zeros_like leaf) params }
 
-let sgd_step (module P : Nx.Ptree.S) ~lr ?(momentum = 0.0) (st : P.t sgd_state)
+let sgd_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr ?(momentum = 0.0) (st : P.t sgd_state)
     ~(params : P.t) ~(grads : P.t) : P.t * P.t sgd_state =
   let velocity =
     (* Plain gradient descent: the velocity is exactly the gradient. Skipping
@@ -850,13 +850,13 @@ let sgd_step (module P : Nx.Ptree.S) ~lr ?(momentum = 0.0) (st : P.t sgd_state)
 
 type 'p adam_state = { mu : 'p; nu : 'p; step : int }
 
-let adam_init (module P : Nx.Ptree.S) (params : P.t) : P.t adam_state =
+let adam_init (type p) (module P : Nx.Ptree.S with type t = p) (params : P.t) : P.t adam_state =
   let zeros () = P.map (fun leaf -> Nx.zeros_like leaf) params in
   { mu = zeros (); nu = zeros (); step = 0 }
 
 (* Advances the moments and computes the bias-corrected update direction shared
    by [adam_step] and [adamw_step]. *)
-let adam_direction (module P : Nx.Ptree.S) ~b1 ~b2 ~eps (st : P.t adam_state)
+let adam_direction (type p) (module P : Nx.Ptree.S with type t = p) ~b1 ~b2 ~eps (st : P.t adam_state)
     ~(grads : P.t) : P.t * P.t adam_state =
   let step = st.step + 1 in
   let mu =
@@ -894,7 +894,7 @@ let adam_direction (module P : Nx.Ptree.S) ~b1 ~b2 ~eps (st : P.t adam_state)
   in
   (direction, { mu; nu; step })
 
-let adam_step (module P : Nx.Ptree.S) ~lr ?(b1 = 0.9) ?(b2 = 0.999)
+let adam_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr ?(b1 = 0.9) ?(b2 = 0.999)
     ?(eps = 1e-8) (st : P.t adam_state) ~(params : P.t) ~(grads : P.t) :
     P.t * P.t adam_state =
   let direction, st = adam_direction (module P) ~b1 ~b2 ~eps st ~grads in
@@ -906,10 +906,10 @@ let adam_step (module P : Nx.Ptree.S) ~lr ?(b1 = 0.9) ?(b2 = 0.999)
   in
   (params, st)
 
-let adamw_init (module P : Nx.Ptree.S) (params : P.t) : P.t adam_state =
+let adamw_init (type p) (module P : Nx.Ptree.S with type t = p) (params : P.t) : P.t adam_state =
   adam_init (module P) params
 
-let adamw_step (module P : Nx.Ptree.S) ~lr ?(b1 = 0.9) ?(b2 = 0.999)
+let adamw_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr ?(b1 = 0.9) ?(b2 = 0.999)
     ?(eps = 1e-8) ?(weight_decay = 0.01) (st : P.t adam_state) ~(params : P.t)
     ~(grads : P.t) : P.t * P.t adam_state =
   let direction, st = adam_direction (module P) ~b1 ~b2 ~eps st ~grads in

--- a/packages/vega/lib/vega.mli
+++ b/packages/vega/lib/vega.mli
@@ -62,12 +62,12 @@ module Schedule = Schedule
     Pure functions on gradient structures, applied between the backward pass and
     the optimizer step. *)
 
-val global_norm : (module P : Nx.Ptree.S) -> P.t -> float
+val global_norm : (module Nx.Ptree.S with type t = 'p) -> 'p -> float
 (** [global_norm (module P) grads] is the L2 norm of all leaves of [grads] taken
     together: [sqrt (sum of every element squared)]. *)
 
 val clip_by_global_norm :
-  (module P : Nx.Ptree.S) -> max_norm:float -> P.t -> P.t
+  (module Nx.Ptree.S with type t = 'p) -> max_norm:float -> 'p -> 'p
 (** [clip_by_global_norm (module P) ~max_norm grads] scales [grads] so that its
     {!global_norm} does not exceed [max_norm]. Gradients within the bound
     (including all-zero gradients) are returned unchanged; larger ones are
@@ -75,7 +75,7 @@ val clip_by_global_norm :
 
     Raises [Invalid_argument] if [max_norm <= 0.]. *)
 
-val clip_by_value : (module P : Nx.Ptree.S) -> max:float -> P.t -> P.t
+val clip_by_value : (module Nx.Ptree.S with type t = 'p) -> max:float -> 'p -> 'p
 (** [clip_by_value (module P) ~max grads] clips every gradient element to the
     interval \[[-. max];[max]\].
 
@@ -133,12 +133,12 @@ module Loss_scale : sig
   (** [scale ls x] is [x] times the current scale, at [x]'s dtype. Apply it to
       the loss, inside the differentiated objective. *)
 
-  val unscale : (module P : Nx.Ptree.S) -> t -> P.t -> P.t
+  val unscale : (module Nx.Ptree.S with type t = 'p) -> t -> 'p -> 'p
   (** [unscale (module P) ls grads] divides every leaf of [grads] by the current
       scale, at the leaf's dtype. Apply it to the gradients before any gradient
       transformation or optimizer step. *)
 
-  val grads_finite : (module P : Nx.Ptree.S) -> P.t -> (bool, Nx.bool_elt) Nx.t
+  val grads_finite : (module Nx.Ptree.S with type t = 'p) -> 'p -> (bool, Nx.bool_elt) Nx.t
   (** [grads_finite (module P) grads] is a scalar boolean tensor: [true] iff
       every element of every leaf of [grads] is finite (no NaN or infinity).
       Feed it to {!adjust} and use it to skip the parameter update of an
@@ -188,18 +188,18 @@ type 'p sgd_state = { velocity : 'p }
 (** The state for {!sgd_step}: the momentum velocity, with the shape of the
     parameters. *)
 
-val sgd_init : (module P : Nx.Ptree.S) -> P.t -> P.t sgd_state
+val sgd_init : (module Nx.Ptree.S with type t = 'p) -> 'p -> 'p sgd_state
 (** [sgd_init (module P) params] is the initial state for optimizing [params]:
     an all-zero velocity of [params]' shape. *)
 
 val sgd_step :
-  (module P : Nx.Ptree.S) ->
+  (module Nx.Ptree.S with type t = 'p) ->
   lr:float ->
   ?momentum:float ->
-  P.t sgd_state ->
-  params:P.t ->
-  grads:P.t ->
-  P.t * P.t sgd_state
+  'p sgd_state ->
+  params:'p ->
+  grads:'p ->
+  'p * 'p sgd_state
 (** [sgd_step (module P) ~lr st ~params ~grads] is [(params', st')] after one
     step of gradient descent with heavy-ball momentum. Per element:
 
@@ -219,20 +219,20 @@ type 'p adam_state = { mu : 'p; nu : 'p; step : int }
     steps apply the correction when computing the update), each with the
     parameters' shape. [step] is the number of completed steps. *)
 
-val adam_init : (module P : Nx.Ptree.S) -> P.t -> P.t adam_state
+val adam_init : (module Nx.Ptree.S with type t = 'p) -> 'p -> 'p adam_state
 (** [adam_init (module P) params] is the initial state for optimizing [params]:
     all-zero moments and [step = 0]. *)
 
 val adam_step :
-  (module P : Nx.Ptree.S) ->
+  (module Nx.Ptree.S with type t = 'p) ->
   lr:float ->
   ?b1:float ->
   ?b2:float ->
   ?eps:float ->
-  P.t adam_state ->
-  params:P.t ->
-  grads:P.t ->
-  P.t * P.t adam_state
+  'p adam_state ->
+  params:'p ->
+  grads:'p ->
+  'p * 'p adam_state
 (** [adam_step (module P) ~lr st ~params ~grads] is [(params', st')] after one
     Adam step (Kingma and Ba, 2015). Per element, with [t = st.step + 1]:
 
@@ -245,20 +245,20 @@ val adam_step :
 
     [b1] defaults to [0.9], [b2] to [0.999], [eps] to [1e-8]. *)
 
-val adamw_init : (module P : Nx.Ptree.S) -> P.t -> P.t adam_state
+val adamw_init : (module Nx.Ptree.S with type t = 'p) -> 'p -> 'p adam_state
 (** [adamw_init] is {!adam_init}: AdamW shares Adam's state. *)
 
 val adamw_step :
-  (module P : Nx.Ptree.S) ->
+  (module Nx.Ptree.S with type t = 'p) ->
   lr:float ->
   ?b1:float ->
   ?b2:float ->
   ?eps:float ->
   ?weight_decay:float ->
-  P.t adam_state ->
-  params:P.t ->
-  grads:P.t ->
-  P.t * P.t adam_state
+  'p adam_state ->
+  params:'p ->
+  grads:'p ->
+  'p * 'p adam_state
 (** [adamw_step (module P) ~lr st ~params ~grads] is like {!adam_step} with
     decoupled weight decay (Loshchilov and Hutter, 2019): with [d] Adam's
     bias-corrected direction, the parameter update becomes

--- a/packages/vega/test/dune
+++ b/packages/vega/test/dune
@@ -1,4 +1,4 @@
 (tests
- (names test_vega test_vega_structural test_loss_scale test_gtree_vega)
+ (names test_vega test_vega_structural test_loss_scale test_uniform_vega)
  (package vega)
  (libraries vega nx nx.core windtrap))

--- a/packages/vega/test/dune
+++ b/packages/vega/test/dune
@@ -1,4 +1,4 @@
 (tests
- (names test_vega test_vega_structural test_loss_scale)
+ (names test_vega test_vega_structural test_loss_scale test_gtree_vega)
  (package vega)
  (libraries vega nx nx.core windtrap))

--- a/packages/vega/test/test_gtree_vega.ml
+++ b/packages/vega/test/test_gtree_vega.ml
@@ -1,0 +1,89 @@
+(*---------------------------------------------------------------------------
+  Copyright (c) 2026 The Raven authors. All rights reserved.
+  SPDX-License-Identifier: ISC
+  ---------------------------------------------------------------------------*)
+
+(* Gtree → Ptree.S bridge: structural optimiser step over Tensor_tree. Uses
+   hand-crafted gradients to avoid a rune dependency in the vega test suite. *)
+
+open Windtrap
+
+(* ——— helpers ——— *)
+
+let as_f32 (type a b) (x : (a, b) Nx.t) : Nx.float32_t =
+  match Nx_core.Dtype.equal_witness (Nx.dtype x) Nx.float32 with
+  | Some Type.Equal -> x
+  | None -> failwith "expected a float32 leaf"
+
+let vec32 xs = Nx.create Nx.float32 [| Array.length xs |] xs
+let pack x = Nx.Ptree.P x
+
+let check_t name shape values (t : Nx.float32_t) =
+  let actual_shape = Nx.shape t in
+  equal ~msg:(name ^ " shape") int (Array.length shape)
+    (Array.length actual_shape);
+  Array.iteri
+    (fun i s ->
+      equal ~msg:(Printf.sprintf "%s shape[%d]" name i) int s actual_shape.(i))
+    shape;
+  let actual = Nx.to_array (Nx.reshape [| -1 |] (Nx.contiguous t)) in
+  equal ~msg:(name ^ " length") int (Array.length values) (Array.length actual);
+  Array.iteri
+    (fun i x ->
+      equal ~msg:(Printf.sprintf "%s[%d]" name i) (float 1e-5) x actual.(i))
+    values
+
+(* ——— hand-written gtree ——— *)
+
+module U = struct
+  type 'a t = { w : 'a; b : 'a }
+
+  let map (f : 'a -> 'b) { w; b } = { w = f w; b = f b }
+  let map2 (f : 'a -> 'b -> 'c) a b = { w = f a.w b.w; b = f a.b b.b }
+
+  let iter (f : 'a -> unit) { w; b } =
+    f w;
+    f b
+
+  let fold (f : string -> 'acc -> 'a -> 'acc) acc { w; b } =
+    f "b" (f "w" acc w) b
+
+  let fold2 (f : string -> 'acc -> 'a -> 'b -> 'acc) acc a b =
+    f "b" (f "w" acc a.w b.w) a.b b.b
+end
+
+module T = Nx.Ptree.Tensor_tree (U)
+
+(* Initial parameters and synthetic gradients. *)
+let params =
+  { U.w = pack (vec32 [| 1.0; -2.0; 3.0 |]); b = pack (vec32 [| 0.5 |]) }
+
+let grads =
+  { U.w = pack (vec32 [| 0.1; 0.2; 0.3 |]); b = pack (vec32 [| 0.05 |]) }
+
+let test_adam_step_on_gtree () =
+  let st = Vega.adam_init (module T) params in
+  let p', _ = Vega.adam_step (module T) ~lr:0.1 st ~params ~grads in
+  let { U.w = Nx.Ptree.P w'; b = Nx.Ptree.P b' } = p' in
+  let w' = as_f32 w' and b' = as_f32 b' in
+  check_t "w after adam step" [| 3 |] [| 0.9; -2.1; 2.9 |] w';
+  check_t "b after adam step" [| 1 |] [| 0.4 |] b'
+
+let test_clip_by_global_norm_on_gtree () =
+  let g_clipped = Vega.clip_by_global_norm (module T) ~max_norm:10.0 grads in
+  let { U.w = Nx.Ptree.P wc; _ } = g_clipped in
+  (* Our gradients are small enough that clipping is a no-op. *)
+  check_t "w after clip" [| 3 |] [| 0.1; 0.2; 0.3 |] (as_f32 wc)
+
+let tests =
+  [
+    group "Vega over Tensor_tree"
+      [
+        test "adam_step preserves structure and applies update"
+          test_adam_step_on_gtree;
+        test "clip_by_global_norm works on gtree-backed gradients"
+          test_clip_by_global_norm_on_gtree;
+      ];
+  ]
+
+let () = run "vega gtree" tests

--- a/packages/vega/test/test_uniform_vega.ml
+++ b/packages/vega/test/test_uniform_vega.ml
@@ -50,6 +50,8 @@ module U = struct
 
   let fold2 (f : string -> 'acc -> 'a -> 'b -> 'acc) acc a b =
     f "b" (f "w" acc a.w b.w) a.b b.b
+
+  let names _ = { w = "w"; b = "b" }
 end
 
 module T = Nx.Ptree.Make (U)

--- a/packages/vega/test/test_uniform_vega.ml
+++ b/packages/vega/test/test_uniform_vega.ml
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: ISC
   ---------------------------------------------------------------------------*)
 
-(* Gtree → Ptree.S bridge: structural optimiser step over Tensor_tree. Uses
+(* Uniform → Ptree.S bridge: structural optimiser step over Ptree.Make. Uses
    hand-crafted gradients to avoid a rune dependency in the vega test suite. *)
 
 open Windtrap
@@ -33,7 +33,7 @@ let check_t name shape values (t : Nx.float32_t) =
       equal ~msg:(Printf.sprintf "%s[%d]" name i) (float 1e-5) x actual.(i))
     values
 
-(* ——— hand-written gtree ——— *)
+(* ——— hand-written uniform structure ——— *)
 
 module U = struct
   type 'a t = { w : 'a; b : 'a }
@@ -52,7 +52,7 @@ module U = struct
     f "b" (f "w" acc a.w b.w) a.b b.b
 end
 
-module T = Nx.Ptree.Tensor_tree (U)
+module T = Nx.Ptree.Make (U)
 
 (* Initial parameters and synthetic gradients. *)
 let params =
@@ -61,7 +61,7 @@ let params =
 let grads =
   { U.w = pack (vec32 [| 0.1; 0.2; 0.3 |]); b = pack (vec32 [| 0.05 |]) }
 
-let test_adam_step_on_gtree () =
+let test_adam_step_on_uniform () =
   let st = Vega.adam_init (module T) params in
   let p', _ = Vega.adam_step (module T) ~lr:0.1 st ~params ~grads in
   let { U.w = Nx.Ptree.P w'; b = Nx.Ptree.P b' } = p' in
@@ -69,7 +69,7 @@ let test_adam_step_on_gtree () =
   check_t "w after adam step" [| 3 |] [| 0.9; -2.1; 2.9 |] w';
   check_t "b after adam step" [| 1 |] [| 0.4 |] b'
 
-let test_clip_by_global_norm_on_gtree () =
+let test_clip_by_global_norm_on_uniform () =
   let g_clipped = Vega.clip_by_global_norm (module T) ~max_norm:10.0 grads in
   let { U.w = Nx.Ptree.P wc; _ } = g_clipped in
   (* Our gradients are small enough that clipping is a no-op. *)
@@ -77,13 +77,13 @@ let test_clip_by_global_norm_on_gtree () =
 
 let tests =
   [
-    group "Vega over Tensor_tree"
+    group "Vega over Ptree.Make"
       [
         test "adam_step preserves structure and applies update"
-          test_adam_step_on_gtree;
-        test "clip_by_global_norm works on gtree-backed gradients"
-          test_clip_by_global_norm_on_gtree;
+          test_adam_step_on_uniform;
+        test "clip_by_global_norm works on uniform-backed gradients"
+          test_clip_by_global_norm_on_uniform;
       ];
   ]
 
-let () = run "vega gtree" tests
+let () = run "vega uniform" tests


### PR DESCRIPTION
Integrates @hennequin's gtree contribution (hennequin-lab/raven@3c4ed3c), cherry-picked as-is, with a rework on top. The design is adopted wholesale, payload-generic structures, a bridge functor into Ptree.S, checked unpacking, a deriver with a mirror mode for concrete records. The rework renames the surface and merges the derivers.

Ptree.Gtree → Ptree.Uniform (the module type of structures with a uniform payload), Ptree.Tensor_tree → Ptree.Make. Mirror mode generates module Uniform, to_uniform, of_uniform. The generated module is an instance of the identically-named signature.

[@@deriving gtree] is merged into [@@deriving ptree], which dispatches on the declaration:

- concrete type → rank-2 traversals (unchanged);
- one type parameter occurring outside tensor leaves, unannotated → uniform traversals (map, map2, iter, fold, fold2, names);
- [@@deriving ptree ~mirror] on a concrete type → additionally the uniform mirror.

Positions carrying a [@ptree.*] attribute keep their rank-2 meaning, so existing records like { tag : 'tag [@ptree.ignore]; ... } derive exactly as before; abstract signatures default to rank-2.
