### PR TITLE
Perf/tolk improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,12 @@ thread.
 
 ### Tolk (new)
 
+- Test same-call WAR dependencies by node identity instead of structural
+  equality in `fix_war_deps`. `Uop.t` nodes are hash-consed, so the two checks
+  give the same verdict, but polymorphic equality on the `call_of` options
+  descends into the full shared payload DAGs (exponentially on graphs with
+  heavy sharing) where `==` is O(1).
+
 - Reduce cold `BEAM`-search compile time by removing two sources of redundant
   CPU work: the device dispatch handle (driver module load, PTX → SASS JIT) is
   loaded once per compiled binary and reused across timed candidates, and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,14 @@ thread.
   Equivalent to BlackJAX/PyMC in Python.
 
 ### Tolk (new)
+- Free `BEAM`-search timing buffers as soon as each kernel's search finishes:
+  they were reclaimed only when the GC ran, and then into the unbounded LRU
+  allocator cache (which matches by exact size), so a model with many
+  distinct kernel shapes accumulated their GPU memory until a failed
+  allocation flushed the cache — OOM on large graphs with `BEAM>=1` where
+  `BEAM=0` fits. Timing buffers now bypass the LRU cache and are released
+  deterministically per kernel.
+
 - Compile `BEAM`-search candidates in parallel domains (`BEAM_PARALLEL=N`,
   default off): the CPU-side compile of a step's candidates — optimize, lower,
   render, nvrtc — now overlaps across domains, while the GPU timing phase

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,15 @@ thread.
   Equivalent to BlackJAX/PyMC in Python.
 
 ### Tolk (new)
+- Compile `BEAM`-search candidates in parallel domains (`BEAM_PARALLEL=N`,
+  default off): the CPU-side compile of a step's candidates — optimize, lower,
+  render, nvrtc — now overlaps across domains, while the GPU timing phase
+  still runs one candidate at a time so timings never contend. Shared state
+  (hash-consing, shape memoisation, kernel naming, program cache, disk cache)
+  is guarded for concurrent access. On the RNN grad repro (CUDA, `BEAM=2`,
+  cleared tolk and driver JIT caches): 27s -> 6s with `BEAM_PARALLEL=8`;
+  with warm caches ~11s -> ~7s.
+
 
 - Stop `BEAM` search when progress drops below timer noise: the default
   `BEAM_MIN_PROGRESS` is now 5µs (still µs-denominated, matching upstream

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,12 @@ thread.
 
 ### Tolk (new)
 
+- Reduce cold `BEAM`-search compile time by removing two sources of redundant
+  CPU work: the device dispatch handle (driver module load, PTX → SASS JIT) is
+  loaded once per compiled binary and reused across timed candidates, and
+  candidates whose AST was already compiled are deduplicated up front via the
+  hash-consed tag instead of only after `nvrtc`.
+
 - Fix CUDA tensor-core kernels failing to compile. Every `__WMMA_*` primitive
   was emitted with scalar parameters and empty asm operand lists —
   `float f(half a, half b, float c)` — while the kernel body correctly built

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,13 @@ thread.
 
 ### Tolk (new)
 
+- Stop `BEAM` search when progress drops below timer noise: the default
+  `BEAM_MIN_PROGRESS` is now 5µs (still µs-denominated, matching upstream
+  tinygrad). The previous default of 0.01µs sat below the CUDA event timer
+  resolution, so neither progress-based exit condition could ever fire and
+  every kernel ran extra search steps until candidates ran out — ~2.6× more
+  candidate compiles on a CUDA `BEAM=2` pass.
+
 - Test same-call WAR dependencies by node identity instead of structural
   equality in `fix_war_deps`. `Uop.t` nodes are hash-consed, so the two checks
   give the same verdict, but polymorphic equality on the `call_of` options

--- a/packages/tolk/lib/codegen/codegen.ml
+++ b/packages/tolk/lib/codegen/codegen.ml
@@ -37,14 +37,24 @@ let buffer_params ast =
 let make_beam_search device beam_width =
   Option.map
     (fun dev k ->
+      (* Timing buffers for this kernel's candidates. [nolru] so their
+         release returns the memory to the driver: the LRU cache matches by
+         exact size, so buffers of distinct per-kernel shapes would otherwise
+         pile up in it for the rest of the compile and can OOM the device on
+         large graphs. Freed explicitly below — [beam_search] only times on
+         them — rather than waiting for a GC that may run much later. *)
+      let spec = { Device.Buffer_spec.default with nolru = true } in
       let rawbufs =
         List.map
-          (fun (_, dtype, size) -> Device.create_buffer ~size ~dtype dev)
+          (fun (_, dtype, size) -> Device.create_buffer ~size ~dtype ~spec dev)
           (buffer_params (Postrange.ast k))
       in
-      Search.beam_search
-        ~allow_test_size:(beam_estimate () <> 0)
-        k rawbufs beam_width dev)
+      Fun.protect
+        ~finally:(fun () -> List.iter Device.Buffer.deallocate rawbufs)
+        (fun () ->
+          Search.beam_search
+            ~allow_test_size:(beam_estimate () <> 0)
+            k rawbufs beam_width dev))
     device
 
 let beam_width sink =

--- a/packages/tolk/lib/codegen/opt/postrange.ml
+++ b/packages/tolk/lib/codegen/opt/postrange.ml
@@ -267,6 +267,8 @@ let to_function_name s =
   Buffer.contents buf
 
 let kernel_cnt : (string, int) Hashtbl.t = Hashtbl.create 16
+(* Guarded: beam search can generate kernel names from parallel domains. *)
+let kernel_cnt_mutex = Mutex.create ()
 
 (* Apply [flatten_range] locally: toposort-reorder range children of
    Reduce/Store/End nodes.  Inline port of [Simplify.pm_flatten_range]
@@ -334,8 +336,14 @@ let make_kernel_name t =
         (List.map (fun s -> "_" ^ s) (special_strs @ rng_strs))
   in
   let fn = to_function_name raw in
-  let cnt = 1 + Option.value ~default:0 (Hashtbl.find_opt kernel_cnt fn) in
-  Hashtbl.replace kernel_cnt fn cnt;
+  let cnt =
+    Mutex.protect kernel_cnt_mutex (fun () ->
+        let cnt =
+          1 + Option.value ~default:0 (Hashtbl.find_opt kernel_cnt fn)
+        in
+        Hashtbl.replace kernel_cnt fn cnt;
+        cnt)
+  in
   raw ^ if cnt > 1 then strf "n%d" (cnt - 1) else ""
 
 (* Finalize the kernel: generate a debug name, flatten ranges, and attach

--- a/packages/tolk/lib/codegen/opt/search.ml
+++ b/packages/tolk/lib/codegen/opt/search.ml
@@ -28,6 +28,11 @@ let beam_uops_max () = Helpers.getenv "BEAM_UOPS_MAX" 3000
 let beam_timeout_sec () = Helpers.getenv "BEAM_TIMEOUT_SEC" 10
 let beam_strict_mode () = Helpers.getenv "BEAM_STRICT_MODE" 0 <> 0
 let beam_dev_timeout () = Helpers.getenv "BEAM_DEV_TIMEOUT" 1 <> 0
+(* [BEAM_PARALLEL] sets the number of domains compiling a beam step's
+   candidates concurrently; 0 (the default) compiles sequentially. Only the
+   CPU-side compile runs in parallel — the GPU timing phase below always runs
+   one candidate at a time. *)
+let beam_parallel () = Helpers.getenv "BEAM_PARALLEL" 0
 let cachelevel () = Helpers.getenv "CACHELEVEL" 1
 let ignore_beam_cache () = Helpers.getenv "IGNORE_BEAM_CACHE" 0 <> 0
 
@@ -259,6 +264,39 @@ let try_compile ~use_timeout ((idx, s) : int * P.t) (device : Device.t)
     | _ when not (beam_strict_mode ()) -> None
   in
   (idx, result)
+
+(* Compile a beam step's candidates, optionally across domains
+   ([beam_parallel] sets the worker count; 0 is sequential). Workers only run
+   the CPU-side compile (optimize, lower, render, nvrtc); the GPU timing phase
+   runs afterwards in the main domain, one candidate at a time, so timings
+   never contend for the device. In parallel mode the per-candidate alarm
+   timeout is skipped: SIGALRM is process-global. *)
+let compile_candidates ~device ~nworkers candidates =
+  let n = List.length candidates in
+  let compiled : compiled option array = Array.make n None in
+  let compile_one ~use_timeout i cand =
+    compiled.(i) <- snd (try_compile ~use_timeout (i, cand) device)
+  in
+  if nworkers <= 0 || n < 2 then begin
+    List.iteri (compile_one ~use_timeout:true) candidates;
+    compiled
+  end else begin
+    let nworkers = min nworkers (min 16 n) in
+    let cands = Array.of_list candidates in
+    let chunk = (n + nworkers - 1) / nworkers in
+    let workers =
+      List.init nworkers (fun w ->
+          let lo = w * chunk in
+          let hi = min ((w + 1) * chunk) n in
+          Domain.spawn (fun () ->
+              for i = lo to hi - 1 do
+                compiled.(i) <-
+                  snd (try_compile ~use_timeout:false (i, cands.(i)) device)
+              done))
+    in
+    List.iter Domain.join workers;
+    compiled
+  end
 
 (* Timing *)
 
@@ -500,6 +538,7 @@ let beam_search ?(allow_test_size = true) ?disable_cache
          the expensive part. Nodes are hash-consed, so the AST's tag is an
          exact identity key. *)
       let seen_asts : (int, unit) Hashtbl.t = Hashtbl.create 256 in
+      let nworkers = beam_parallel () in
       if beam_debug > 0 then
         Format.eprintf "BEAM_SEARCH:@\n%a@." U.pp (P.ast s);
       if debug >= 2 then
@@ -548,10 +587,10 @@ let beam_search ?(allow_test_size = true) ?disable_cache
              | Failure _ | Invalid_argument _ -> ()
              | _ -> raise exn)
       in
-      let step_one timed least_compute_ops n_candidates i cand =
-        match try_compile ~use_timeout:true (i, cand) device with
-        | _, None -> ()
-        | _, Some { program; compile_time } ->
+      let consume_one timed least_compute_ops n_candidates i cand compiled =
+        match compiled with
+        | None -> ()
+        | Some { program; compile_time } ->
             let lib = match Program_spec.lib program with
               | Some l -> l
               | None -> assert false
@@ -589,8 +628,11 @@ let beam_search ?(allow_test_size = true) ?disable_cache
         let timed = ref [] in
         let least_compute_ops = ref infinity in
         let n_candidates = List.length candidates in
+        let compiled = compile_candidates ~device ~nworkers candidates in
         List.iteri
-          (step_one timed least_compute_ops n_candidates)
+          (fun i cand ->
+            consume_one timed least_compute_ops n_candidates i cand
+              compiled.(i))
           candidates;
         let opts =
           List.sort (fun (_, t1) (_, t2) -> Float.compare t1 t2) !timed

--- a/packages/tolk/lib/codegen/opt/search.ml
+++ b/packages/tolk/lib/codegen/opt/search.ml
@@ -31,10 +31,16 @@ let beam_dev_timeout () = Helpers.getenv "BEAM_DEV_TIMEOUT" 1 <> 0
 let cachelevel () = Helpers.getenv "CACHELEVEL" 1
 let ignore_beam_cache () = Helpers.getenv "IGNORE_BEAM_CACHE" 0 <> 0
 
+(* Minimum measurable progress per beam step, in microseconds (matching
+   tinygrad's [BEAM_MIN_PROGRESS] convention). The default must sit above the
+   device timer resolution — CUDA events resolve ~0.5us — otherwise the two
+   progress-based exit conditions in [beam_search] can never fire and the
+   search only stops when candidates run out. 5us is what upstream's
+   production configs use. *)
 let beam_min_progress () =
   (match Sys.getenv_opt "BEAM_MIN_PROGRESS" with
-   | Some s -> (try Float.of_string s with Failure _ -> 0.01)
-   | None -> 0.01) /. 1e6
+   | Some s -> (try Float.of_string s with Failure _ -> 5.0)
+   | None -> 5.0) /. 1e6
 
 (* Actions *)
 

--- a/packages/tolk/lib/codegen/opt/search.ml
+++ b/packages/tolk/lib/codegen/opt/search.ml
@@ -347,6 +347,16 @@ let indexed_rawbufs ~device ast rawbufs =
     (fun (req, buf) -> (req.slot, normalize_buffer_req device req buf))
     pairs
 
+(* Device dispatch handles for already-loaded compiled binaries, shared across
+   every kernel's beam search in this process and keyed by device: the driver's
+   module load (PTX -> SASS JIT) is pure CPU work and would otherwise run once
+   per timed candidate. The entry name is always "test" in beam search, so
+   the binary identifies the module; runtimevars join the key because some
+   runtimes capture them at handle creation. *)
+let prog_caches : (string, ((bytes * string), Device.prog) Hashtbl.t)
+    Hashtbl.t =
+  Hashtbl.create 4
+
 (* Time a compiled program on device. Returns a list of timing samples. *)
 let time_program ~device p rawbufs_by_slot var_vals ~early_stop ~cnt ~clear_l2
     ~allow_test_size ~dev_timeout =
@@ -365,7 +375,34 @@ let time_program ~device p rawbufs_by_slot var_vals ~early_stop ~cnt ~clear_l2
       factor := f;
       Program_spec.with_global_dims scaled_global p
   in
-  let car = Realize.Compiled_runner.create ~device p in
+  let prg =
+    match Program_spec.lib p with
+    | Some lib ->
+        let dname = Device.name device in
+        let cache =
+          match Hashtbl.find_opt prog_caches dname with
+          | Some cache -> cache
+          | None ->
+              let cache = Hashtbl.create 64 in
+              Hashtbl.replace prog_caches dname cache;
+              cache
+        in
+        let runtimevars =
+          Tolk_uop.Uop.program_runtimevars (Program_spec.program_info p)
+        in
+        let key = (lib, String.concat "," (List.map fst runtimevars)) in
+        (match Hashtbl.find_opt cache key with
+         | Some prg -> Some prg
+         | None ->
+             let name =
+               Tolk_uop.Uop.sanitize_function_name (Program_spec.name p)
+             in
+             let prg = Device.runtime device name lib ~runtimevars in
+             Hashtbl.replace cache key prg;
+             Some prg)
+    | None -> None
+  in
+  let car = Realize.Compiled_runner.create ~device ?prg p in
   let input_bufs =
     List.map
       (fun slot ->
@@ -452,6 +489,11 @@ let beam_search ?(allow_test_size = true) ?disable_cache
   | None ->
       let beam = ref [(s, infinity)] in
       let seen_libs : (bytes, unit) Hashtbl.t = Hashtbl.create 256 in
+      (* Candidates whose AST has already been compiled: applying actions in
+         different orders converges to identical programs, and compiling is
+         the expensive part. Nodes are hash-consed, so the AST's tag is an
+         exact identity key. *)
+      let seen_asts : (int, unit) Hashtbl.t = Hashtbl.create 256 in
       if beam_debug > 0 then
         Format.eprintf "BEAM_SEARCH:@\n%a@." U.pp (P.ast s);
       if debug >= 2 then
@@ -526,6 +568,17 @@ let beam_search ?(allow_test_size = true) ?disable_cache
             (fun (si, _) ->
               List.map snd (get_kernel_actions ~include_0:false si))
             !beam
+        in
+        let candidates =
+          List.filter
+            (fun cand ->
+              let k = U.tag (P.ast cand) in
+              if Hashtbl.mem seen_asts k then false
+              else begin
+                Hashtbl.replace seen_asts k ();
+                true
+              end)
+            candidates
         in
         let timed = ref [] in
         let least_compute_ops = ref infinity in

--- a/packages/tolk/lib/codegen/opt/search.ml
+++ b/packages/tolk/lib/codegen/opt/search.ml
@@ -354,7 +354,12 @@ let buffer_reqs ast =
 let normalize_buffer_req device req buf =
   if Device.Buffer.size buf < req.size
      || not (Dtype.equal (Device.Buffer.dtype buf) req.dtype)
-  then Device.create_buffer ~size:req.size ~dtype:req.dtype device
+  then
+    (* A beam timing buffer: bypass the LRU cache so a GC-collected
+       replacement returns its memory to the driver instead of piling up
+       in the allocator cache. *)
+    Device.create_buffer ~size:req.size ~dtype:req.dtype
+      ~spec:{ Device.Buffer_spec.default with nolru = true } device
   else buf
 
 let indexed_rawbufs ~device ast rawbufs =

--- a/packages/tolk/lib/device.ml
+++ b/packages/tolk/lib/device.ml
@@ -693,32 +693,39 @@ let compile_program d ?name ?(applied_opts = []) ?(estimates = Program_spec.Esti
       }
   in
   let ckey = make_key ~device:d.name ~base:false in
-  Mutex.lock Program_cache.mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock Program_cache.mutex)
-    (fun () ->
-      match Program_cache.Cache.find_opt Program_cache.cache ckey with
-      | Some cached -> cached
-      | None ->
-          let bkey =
-            make_key ~device:(Program_cache.base_device d.name) ~base:true
-          in
-          let build_spec () =
+  (* The mutex only guards the table: render and nvrtc run unlocked, so
+     beam-search candidates compiled in parallel domains overlap. A
+     concurrent build of the same key is benign — identical work — and the
+     first insertion wins. *)
+  let cache_find key =
+    Mutex.protect Program_cache.mutex (fun () ->
+        Program_cache.Cache.find_opt Program_cache.cache key)
+  in
+  let cache_add key spec =
+    Mutex.protect Program_cache.mutex (fun () ->
+        match Program_cache.Cache.find_opt Program_cache.cache key with
+        | Some existing -> existing
+        | None ->
+            Program_cache.Cache.add Program_cache.cache key spec;
+            spec)
+  in
+  match cache_find ckey with
+  | Some cached -> cached
+  | None ->
+      let bkey =
+        make_key ~device:(Program_cache.base_device d.name) ~base:true
+      in
+      let spec =
+        match cache_find bkey with
+        | Some cached -> cached
+        | None ->
             let src = Renderer.render ren ~name:kernel_name program in
             let lib = Compiler.compile_cached comp src in
             Program_spec.of_program ~name:kernel_name ~src ~device:d.name
               ~lib ~applied_opts ~estimates program
-          in
-          let spec =
-            match Program_cache.Cache.find_opt Program_cache.cache bkey with
-            | Some cached -> cached
-            | None ->
-                let s = build_spec () in
-                Program_cache.Cache.add Program_cache.cache bkey s;
-                s
-          in
-          Program_cache.Cache.add Program_cache.cache ckey spec;
-          spec)
+      in
+      ignore (cache_add bkey spec);
+      cache_add ckey spec
 
 let create_buffer ~size ~dtype ?spec d =
   Buffer.create ~device:d.name ~size ~dtype ?spec d.allocator

--- a/packages/tolk/lib/diskcache.ml
+++ b/packages/tolk/lib/diskcache.ml
@@ -71,13 +71,19 @@ let get ~table ~key =
 
 (* Write-then-rename keeps entries atomic: a concurrent reader or writer of
    the same key never observes a partially written file, only the previous
-   complete entry or the new one. The temporary name is per-pid, so
-   concurrent writers in different processes cannot clobber each other's
+   complete entry or the new one. The temporary name carries the pid and a
+   process-unique counter, so concurrent writers — in different processes or
+   in different domains of the same one — cannot clobber each other's
    in-progress writes. *)
+let tmp_counter = Atomic.make 0
+
 let put ~table ~key value =
   let path = cache_path ~table ~key in
   ensure_dir (Filename.dirname path);
-  let tmp = path ^ ".tmp." ^ string_of_int (Unix.getpid ()) in
+  let tmp =
+    Printf.sprintf "%s.tmp.%d.%d" path (Unix.getpid ())
+      (Atomic.fetch_and_add tmp_counter 1)
+  in
   try
     let oc = open_out_bin tmp in
     (try

--- a/packages/tolk/lib/runtime/cuda/dune
+++ b/packages/tolk/lib/runtime/cuda/dune
@@ -7,4 +7,5 @@
  (foreign_stubs
   (language c)
   (names tolk_cuda_stubs))
- (c_library_flags (-ldl)))
+ (c_library_flags
+  (-ldl -lpthread)))

--- a/packages/tolk/lib/runtime/cuda/tolk_cuda_stubs.c
+++ b/packages/tolk/lib/runtime/cuda/tolk_cuda_stubs.c
@@ -11,6 +11,7 @@
 #include <caml/mlvalues.h>
 #include <caml/threads.h>
 #include <dlfcn.h>
+#include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -708,11 +709,14 @@ static nvrtcResult (*p_nvrtcDestroyProgram)(nvrtcProgram *);
 
 static void *nvrtc_handle = NULL;
 
-static void ensure_nvrtc(void) {
+/* pthread_once: beam search can call nvrtc_compile from several OCaml
+   domains concurrently, and the first of them loads the library. */
+static pthread_once_t nvrtc_once = PTHREAD_ONCE_INIT;
+
+static void load_nvrtc(void) {
   static const char *names[] = {"libnvrtc.so", "libnvrtc.so.13",
                                 "libnvrtc.so.12",
                                 "/usr/local/cuda/lib64/libnvrtc.so", NULL};
-  if (nvrtc_handle != NULL) return;
   for (int i = 0; nvrtc_handle == NULL && names[i] != NULL; ++i)
     nvrtc_handle = dlopen(names[i], RTLD_LAZY | RTLD_LOCAL);
   if (nvrtc_handle == NULL)
@@ -732,6 +736,11 @@ static void ensure_nvrtc(void) {
   LOAD_NVRTC(p_nvrtcGetErrorString, "nvrtcGetErrorString");
   LOAD_NVRTC(p_nvrtcDestroyProgram, "nvrtcDestroyProgram");
 #undef LOAD_NVRTC
+}
+
+static void ensure_nvrtc(void) {
+  if (pthread_once(&nvrtc_once, load_nvrtc) != 0)
+    caml_failwith("NVRTC initialisation failed");
 }
 
 CAMLprim value caml_tolk_cuda_nvrtc_version(value unit) {

--- a/packages/tolk/lib/schedule/rangeify.ml
+++ b/packages/tolk/lib/schedule/rangeify.ml
@@ -1795,12 +1795,24 @@ let fix_war_deps root =
         List.iter (fun s ->
             if s != u_buf then
               match U.Ref_tbl.find_opt kernel_assign s with
-              | Some a when not (call_of a <> None && call_of a = call_of u) ->
-                  let prev =
-                    Option.value (U.Ref_tbl.find_opt assign_rep a) ~default:[]
-                  in
-                  if not (List.exists (( == ) u) prev) then
-                    U.Ref_tbl.replace assign_rep a (u :: prev)
+              | Some a -> (
+                  (* A WAR dep between two AFTERs is only needed across
+                     different calls: within one call the ordering is the
+                     call's own business. Calls are unique graph nodes, so
+                     identity is the test — structural equality walks both
+                     calls' whole payload DAGs (a staged loop call carries
+                     its entire body program), which is pathologically slow
+                     and compares nodes that should simply be [==]. *)
+                  match (call_of a, call_of u) with
+                  | Some ca, Some cu when ca == cu -> ()
+                  | _ ->
+                      let prev =
+                        Option.value
+                          (U.Ref_tbl.find_opt assign_rep a)
+                          ~default:[]
+                      in
+                      if not (List.exists (( == ) u) prev) then
+                        U.Ref_tbl.replace assign_rep a (u :: prev))
               | _ -> ()) reads) afters;
     if U.Ref_tbl.length assign_rep = 0 then root
     else

--- a/packages/tolk/lib/uop/uop.ml
+++ b/packages/tolk/lib/uop/uop.ml
@@ -286,7 +286,14 @@ module H = Hashcons.Make (Node_hashed)
 
 let global_table = H.create 4096
 
-let intern_node node = H.hashcons global_table node
+(* Hash-consing and node metadata are global mutable state: beam search can
+   compile candidates in parallel domains, so every access takes this lock.
+   No other [intern_mutex] section nests inside one, and [min_max_mutex]
+   below is a separate lock, so there is no lock ordering to deadlock on. *)
+let intern_mutex = Mutex.create ()
+
+let intern_node node =
+  Mutex.protect intern_mutex (fun () -> H.hashcons global_table node)
 
 module Side_metadata_tbl = Hashtbl.Make (struct
   type nonrec t = t
@@ -366,11 +373,14 @@ let src u = u.Hashcons.node.src
 let arg u = u.Hashcons.node.arg
 let node_tag u = u.Hashcons.node.node_tag
 let tag u = u.Hashcons.tag
-let metadata u = Option.value (Side_metadata_tbl.find_opt side_metadata u) ~default:[]
+let metadata u =
+  Mutex.protect intern_mutex (fun () ->
+      Option.value (Side_metadata_tbl.find_opt side_metadata u) ~default:[])
 
 let with_metadata md u =
-  Side_metadata_tbl.replace side_metadata u md;
-  u
+  Mutex.protect intern_mutex (fun () ->
+      Side_metadata_tbl.replace side_metadata u md;
+      u)
 
 let children u = Array.to_list (src u)
 let equal a b = a.Hashcons.tag = b.Hashcons.tag
@@ -1696,12 +1706,16 @@ let substitute ?(walk = false) mappings root =
 
 let min_max_cache : (int * int) Ref_tbl.t = Ref_tbl.create 1024
 
+let min_max_mutex = Mutex.create ()
+
 let rec min_max u =
-  match Ref_tbl.find_opt min_max_cache u with
+  match
+    Mutex.protect min_max_mutex (fun () -> Ref_tbl.find_opt min_max_cache u)
+  with
   | Option.Some mm -> mm
   | Option.None ->
       let mm = compute_min_max u in
-      Ref_tbl.replace min_max_cache u mm;
+      Mutex.protect min_max_mutex (fun () -> Ref_tbl.replace min_max_cache u mm);
       mm
 
 and compute_min_max u =


### PR DESCRIPTION
## perf/tolk: faster and more memory-safe beam search

Five focused commits on top of `main` that speed up tolk's `BEAM`-search compilation and fix a GPU OOM under `BEAM>=1`. `+264/−55` across 10 files, all in `packages/tolk`, under the `### Tolk` changelog section.

### 1. Fix GPU OOM under `BEAM>=1` (`1bc5a7ab`)
Beam search allocates per-kernel raw timing buffers that were only reclaimed by the GC — and then only into the allocator's unbounded, exact-size-match LRU cache. Models with many distinct kernel shapes therefore accumulated their timing buffers for the whole compile, OOM-ing where `BEAM=0` fit. Timing buffers now bypass the LRU cache (`Buffer_spec.nolru`) and are deallocated deterministically as soon as each kernel's search finishes.
- Measured on a 12-matmul chain with distinct shapes (CUDA): BEAM=2 peak GPU usage **364 → 288 MiB** (BEAM=0 baseline 276 MiB).

### 2. Parallel candidate compilation — `BEAM_PARALLEL` (`646dc955`)
New opt-in env flag: compiles a beam step's candidates across N OCaml 5 domains. Only the CPU side (optimize / lower / render / nvrtc) runs in parallel; the GPU timing phase stays strictly sequential so candidate rankings stay meaningful. Making it safe required guarding the global shared state (hash-cons table, shape memoisation, kernel-name counter, program cache, disk cache, nvrtc lazy init).
- Measured (repro_jit_beam, CUDA, BEAM=2, cleared tolk + driver JIT caches): **27s → 6s** with `BEAM_PARALLEL=8`; warm caches ~11s → ~7s; CPU device 57s → 20s at `BEAM_PARALLEL=4`. No measurable sequential-regression from the new mutexes (interleaved old/new binaries).

### 3. Stop searching when progress is below timer noise (`5d4736b6`)
`BEAM_MIN_PROGRESS` default was 0.01µs (10ns) — below the CUDA event timer resolution (~0.5µs), so both progress-exit conditions were dead code and every kernel searched to exhaustion. Default raised to 5µs (still µs-denominated, matching upstream tinygrad's production configs; env still overrides).
- Effect: ~2.6× fewer candidate compiles per CUDA BEAM=2 pass, and much less run-to-run noise in the winning kernels.

### 4. Cut redundant per-candidate work (`4987c343`)
- **Module-load cache:** the driver's `cuModuleLoadData` (PTX→SASS JIT) ran per timed candidate; now one `Device.prog` handle per `(device, binary, runtimevars)`.
- **Pre-compile AST dedup:** candidates that converge to an already-compiled AST (hash-consed tag identity) are skipped *before* nvrtc, not after.

### 5. Same-call WAR deps by identity, not structural equality (`df1faa40`)
In `fix_war_deps`, the same-call test used polymorphic `=` on call nodes. With hash-consed `Uop.t` the verdicts are identical, but `=` descends into the whole shared payload DAGs — exponentially slow on heavy sharing — where `==` is O(1).

### Notes
- All changes are behavior-preserving except the intended ones (new `BEAM_PARALLEL` opt-in; timing-buffer release; more aggressive default beam exit).
- Same results verified via `repro_jit_beam` eager-vs-jit checks (CUDA + CPU) and the tolk test suite (unchanged, apart from two pre-existing vendored-tinygrad parity failures present on `main` too).