### PR TITLE
rune: differentiate and batch the real FFT family

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -861,6 +861,10 @@ thread.
 
 ### Rune
 
+- `grad`, `vjp`, and `jvp` now differentiate `Nx.rfft` and `Nx.irfft` — both
+  are linear, so each rule is an exact transpose — and `vmap` batches all four
+  FFT transforms (`fft`, `ifft`, `rfft`, `irfft`), so spectral losses built on
+  real FFTs train end to end.
 - A parameter structure may now hold leaves that are not parameters — an
   `Nx.Rng.key` threaded through a compiled step, a step counter, a batch of
   indices. `grad`, `value_and_grad` and `vjp` carry them instead of raising:

--- a/packages/rune/lib/forward.ml
+++ b/packages/rune/lib/forward.ml
@@ -465,11 +465,12 @@ let handler (tangents : Tensor_map.t) =
       | E_rfft { t; dtype; axes } ->
           Some
             (fun k ->
-              no_rule k "rfft" (active t) (fun () -> rfft t ~dtype ~axes))
+              lift1 k (rfft t ~dtype ~axes) t (fun dx -> rfft dx ~dtype ~axes))
       | E_irfft { t; dtype; axes; s } ->
           Some
             (fun k ->
-              no_rule k "irfft" (active t) (fun () -> irfft t ~axes ?s ~dtype))
+              lift1 k (irfft t ~axes ?s ~dtype) t (fun dx ->
+                  irfft dx ~axes ?s ~dtype))
       | E_psum { t_in } ->
           Some
             (fun k -> no_rule k "psum" (active t_in) (fun () -> op_psum t_in))

--- a/packages/rune/lib/reverse.ml
+++ b/packages/rune/lib/reverse.ml
@@ -20,10 +20,10 @@
    gradient fall into three deliberate categories: - zero derivative
    (comparisons, bitwise and integer ops, rounding, argmax/argmin/argsort, RNG,
    tensor creation): fall through untracked, which yields the correct zero
-   gradient; - no rule implemented (svd, eig, eigh, rfft, irfft, psum, mod):
-   raise when an input is tracked instead of silently producing a zero gradient
-   — detach the input if differentiation should not flow through it; - in-place
-   mutation (assign): always raises during differentiation. *)
+   gradient; - no rule implemented (svd, eig, eigh, psum, mod): raise when an
+   input is tracked instead of silently producing a zero gradient — detach the
+   input if differentiation should not flow through it; - in-place mutation
+   (assign): always raises during differentiation. *)
 
 open Nx_effect
 module T = Nx
@@ -714,20 +714,90 @@ let handler (tape : Tape.t) =
               continue k out)
       (* FFT: the transform matrix is symmetric, so each transform is its own
          transpose and pulls back through itself. Going through the inverse
-         instead would reverse the frequency index. The real-valued variants
-         have no rule yet. *)
+         instead would reverse the frequency index. *)
       | E_fft { t; axes } ->
           Some (fun k -> pull1 k (fft t ~axes) t (fun g -> fft g ~axes))
       | E_ifft { t; axes } ->
           Some (fun k -> pull1 k (ifft t ~axes) t (fun g -> ifft g ~axes))
+      (* rfft factors as real-embed, fft over every transformed axis, then a
+         slice to the first n/2 + 1 bins of the last one. Each factor pulls back
+         through its own transpose: the slice through a zero-pad, the fft
+         through itself, and the embed through the real part — the same pair the
+         cast rules use between float and complex. No Hermitian mirror appears
+         anywhere: the forward never built one, so the transpose never reads
+         one. *)
       | E_rfft { t; dtype; axes } ->
+          ignore dtype;
           Some
             (fun k ->
-              no_rule k "rfft" (tracked t) (fun () -> rfft t ~dtype ~axes))
+              pull1 k (rfft t ~dtype ~axes) t (fun g ->
+                  let last = axes.(Array.length axes - 1) in
+                  let n = (T.shape t).(last) in
+                  let m = (T.shape g).(last) in
+                  let g =
+                    if n > m then begin
+                      let cfg = Array.make (T.ndim g) (0, 0) in
+                      cfg.(last) <- (0, n - m);
+                      T.pad cfg Complex.zero g
+                    end
+                    else g
+                  in
+                  T.real (T.dtype t) (fft g ~axes)))
+      (* irfft factors as Hermitian-extend along the last transformed axis, ifft
+         over every transformed axis, then the real part. The pull runs the
+         transposes in reverse: complex-embed the real cotangent, ifft it
+         through itself, then transpose the extension — bin k of the input fed
+         slot k directly and slot n - k through a conjugate, so the pull folds
+         conj of the mirror slots onto bins 1 .. n - m (bin 0, and the Nyquist
+         bin when n is even, fed one slot only). The fold is spelled out rather
+         than collapsed into a doubling: with leading axes transformed too, the
+         spectrum's symmetry pairs (j, k) with (-j, -k) across axes, so the
+         mirror along the last axis alone is not the conjugate of what it folds
+         onto. The leading c2c pass — its own transpose — runs after the fold,
+         never inside it: conjugation anti-commutes with a complex transform, so
+         folding a leading-transformed mirror would pull those axes through the
+         wrong direction. The forward ignores bins past what n supports and
+         zero-fills a short spectrum, so the pull shrinks or pads back to the
+         input's bins before that final pass. *)
       | E_irfft { t; dtype; axes; s } ->
           Some
             (fun k ->
-              no_rule k "irfft" (tracked t) (fun () -> irfft t ~axes ?s ~dtype))
+              pull1 k (irfft t ~axes ?s ~dtype) t (fun g ->
+                  let last = axes.(Array.length axes - 1) in
+                  let n = (T.shape g).(last) in
+                  let m = (n / 2) + 1 in
+                  let m_in = (T.shape t).(last) in
+                  let cdtype = T.dtype t in
+                  let gz = ifft (T.cast cdtype g) ~axes:[| last |] in
+                  let sub lo hi x =
+                    let lim = Array.map (fun d -> (0, d)) (T.shape x) in
+                    lim.(last) <- (lo, hi);
+                    T.shrink lim x
+                  in
+                  let head = sub 0 m gz in
+                  let gi =
+                    if n - m >= 1 then begin
+                      let mirror =
+                        T.conjugate (T.flip ~axes:[ last ] (sub m n gz))
+                      in
+                      let cfg = Array.make (T.ndim mirror) (0, 0) in
+                      cfg.(last) <- (1, m - 1 - (n - m));
+                      T.add head (T.pad cfg Complex.zero mirror)
+                    end
+                    else head
+                  in
+                  let gi =
+                    if m_in > m then begin
+                      let cfg = Array.make (T.ndim gi) (0, 0) in
+                      cfg.(last) <- (0, m_in - m);
+                      T.pad cfg Complex.zero gi
+                    end
+                    else if m_in < m then sub 0 m_in gi
+                    else gi
+                  in
+                  if Array.length axes > 1 then
+                    ifft gi ~axes:(Array.sub axes 0 (Array.length axes - 1))
+                  else gi))
       | E_psum { t_in } ->
           Some
             (fun k -> no_rule k "psum" (tracked t_in) (fun () -> op_psum t_in))

--- a/packages/rune/lib/vmap.ml
+++ b/packages/rune/lib/vmap.ml
@@ -392,11 +392,32 @@ let rec handler : type r. state -> (r, r) Effect.Deep.handler =
             in
             mark st out;
             continue k out)
-    (* No batching rule yet. *)
-    | E_fft { t; _ } when batched st t -> err_no_rule "fft"
-    | E_ifft { t; _ } when batched st t -> err_no_rule "ifft"
-    | E_rfft { t; _ } when batched st t -> err_no_rule "rfft"
-    | E_irfft { t; _ } when batched st t -> err_no_rule "irfft"
+    (* FFT: the transformed axes shift past the batch dimension; sizes ([s]) are
+       per-axis and unchanged. *)
+    | E_fft { t; axes } when batched st t ->
+        Some
+          (fun k ->
+            let out = fft t ~axes:(Array.map taxis axes) in
+            mark st out;
+            continue k out)
+    | E_ifft { t; axes } when batched st t ->
+        Some
+          (fun k ->
+            let out = ifft t ~axes:(Array.map taxis axes) in
+            mark st out;
+            continue k out)
+    | E_rfft { t; dtype; axes } when batched st t ->
+        Some
+          (fun k ->
+            let out = rfft t ~dtype ~axes:(Array.map taxis axes) in
+            mark st out;
+            continue k out)
+    | E_irfft { t; dtype; axes; s } when batched st t ->
+        Some
+          (fun k ->
+            let out = irfft t ~axes:(Array.map taxis axes) ?s ~dtype in
+            mark st out;
+            continue k out)
     | E_psum { t_in } when batched st t_in -> err_no_rule "psum"
     | E_cholesky { t_in; _ } when batched st t_in -> err_no_rule "cholesky"
     | E_qr { t_in; _ } when batched st t_in -> err_no_rule "qr"

--- a/packages/rune/test/dune
+++ b/packages/rune/test/dune
@@ -8,6 +8,7 @@
   test_jvp
   test_vmap
   test_custom
+  test_fft
   test_jacobian
   test_control
   test_jit
@@ -23,6 +24,7 @@
   test_jvp
   test_vmap
   test_custom
+  test_fft
   test_jacobian
   test_control
   test_jit

--- a/packages/rune/test/test_complex.ml
+++ b/packages/rune/test/test_complex.ml
@@ -81,12 +81,36 @@ let modulus_tests =
    transpose. A pullback through the inverse transform instead would come back
    reindexed. *)
 
+let z5 () =
+  cvec [| (1.1, 0.5); (-0.7, 1.3); (0.4, -0.9); (0.2, 0.6); (-1.0, 0.3) |]
+
 let transform_tests =
   List.concat
     [
       both "fft" (fun z -> Nx.fft z ~axis:0) z3;
       both "ifft" (fun z -> Nx.ifft z ~axis:0) z3;
       both "ifft of fft" (fun z -> Nx.ifft (Nx.fft z ~axis:0) ~axis:0) z3;
+      (* The real transforms, driven by the complex oracle so their cotangents
+         and tangents are non-zero in both components: irfft's leaf is complex
+         already, and rfft is reached through the real part of one, so a
+         conjugation slipped into either pull cannot agree by coincidence. *)
+      both "irfft" (fun z -> Nx.cast Nx.complex128 (Nx.irfft f64 ~n:8 z)) z5;
+      both "irfft, odd length"
+        (fun z -> Nx.cast Nx.complex128 (Nx.irfft f64 ~n:7 z))
+        z5;
+      both "irfft, truncated"
+        (fun z -> Nx.cast Nx.complex128 (Nx.irfft f64 ~n:4 z))
+        z5;
+      both "rfft of a real part"
+        (fun z -> Nx.rfft Nx.complex128 (Nx.real f64 z))
+        z5;
+      both "complex-filtered round trip"
+        (fun z ->
+          let x = Nx.real f64 z in
+          let h = Nx.shrink [| (0, 3) |] z in
+          Nx.cast Nx.complex128
+            (Nx.irfft f64 ~n:5 (Nx.mul (Nx.rfft Nx.complex128 x) h)))
+        z5;
     ]
 
 (* Reading a component out and putting one back: the paths a real-valued

--- a/packages/rune/test/test_fft.ml
+++ b/packages/rune/test/test_fft.ml
@@ -1,0 +1,418 @@
+(*---------------------------------------------------------------------------
+  Copyright (c) 2026 The Raven authors. All rights reserved.
+  SPDX-License-Identifier: ISC
+  ---------------------------------------------------------------------------*)
+
+(* Differentiation and batching of the FFT family. Gradients of rfft/irfft
+   compositions are validated against central finite differences, including
+   one-way losses whose cotangents are not Hermitian — the cases a round trip
+   cancels and a conjugation error passes. The pulls are additionally pinned
+   against the DFT-definition transpose, whose mirror fold differs between even
+   and odd lengths. vmap is checked against the loop oracle for all four
+   transforms. *)
+
+open Windtrap
+open Rune_test_support.Support
+
+let c128 = Nx.complex128
+let cx re im = { Complex.re; im }
+let pi = 4.0 *. Stdlib.atan 1.0
+
+let cvec xs =
+  Nx.create c128 [| Array.length xs |] (Array.map (fun (re, im) -> cx re im) xs)
+
+let to_carr t = Nx.to_array (Nx.reshape [| -1 |] (Nx.contiguous t))
+
+let check_carr ?(eps = 1e-10) ~msg (expected : Complex.t array) actual =
+  let actual = to_carr actual in
+  equal ~msg int (Array.length expected) (Array.length actual);
+  Array.iteri
+    (fun i e ->
+      equal
+        ~msg:(Printf.sprintf "%s[%d].re" msg i)
+        (float eps) e.Complex.re actual.(i).Complex.re;
+      equal
+        ~msg:(Printf.sprintf "%s[%d].im" msg i)
+        (float eps) e.Complex.im actual.(i).Complex.im)
+    expected
+
+(* Deterministic signals. *)
+let x8 () = vec64 [| 0.5; -1.2; 2.1; 1.7; -0.4; 0.9; 0.2; 1.3 |]
+let x7 () = vec64 [| 0.5; -1.2; 2.1; 1.7; -0.4; 0.9; 0.2 |]
+let x4 () = vec64 [| 0.5; -1.2; 2.1; 1.7 |]
+
+(* A real-valued spectral mask for x8's 5 bins: multiplying the spectrum by it
+   and measuring the filtered energy is a per-bin weighted |X|^2 loss. *)
+let h5 () =
+  Nx.create c128 [| 5 |]
+    [| cx 1.0 0.0; cx 0.5 0.0; cx 2.0 0.0; cx 0.25 0.0; cx 1.5 0.0 |]
+
+(* Gradients against finite differences *)
+
+let test_grad_roundtrip_even () =
+  check_grad ~msg:"irfft(rfft x), n=8"
+    (fun x -> Nx.irfft f64 (Nx.rfft c128 x))
+    (x8 ())
+
+let test_grad_roundtrip_odd () =
+  check_grad ~msg:"irfft(rfft x), n=7"
+    (fun x -> Nx.irfft f64 ~n:7 (Nx.rfft c128 x))
+    (x7 ())
+
+let test_grad_axis_even () =
+  check_grad ~msg:"irfft(rfft x) along axis 0, n=4"
+    (fun x -> Nx.irfft f64 ~axis:0 (Nx.rfft c128 ~axis:0 x))
+    (mat64 4 3
+       [| 0.5; -1.2; 2.1; 1.7; -0.4; 0.9; 0.2; 1.3; -0.7; 0.8; -1.6; 0.4 |])
+
+let test_grad_axis_odd () =
+  check_grad ~msg:"irfft(rfft x) along axis 0, n=5"
+    (fun x -> Nx.irfft f64 ~axis:0 ~n:5 (Nx.rfft c128 ~axis:0 x))
+    (mat64 5 2 [| 0.5; -1.2; 2.1; 1.7; -0.4; 0.9; 0.2; 1.3; -0.7; 0.8 |])
+
+let test_grad_ortho_norm () =
+  check_grad ~msg:"irfft(rfft x), ortho"
+    (fun x -> Nx.irfft f64 ~norm:`Ortho (Nx.rfft c128 ~norm:`Ortho x))
+    (x8 ())
+
+let test_grad_padded_spectrum () =
+  (* n:6 needs 4 bins but rfft of 4 samples supplies 3: the forward zero-fills
+     and the pull drops the extra bin's cotangent. *)
+  check_grad ~msg:"irfft ~n:6 (rfft x), 4 samples"
+    (fun x -> Nx.irfft f64 ~n:6 (Nx.rfft c128 x))
+    (x4 ())
+
+let test_grad_truncated_spectrum () =
+  (* n:4 keeps 3 of the 5 supplied bins: the pull zero-fills the ignored
+     bins. *)
+  check_grad ~msg:"irfft ~n:4 (rfft x), 8 samples"
+    (fun x -> Nx.irfft f64 ~n:4 (Nx.rfft c128 x))
+    (x8 ())
+
+let test_grad_2d () =
+  check_grad ~msg:"irfft2(rfft2 x)"
+    (fun x -> Nx.irfft2 f64 ~s:[ 3; 4 ] (Nx.rfft2 c128 x))
+    (mat64 3 4
+       [| 0.5; -1.2; 2.1; 1.7; -0.4; 0.9; 0.2; 1.3; -0.7; 0.8; -1.6; 0.4 |])
+
+let test_grad_spectral_energy () =
+  (* Filtered energy: sum ((irfft (h * rfft x))^2) is, by Parseval, a per-bin
+     weighted spectral magnitude-squared loss. *)
+  let h = h5 () in
+  check_grad ~msg:"filtered spectral energy"
+    (fun x ->
+      let y = Nx.irfft f64 ~n:8 (Nx.mul (Nx.rfft c128 x) h) in
+      Nx.mul y y)
+    (x8 ())
+
+(* Pulls against the DFT-definition transpose, under the same convention as the
+   c2c rules: each pull is the plain transpose of the forward, with no
+   conjugation of its own. The pull of [rfft] at sample j is Re (sum_k ct_k
+   e^{-2 pi i j k / n}) — the forward twiddle over the zero-padded half spectrum
+   — and the pull of [irfft] at bin k is factor_k / n * sum_j w_j e^{+2 pi i j k
+   / n}, where factor_k doubles exactly the bins the forward mirrors (the fold
+   of a real cotangent's own symmetry; the rule spells the fold out for the
+   multi-axis case). *)
+
+let rfft_pull_reference n (ct : Complex.t array) =
+  Array.init n (fun j ->
+      let acc = ref 0.0 in
+      Array.iteri
+        (fun k c ->
+          let th = 2.0 *. pi *. float_of_int (j * k) /. float_of_int n in
+          acc :=
+            !acc
+            +. (c.Complex.re *. Stdlib.cos th)
+            +. (c.Complex.im *. Stdlib.sin th))
+        ct;
+      !acc)
+
+let irfft_pull_reference n m (w : float array) =
+  Array.init m (fun k ->
+      let factor = if k = 0 || (n mod 2 = 0 && k = n / 2) then 1.0 else 2.0 in
+      let re = ref 0.0 and im = ref 0.0 in
+      Array.iteri
+        (fun j wj ->
+          let th = 2.0 *. pi *. float_of_int (j * k) /. float_of_int n in
+          re := !re +. (wj *. Stdlib.cos th);
+          im := !im +. (wj *. Stdlib.sin th))
+        w;
+      let s = factor /. float_of_int n in
+      cx (s *. !re) (s *. !im))
+
+let ct4 () = cvec [| (0.3, -1.1); (1.0, 0.4); (-0.7, 0.9) |]
+
+let test_rfft_pull_even () =
+  let ct = ct4 () in
+  let _, g = Rune.vjp' (Nx.rfft c128) (x4 ()) ct in
+  check_arr ~eps:1e-10 ~msg:"rfft pull, n=4"
+    (rfft_pull_reference 4 (to_carr ct))
+    g
+
+let test_rfft_pull_odd () =
+  let ct = cvec [| (0.3, -1.1); (1.0, 0.4); (-0.7, 0.9) |] in
+  let x = vec64 [| 0.5; -1.2; 2.1; 1.7; -0.4 |] in
+  let _, g = Rune.vjp' (Nx.rfft c128) x ct in
+  check_arr ~eps:1e-10 ~msg:"rfft pull, n=5"
+    (rfft_pull_reference 5 (to_carr ct))
+    g
+
+let test_irfft_pull_even () =
+  let y = ct4 () in
+  let w = vec64 [| 1.0; -0.5; 2.0; 0.25 |] in
+  let _, g = Rune.vjp' (fun y -> Nx.irfft f64 ~n:4 y) y w in
+  check_carr ~msg:"irfft pull, n=4" (irfft_pull_reference 4 3 (to_arr w)) g
+
+let test_irfft_pull_odd () =
+  let y = ct4 () in
+  let w = vec64 [| 1.0; -0.5; 2.0; 0.25; -1.5 |] in
+  let _, g = Rune.vjp' (fun y -> Nx.irfft f64 ~n:5 y) y w in
+  check_carr ~msg:"irfft pull, n=5" (irfft_pull_reference 5 3 (to_arr w)) g
+
+(* Forward mode *)
+
+let test_jvp_roundtrip_even () =
+  check_jvp ~msg:"irfft(rfft x), n=8"
+    (fun x -> Nx.irfft f64 (Nx.rfft c128 x))
+    (x8 ())
+
+let test_jvp_roundtrip_odd () =
+  check_jvp ~msg:"irfft(rfft x), n=7"
+    (fun x -> Nx.irfft f64 ~n:7 (Nx.rfft c128 x))
+    (x7 ())
+
+let test_jvp_rfft_is_linear () =
+  (* rfft is linear: its tangent is the transform of the tangent. *)
+  let v = vec64 [| 0.3; -0.9; 1.4; 0.1; 2.0; -0.6; 0.8; -1.7 |] in
+  let _, dy = Rune.jvp' (Nx.rfft c128) (x8 ()) v in
+  check_carr ~msg:"jvp rfft = rfft v" (to_carr (Nx.rfft c128 v)) dy
+
+let test_jvp_irfft_is_linear () =
+  let y = ct4 () in
+  let v = cvec [| (0.6, 0.2); (-0.8, 1.3); (0.4, -0.5) |] in
+  let _, dy = Rune.jvp' (fun y -> Nx.irfft f64 ~n:5 y) y v in
+  check_arr ~eps:1e-10 ~msg:"jvp irfft = irfft v"
+    (to_arr (Nx.irfft f64 ~n:5 v))
+    dy
+
+let test_jvp_vjp_consistency () =
+  (* <w, jvp_v f x> = <vjp_w f x, v> for the filtered spectral pipeline. *)
+  let h = h5 () in
+  let f x = Nx.irfft f64 ~n:8 (Nx.mul (Nx.rfft c128 x) h) in
+  let x = x8 () in
+  let v = vec64 [| 0.3; -0.9; 1.4; 0.1; 2.0; -0.6; 0.8; -1.7 |] in
+  let w = vec64 [| 1.0; -0.5; 2.0; 0.25; -1.5; 0.75; -2.0; 0.5 |] in
+  let _, dy = Rune.jvp' f x v in
+  let _, g = Rune.vjp' f x w in
+  equal ~msg:"pairings agree" (float 1e-10)
+    (scalar (Nx.sum (Nx.mul w dy)))
+    (scalar (Nx.sum (Nx.mul g v)))
+
+(* vmap against the loop oracle *)
+
+let loop_map f x =
+  let b = (Nx.shape x).(0) in
+  Nx.stack ~axis:0 (List.init b (fun i -> f (Nx.slice [ Nx.I i ] x)))
+
+let check_vmap_c ~msg f x =
+  check_carr ~msg (to_carr (loop_map f x)) (Rune.vmap' f x)
+
+let check_vmap_r ~msg f x =
+  check_arr ~msg (to_arr (loop_map f x)) (Rune.vmap' f x)
+
+let zs () =
+  Nx.create c128 [| 3; 4 |]
+    (Array.init 12 (fun i ->
+         cx
+           (float_of_int ((i * 3 mod 7) - 3) /. 2.0)
+           (float_of_int ((i * 5 mod 11) - 5) /. 4.0)))
+
+let xs () =
+  Nx.create f64 [| 3; 5 |]
+    (Array.init 15 (fun i -> float_of_int ((i * 7 mod 13) - 6) /. 4.0))
+
+let test_vmap_fft () = check_vmap_c ~msg:"fft" (fun z -> Nx.fft z) (zs ())
+let test_vmap_ifft () = check_vmap_c ~msg:"ifft" (fun z -> Nx.ifft z) (zs ())
+
+let test_vmap_rfft () =
+  check_vmap_c ~msg:"rfft" (fun x -> Nx.rfft c128 x) (xs ())
+
+let test_vmap_irfft () =
+  check_vmap_r ~msg:"irfft" (fun z -> Nx.irfft f64 ~n:6 z) (zs ())
+
+let test_vmap_fft_non_last_axis () =
+  let z =
+    Nx.create c128 [| 2; 4; 2 |]
+      (Array.init 16 (fun i ->
+           cx
+             (float_of_int ((i * 3 mod 7) - 3) /. 2.0)
+             (float_of_int ((i * 5 mod 11) - 5) /. 4.0)))
+  in
+  check_vmap_c ~msg:"fft axis 0" (fun m -> Nx.fft ~axis:0 m) z
+
+let test_vmap_rfft_non_last_axis () =
+  let x =
+    Nx.create f64 [| 2; 4; 3 |]
+      (Array.init 24 (fun i -> float_of_int ((i * 7 mod 13) - 6) /. 4.0))
+  in
+  check_vmap_c ~msg:"rfft axis 0" (fun m -> Nx.rfft c128 ~axis:0 m) x
+
+let test_vmap_non_leading_batch_axis () =
+  (* Mapping axis 1: the batch dimension crosses the transformed axis. *)
+  let x =
+    Nx.create f64 [| 5; 3 |]
+      (Array.init 15 (fun i -> float_of_int ((i * 7 mod 13) - 6) /. 4.0))
+  in
+  let looped = loop_map (fun r -> Nx.rfft c128 r) (Nx.transpose x) in
+  check_carr ~msg:"rfft over axis-1 lanes" (to_carr looped)
+    (Rune.vmap' ~in_axis:1 (fun r -> Nx.rfft c128 r) x)
+
+let test_vmap_of_grad () =
+  (* Per-sample gradients of the spectral round-trip energy, odd length. *)
+  let x =
+    Nx.create f64 [| 3; 5 |]
+      (Array.init 15 (fun i -> float_of_int ((i * 7 mod 13) - 6) /. 4.0))
+  in
+  let energy x =
+    let y = Nx.irfft f64 ~n:5 (Nx.rfft c128 x) in
+    Nx.sum (Nx.mul y y)
+  in
+  check_vmap_r ~msg:"per-sample spectral gradients" (Rune.grad' energy) x
+
+(* jit: the FFT family is refused under tracing (Tolk cannot express it). *)
+
+let raises_jit_error f =
+  raises_match
+    (fun exn -> match exn with Rune.Jit_error _ -> true | _ -> false)
+    f
+
+let test_jit_rfft_refused () =
+  let g = Rune.jit' (fun x -> Nx.rfft c128 x) in
+  raises_jit_error (fun () -> g (vec32 [| 1.0; 2.0; 3.0; 4.0 |]))
+
+(* One-way losses. Round trips cannot adjudicate the pull convention: a wrong
+   direction on one side composes with its mirror image on the other and
+   cancels. Each of these stops after a single real transform, and the complex
+   masks carry nonzero imaginary parts so the cotangent reaching the transform
+   is not Hermitian — the shape where a conjugation error is invisible to every
+   symmetric test and wrong in training. *)
+
+let test_grad_rfft2_energy () =
+  let x =
+    Nx.create f64 [| 3; 4 |]
+      (Array.init 12 (fun i ->
+           0.3
+           +. (0.17 *. float_of_int i)
+           -. (0.05 *. float_of_int (i * i mod 7))))
+  in
+  check_grad ~msg:"rfft2 energy, no inverse"
+    (fun x -> Nx.square (Nx.magnitude f64 (Nx.rfft2 c128 x)))
+    x
+
+let test_grad_irfft2_of_lift () =
+  let x =
+    Nx.create f64 [| 3; 4 |]
+      (Array.init 12 (fun i ->
+           0.3
+           +. (0.17 *. float_of_int i)
+           -. (0.05 *. float_of_int (i * i mod 7))))
+  in
+  check_grad ~msg:"irfft2 of a lifted spectrum"
+    (fun x ->
+      let z = Nx.complex c128 ~re:x ~im:(Nx.mul_s x 0.25) in
+      Nx.irfft2 f64 ~s:[ 3; 4 ] z)
+    x
+
+let hc5 () =
+  Nx.create c128 [| 5 |]
+    [| cx 1.0 0.7; cx 0.5 (-0.3); cx 2.0 1.1; cx 0.25 0.4; cx 1.5 (-0.8) |]
+
+let test_grad_complex_mask_even () =
+  check_grad ~msg:"complex-mask energy, even length"
+    (fun x -> Nx.square (Nx.magnitude f64 (Nx.mul (Nx.rfft c128 x) (hc5 ()))))
+    (x8 ())
+
+let test_grad_complex_mask_odd () =
+  let h4 =
+    Nx.create c128 [| 4 |]
+      [| cx 1.0 0.7; cx 0.5 (-0.3); cx 2.0 1.1; cx 0.25 0.4 |]
+  in
+  check_grad ~msg:"complex-mask energy, odd length"
+    (fun x -> Nx.square (Nx.magnitude f64 (Nx.mul (Nx.rfft c128 x) h4)))
+    (x7 ())
+
+let test_grad_complex_mask_irfft () =
+  check_grad ~msg:"complex-masked irfft energy"
+    (fun x -> Nx.square (Nx.irfft f64 ~n:8 (Nx.mul (Nx.rfft c128 x) (hc5 ()))))
+    (x8 ())
+
+let test_grad_power_spectrum () =
+  (* The power spectrogram — the loss every mel and MFCC objective reduces to.
+     The magnitude's own pull conjugates, so the cotangent reaching rfft is
+     non-Hermitian even though the weights are real. *)
+  check_grad ~msg:"power spectrum"
+    (fun x -> Nx.square (Nx.magnitude f64 (Nx.rfft c128 x)))
+    (x8 ())
+
+let test_grad_c2c_in_chain () =
+  (* A c2c pass between the real transforms: pins that all four rules share one
+     convention — a pair of self-cancelling errors survives every round trip but
+     not a mixed chain. *)
+  check_grad ~msg:"irfft of ifft of fft of rfft"
+    (fun x -> Nx.irfft f64 ~n:8 (Nx.ifft (Nx.fft (Nx.rfft c128 x))))
+    (x8 ())
+
+let tests =
+  [
+    group "gradients"
+      [
+        test "round trip, even length" test_grad_roundtrip_even;
+        test "round trip, odd length" test_grad_roundtrip_odd;
+        test "round trip along axis 0, even length" test_grad_axis_even;
+        test "round trip along axis 0, odd length" test_grad_axis_odd;
+        test "round trip with ortho norm" test_grad_ortho_norm;
+        test "zero-padded spectrum" test_grad_padded_spectrum;
+        test "truncated spectrum" test_grad_truncated_spectrum;
+        test "2-D round trip" test_grad_2d;
+        test "filtered spectral energy" test_grad_spectral_energy;
+      ];
+    group "one-way losses"
+      [
+        test "rfft2 energy" test_grad_rfft2_energy;
+        test "irfft2 of a lifted spectrum" test_grad_irfft2_of_lift;
+        test "complex mask, even length" test_grad_complex_mask_even;
+        test "complex mask, odd length" test_grad_complex_mask_odd;
+        test "complex-masked irfft" test_grad_complex_mask_irfft;
+        test "power spectrum" test_grad_power_spectrum;
+        test "c2c pass in the chain" test_grad_c2c_in_chain;
+      ];
+    group "pulls against the DFT transpose"
+      [
+        test "rfft pull, even length" test_rfft_pull_even;
+        test "rfft pull, odd length" test_rfft_pull_odd;
+        test "irfft pull, even length" test_irfft_pull_even;
+        test "irfft pull, odd length" test_irfft_pull_odd;
+      ];
+    group "forward mode"
+      [
+        test "round trip, even length" test_jvp_roundtrip_even;
+        test "round trip, odd length" test_jvp_roundtrip_odd;
+        test "rfft tangent is rfft of the tangent" test_jvp_rfft_is_linear;
+        test "irfft tangent is irfft of the tangent" test_jvp_irfft_is_linear;
+        test "forward and reverse pairings agree" test_jvp_vjp_consistency;
+      ];
+    group "vmap"
+      [
+        test "fft" test_vmap_fft;
+        test "ifft" test_vmap_ifft;
+        test "rfft" test_vmap_rfft;
+        test "irfft" test_vmap_irfft;
+        test "fft along a non-last axis" test_vmap_fft_non_last_axis;
+        test "rfft along a non-last axis" test_vmap_rfft_non_last_axis;
+        test "non-leading batch axis" test_vmap_non_leading_batch_axis;
+        test "vmap of grad" test_vmap_of_grad;
+      ];
+    group "jit" [ test "rfft is refused under jit" test_jit_rfft_refused ];
+  ]
+
+let () = run "rune fft" tests


### PR DESCRIPTION
`grad`, `vjp` and `jvp` now differentiate `Nx.rfft` and `Nx.irfft`, and
`vmap` batches all four FFT transforms.