### PR TITLE
feat(vega)!: Jit-compilable optimizer steps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,10 @@ All notable changes to this project will be documented in this file.
   delegate to it, by hand or via `ppx_ptree`), threaded across compiled
   calls as ordinary leaves. The leaf order (payload leaves, then the counter) is part
   of a compiled step's leaf signature and is fixed.
+- **Breaking:** `sgd_state` is `{ velocity; step }` — every structural state
+  now carries its step counter, a scalar `int32` tensor, so a schedule
+  applies to `st.step` whichever optimizer is stepping; without it an SGD
+  loop under `jit` had to thread a counter of its own.
 - **Breaking:** `adam_state` is `{ mu; nu; step }` — `step` is a scalar
   `int32` tensor, the number of completed steps. A host `int` counter burned
   the Adam bias corrections into the trace at compile time and replayed them

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,38 +14,41 @@ All notable changes to this project will be documented in this file.
 ### Vega
 
 - Optimizer state now compiles. The structural states are parameter trees —
-  `Sgd_state.Make (P)` and `Adam_state.Make (P)` produce the `Nx.Ptree.S`
-  for the state over a parameter tree `P` (plus flat `map`/`map2`/`iter`), so
-  the state is one field of a `Rune.jit2`/`pmap2` step's input and output
-  records, threaded across compiled calls as ordinary leaves. The leaf order
-  (payload leaves, then scalars) is part of a compiled step's leaf signature
-  and is fixed.
-- **Breaking:** `adam_state` is `{ mu; nu; c1; c2; step }` — the bias
-  corrections `c1 = 1 - b1^step` and `c2 = 1 - b2^step` are scalar `float64`
-  tensors and `step` is a scalar `int32` tensor, advanced inside the step by
-  affine recurrences (`c' = (1 - b) + b*c`). A host `int` counter burned the
-  correction into the trace at compile time and replayed it stale on every
-  later call; the tensors track correctly under `jit`. Seed values: zero
-  corrections, counter zero.
+  `Vega.Sgd_state (P)` and `Vega.Adam_state (P)` are the `Nx.Ptree.S` for the
+  state over a parameter tree `P` — so the state is one field of a
+  `Rune.jit2`/`pmap2` step's input and output records (whose traversals
+  delegate to it, by hand or via `ppx_ptree`), threaded across compiled
+  calls as ordinary leaves. The leaf order (payload leaves, then the counter) is part
+  of a compiled step's leaf signature and is fixed.
+- **Breaking:** `adam_state` is `{ mu; nu; step }` — `step` is a scalar
+  `int32` tensor, the number of completed steps. A host `int` counter burned
+  the Adam bias corrections into the trace at compile time and replayed them
+  stale on every later call; the tensor counter tracks correctly under `jit`,
+  and the corrections `1 - b^t` are derived from it inside each step, per
+  leaf at the leaf's dtype (`float64` parameters keep their exact analytic
+  corrections). The state carries nothing the counter does not determine, so
+  checkpoints hold the moments plus one scalar.
 - **Breaking:** the structural step functions take the learning rate as a
-  scalar tensor: `~lr:(float, 'b) Nx.t`, cast to each leaf's dtype.
-  `Vega.lr v` is the constant-rate helper (`Nx.scalar Nx.float64 v`); a
-  scheduled rate derives from the state's `step` leaf inside the step — see
-  the new tensor schedules. The per-element arithmetic is otherwise
-  unchanged, and eager trajectories are preserved (float32 parameters see
-  bit-identical updates).
-- Add tensor schedules mirroring the scalar family over a scalar `int32` step
-  counter, so a learning rate is derived inside a compiled program:
-  `Schedule.constant_t`, `linear_t`, `cosine_decay_t`, `warmup_cosine_t`,
-  `warmup_cosine_decay_t`, `one_cycle_t`, `piecewise_constant_t`. At every
-  integer step the tensor value matches the scalar schedule's (to float32
-  rounding). `exponential_decay`, `polynomial_decay` and
-  `cosine_decay_restarts` remain scalar-only for now (they need `pow` and
-  integer division on tensors).
-- `clip_by_global_norm` computes its scale factor in tensor arithmetic and
-  selects it with `Nx.where` — no host read — so it traces under `jit` and can
-  sit between a jitted backward pass and a jitted optimizer step.
-  `global_norm` remains the host-float read for reporting.
+  scalar tensor: `~lr:(float, 'b) Nx.t`, cast to each leaf's dtype. `Vega.lr
+  v` is the constant-rate helper (`Nx.scalar Nx.float32 v`; any float dtype
+  is accepted, so `float64` loops can pass a `float64` rate); a scheduled
+  rate is the schedule applied to the state's `step` leaf. The per-element
+  arithmetic is otherwise unchanged.
+- **Breaking:** `Schedule.t` is now a function from a scalar `int32` step
+  tensor to a scalar `float32` rate tensor — pure tensor arithmetic, so one
+  schedule family serves eager loops and compiled steps alike, every
+  schedule included (`exponential_decay`, `polynomial_decay` and
+  `cosine_decay_restarts` too). `Schedule.eval` reads a schedule at a host
+  `int` for logging and eager loops that keep their own count; the
+  per-tensor tier (`scale_by_schedule`, `scale_by_learning_rate`,
+  `add_decayed_weights`, the aliases) is unchanged at its call sites.
+  `cosine_decay_restarts` now validates `t_mul >= 1` and `m_mul > 0`, and
+  `exponential_decay` validates `decay_rate > 0`.
+- `clip_by_global_norm` computes its scale factor in `float32` tensor
+  arithmetic and selects it with `Nx.where` — no host read — so it traces
+  under `jit` on any device and can sit between a jitted backward pass and a
+  jitted optimizer step. `global_norm` remains the `float64` host read for
+  reporting.
 
 ### Ppx_ptree (new)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,42 @@ All notable changes to this project will be documented in this file.
 
 - Add compatibility with OCaml 5.5.
 
+### Vega
+
+- Optimizer state now compiles. The structural states are parameter trees —
+  `Sgd_state.Make (P)` and `Adam_state.Make (P)` produce the `Nx.Ptree.S`
+  for the state over a parameter tree `P` (plus flat `map`/`map2`/`iter`), so
+  the state is one field of a `Rune.jit2`/`pmap2` step's input and output
+  records, threaded across compiled calls as ordinary leaves. The leaf order
+  (payload leaves, then scalars) is part of a compiled step's leaf signature
+  and is fixed.
+- **Breaking:** `adam_state` is `{ mu; nu; c1; c2; step }` — the bias
+  corrections `c1 = 1 - b1^step` and `c2 = 1 - b2^step` are scalar `float64`
+  tensors and `step` is a scalar `int32` tensor, advanced inside the step by
+  affine recurrences (`c' = (1 - b) + b*c`). A host `int` counter burned the
+  correction into the trace at compile time and replayed it stale on every
+  later call; the tensors track correctly under `jit`. Seed values: zero
+  corrections, counter zero.
+- **Breaking:** the structural step functions take the learning rate as a
+  scalar tensor: `~lr:(float, 'b) Nx.t`, cast to each leaf's dtype.
+  `Vega.lr v` is the constant-rate helper (`Nx.scalar Nx.float64 v`); a
+  scheduled rate derives from the state's `step` leaf inside the step — see
+  the new tensor schedules. The per-element arithmetic is otherwise
+  unchanged, and eager trajectories are preserved (float32 parameters see
+  bit-identical updates).
+- Add tensor schedules mirroring the scalar family over a scalar `int32` step
+  counter, so a learning rate is derived inside a compiled program:
+  `Schedule.constant_t`, `linear_t`, `cosine_decay_t`, `warmup_cosine_t`,
+  `warmup_cosine_decay_t`, `one_cycle_t`, `piecewise_constant_t`. At every
+  integer step the tensor value matches the scalar schedule's (to float32
+  rounding). `exponential_decay`, `polynomial_decay` and
+  `cosine_decay_restarts` remain scalar-only for now (they need `pow` and
+  integer division on tensors).
+- `clip_by_global_norm` computes its scale factor in tensor arithmetic and
+  selects it with `Nx.where` — no host read — so it traces under `jit` and can
+  sit between a jitted backward pass and a jitted optimizer step.
+  `global_norm` remains the host-float read for reporting.
+
 ### Ppx_ptree (new)
 
 - `[@@deriving ptree]` recognises a field typed `Nx.Rng.key` as a tensor leaf.

--- a/bench/migrate/models/char_lstm/model.ml
+++ b/bench/migrate/models/char_lstm/model.ml
@@ -199,7 +199,7 @@ let train_step spec (s : Step_in.t) =
   let params, st =
     Vega.sgd_step
       (module Model)
-      ~lr:spec.lr ~momentum:spec.momentum { velocity = s.velocity }
+      ~lr:(Vega.lr spec.lr) ~momentum:spec.momentum { velocity = s.velocity }
       ~params:s.params ~grads
   in
   { Step_out.params; velocity = st.velocity; loss = l }

--- a/packages/fehu/examples/03-reinforce/main.ml
+++ b/packages/fehu/examples/03-reinforce/main.ml
@@ -170,7 +170,7 @@ let () =
 
     let loss, grads = Rune.value_and_grad policy_tree loss_fn !params in
     let new_params, new_opt_state =
-      Vega.adam_step policy_tree ~lr !opt_state ~params:!params ~grads
+      Vega.adam_step policy_tree ~lr:(Vega.lr lr) !opt_state ~params:!params ~grads
     in
     params := new_params;
     opt_state := new_opt_state;

--- a/packages/fehu/examples/04-dqn/main.ml
+++ b/packages/fehu/examples/04-dqn/main.ml
@@ -211,7 +211,7 @@ let () =
 
     let loss, grads = Rune.value_and_grad q_tree loss_fn !params in
     let new_params, new_opt_state =
-      Vega.adam_step q_tree ~lr !opt_state ~params:!params ~grads
+      Vega.adam_step q_tree ~lr:(Vega.lr lr) !opt_state ~params:!params ~grads
     in
     params := new_params;
     opt_state := new_opt_state;

--- a/packages/kaun/bench/bench_kaun.ml
+++ b/packages/kaun/bench/bench_kaun.ml
@@ -129,14 +129,14 @@ let () =
   let adam_step () =
     let l, grads = Rune.value_and_grad (module Mlp) loss params in
     let params', state' =
-      Vega.adam_step (module Mlp) ~lr adam_state ~params ~grads
+      Vega.adam_step (module Mlp) ~lr:(Vega.lr lr) adam_state ~params ~grads
     in
     (l, params', state')
   in
   let sgd_step () =
     let l, grads = Rune.value_and_grad (module Mlp) loss params in
     let params', state' =
-      Vega.sgd_step (module Mlp) ~lr sgd_state ~params ~grads
+      Vega.sgd_step (module Mlp) ~lr:(Vega.lr lr) sgd_state ~params ~grads
     in
     (l, params', state')
   in
@@ -156,7 +156,7 @@ let () =
   let cnn_step () =
     let l, grads = Rune.value_and_grad (module Cnn) cnn_loss cnn_params in
     let params', state' =
-      Vega.adam_step (module Cnn) ~lr cnn_state ~params:cnn_params ~grads
+      Vega.adam_step (module Cnn) ~lr:(Vega.lr lr) cnn_state ~params:cnn_params ~grads
     in
     (l, params', state')
   in

--- a/packages/kaun/doc/01-getting-started.md
+++ b/packages/kaun/doc/01-getting-started.md
@@ -85,7 +85,7 @@ let () =
   let step (params, ostate) =
     let l, grads = Rune.value_and_grad mlp loss params in
     let params, ostate =
-      Vega.adam_step mlp ~lr:0.05 ostate ~params ~grads
+      Vega.adam_step mlp ~lr:(Vega.lr 0.05) ostate ~params ~grads
     in
     ((params, ostate), Nx.item [] l)
   in
@@ -139,7 +139,7 @@ let step (params, ostate) (x, y) =
   let loss p = Loss.softmax_cross_entropy_sparse (Mlp.apply p x) y in
   let l, grads = Rune.value_and_grad mlp loss params in
   let params, ostate =
-    Vega.adamw_step mlp ~lr:1e-3 ostate ~params ~grads
+    Vega.adamw_step mlp ~lr:(Vega.lr 1e-3) ostate ~params ~grads
   in
   ((params, ostate), Nx.item [] l)
 ```

--- a/packages/kaun/doc/02-layers-and-models.md
+++ b/packages/kaun/doc/02-layers-and-models.md
@@ -212,7 +212,7 @@ let () =
       Rune.value_and_grad_aux net objective params
     in
     let params, ostate =
-      Vega.adam_step net ~lr:1e-2 ostate ~params ~grads
+      Vega.adam_step net ~lr:(Vega.lr 1e-2) ostate ~params ~grads
     in
     ((params, stats', ostate), Nx.item [] loss)
   in

--- a/packages/kaun/doc/03-training.md
+++ b/packages/kaun/doc/03-training.md
@@ -49,23 +49,16 @@ Because the step is yours, extensions are insertions, not configuration. Gradien
 let grads = Vega.clip_by_global_norm mlp ~max_norm:1.0 grads in
 ```
 
-A learning-rate schedule is a function `int -> float` you evaluate at your own step counter — or, inside a jitted step, its tensor mirror evaluated at the state's own step leaf:
+A learning-rate schedule maps the state's step counter to that step's rate, in tensor arithmetic — so the same line works in an eager loop and inside a jitted step, where the rate derives from the state's own counter leaf:
 
 <!-- $MDX skip -->
 ```ocaml
 let sched =
   Vega.Schedule.cosine_decay ~init_value:1e-3 ~decay_steps:1000 ()
 in
-let step k (params, ostate) (x, y) =
+let step (params, ostate) (x, y) =
   ...
-  Vega.adamw_step mlp ~lr:(sched k) ostate ~params ~grads
-
-(* jitted: the rate derives inside the compiled program from ostate.step *)
-let lr =
-  Vega.Schedule.cosine_decay_t ~init_value:1e-3 ~decay_steps:1000
-    ostate.step
-in
-... Vega.adamw_step mlp ~lr ostate ~params ~grads
+  Vega.adamw_step mlp ~lr:(sched ostate.step) ostate ~params ~grads
 ```
 
 ## Optimizers
@@ -75,8 +68,8 @@ Vega's structural optimizers step whole parameter structures. Each keeps its sta
 | Optimizer | Init | Step | State |
 |-----------|------|------|-------|
 | SGD (+ momentum) | `Vega.sgd_init` | `Vega.sgd_step ~lr ?momentum` | `{ velocity }` |
-| Adam | `Vega.adam_init` | `Vega.adam_step ~lr ?b1 ?b2 ?eps` | `{ mu; nu; c1; c2; step }` |
-| AdamW | `Vega.adamw_init` | `Vega.adamw_step ~lr ... ?weight_decay` | `{ mu; nu; c1; c2; step }` |
+| Adam | `Vega.adam_init` | `Vega.adam_step ~lr ?b1 ?b2 ?eps` | `{ mu; nu; step }` |
+| AdamW | `Vega.adamw_init` | `Vega.adamw_step ~lr ... ?weight_decay` | `{ mu; nu; step }` |
 
 Steps are pure: they consume a state and return `(params', state')`. AdamW's `weight_decay` defaults to `0.01` and is decoupled — applied to the parameters directly rather than through the adaptive scaling.
 
@@ -91,7 +84,7 @@ let () =
   in
   let ostate = Vega.adamw_init mlp params in
   (* The moments have the parameters' type, inspectable like them; the
-     corrections and the counter are scalar tensors. *)
+     counter is a scalar tensor. *)
   Format.printf "mu.l1.w: %a  step: %d@." Nx.pp_shape
     (Nx.shape ostate.mu.l1.w)
     (Int32.to_int (Nx.item [] ostate.step))

--- a/packages/kaun/doc/03-training.md
+++ b/packages/kaun/doc/03-training.md
@@ -35,7 +35,7 @@ let step (params, ostate) (x, y) =
   let loss p = Loss.softmax_cross_entropy_sparse (Mlp.apply p x) y in
   let l, grads = Rune.value_and_grad mlp loss params in
   let params, ostate =
-    Vega.adamw_step mlp ~lr:1e-3 ostate ~params ~grads
+    Vega.adamw_step mlp ~lr:(Vega.lr 1e-3) ostate ~params ~grads
   in
   ((params, ostate), Nx.item [] l)
 ```
@@ -49,7 +49,7 @@ Because the step is yours, extensions are insertions, not configuration. Gradien
 let grads = Vega.clip_by_global_norm mlp ~max_norm:1.0 grads in
 ```
 
-A learning-rate schedule is a function `int -> float` you evaluate at your own step counter:
+A learning-rate schedule is a function `int -> float` you evaluate at your own step counter — or, inside a jitted step, its tensor mirror evaluated at the state's own step leaf:
 
 <!-- $MDX skip -->
 ```ocaml
@@ -59,6 +59,13 @@ in
 let step k (params, ostate) (x, y) =
   ...
   Vega.adamw_step mlp ~lr:(sched k) ostate ~params ~grads
+
+(* jitted: the rate derives inside the compiled program from ostate.step *)
+let lr =
+  Vega.Schedule.cosine_decay_t ~init_value:1e-3 ~decay_steps:1000
+    ostate.step
+in
+... Vega.adamw_step mlp ~lr ostate ~params ~grads
 ```
 
 ## Optimizers
@@ -68,8 +75,8 @@ Vega's structural optimizers step whole parameter structures. Each keeps its sta
 | Optimizer | Init | Step | State |
 |-----------|------|------|-------|
 | SGD (+ momentum) | `Vega.sgd_init` | `Vega.sgd_step ~lr ?momentum` | `{ velocity }` |
-| Adam | `Vega.adam_init` | `Vega.adam_step ~lr ?b1 ?b2 ?eps` | `{ mu; nu; step }` |
-| AdamW | `Vega.adamw_init` | `Vega.adamw_step ~lr ... ?weight_decay` | `{ mu; nu; step }` |
+| Adam | `Vega.adam_init` | `Vega.adam_step ~lr ?b1 ?b2 ?eps` | `{ mu; nu; c1; c2; step }` |
+| AdamW | `Vega.adamw_init` | `Vega.adamw_step ~lr ... ?weight_decay` | `{ mu; nu; c1; c2; step }` |
 
 Steps are pure: they consume a state and return `(params', state')`. AdamW's `weight_decay` defaults to `0.01` and is decoupled — applied to the parameters directly rather than through the adaptive scaling.
 
@@ -83,10 +90,11 @@ let () =
     }
   in
   let ostate = Vega.adamw_init mlp params in
-  (* The moments have the parameters' type, inspectable like them. *)
+  (* The moments have the parameters' type, inspectable like them; the
+     corrections and the counter are scalar tensors. *)
   Format.printf "mu.l1.w: %a  step: %d@." Nx.pp_shape
     (Nx.shape ostate.mu.l1.w)
-    ostate.step
+    (Int32.to_int (Nx.item [] ostate.step))
 ```
 
 ## Losses

--- a/packages/kaun/doc/03-training.md
+++ b/packages/kaun/doc/03-training.md
@@ -67,7 +67,7 @@ Vega's structural optimizers step whole parameter structures. Each keeps its sta
 
 | Optimizer | Init | Step | State |
 |-----------|------|------|-------|
-| SGD (+ momentum) | `Vega.sgd_init` | `Vega.sgd_step ~lr ?momentum` | `{ velocity }` |
+| SGD (+ momentum) | `Vega.sgd_init` | `Vega.sgd_step ~lr ?momentum` | `{ velocity; step }` |
 | Adam | `Vega.adam_init` | `Vega.adam_step ~lr ?b1 ?b2 ?eps` | `{ mu; nu; step }` |
 | AdamW | `Vega.adamw_init` | `Vega.adamw_step ~lr ... ?weight_decay` | `{ mu; nu; step }` |
 

--- a/packages/kaun/doc/04-checkpoints-and-pretrained.md
+++ b/packages/kaun/doc/04-checkpoints-and-pretrained.md
@@ -101,7 +101,10 @@ let () =
          Checkpoint.of_params (module Mlp) ~prefix:"model" params;
          Checkpoint.of_params (module Mlp) ~prefix:"optim.mu" ostate.mu;
          Checkpoint.of_params (module Mlp) ~prefix:"optim.nu" ostate.nu;
-         Checkpoint.of_int "optim.step" ostate.step;
+         Checkpoint.of_tensor "optim.c1" ostate.c1;
+         Checkpoint.of_tensor "optim.c2" ostate.c2;
+         Checkpoint.of_int "optim.step"
+           (Int32.to_int (Nx.item [] ostate.step));
        ]);
 
   (* Resuming: extract each section with its own prefix. *)
@@ -114,12 +117,16 @@ let () =
     {
       Vega.mu = Checkpoint.to_params (module Mlp) ~prefix:"optim.mu" ~like ckpt;
       nu = Checkpoint.to_params (module Mlp) ~prefix:"optim.nu" ~like ckpt;
-      step = Checkpoint.to_int "optim.step" ckpt;
+      c1 = Nx.Ptree.unpack Nx.float64 (Checkpoint.get "optim.c1" ckpt);
+      c2 = Nx.Ptree.unpack Nx.float64 (Checkpoint.get "optim.c2" ckpt);
+      step =
+        Nx.scalar Nx.int32
+          (Int32.of_int (Checkpoint.to_int "optim.step" ckpt));
     }
   in
   Sys.remove path;
   ignore params;
-  Printf.printf "resumed at step %d\n" ostate.step
+  Printf.printf "resumed at step %d\n" (Int32.to_int (Nx.item [] ostate.step))
 ```
 
 The optimizer moments checkpoint with the *model's* module because they have the model's shape — one more payoff of parameter-shaped state. `Batch_norm` running statistics work the same way, under their own prefix with `(module Batch_norm.Stats)`.

--- a/packages/kaun/doc/04-checkpoints-and-pretrained.md
+++ b/packages/kaun/doc/04-checkpoints-and-pretrained.md
@@ -101,10 +101,7 @@ let () =
          Checkpoint.of_params (module Mlp) ~prefix:"model" params;
          Checkpoint.of_params (module Mlp) ~prefix:"optim.mu" ostate.mu;
          Checkpoint.of_params (module Mlp) ~prefix:"optim.nu" ostate.nu;
-         Checkpoint.of_tensor "optim.c1" ostate.c1;
-         Checkpoint.of_tensor "optim.c2" ostate.c2;
-         Checkpoint.of_int "optim.step"
-           (Int32.to_int (Nx.item [] ostate.step));
+         Checkpoint.of_tensor "optim.step" ostate.step;
        ]);
 
   (* Resuming: extract each section with its own prefix. *)
@@ -117,11 +114,7 @@ let () =
     {
       Vega.mu = Checkpoint.to_params (module Mlp) ~prefix:"optim.mu" ~like ckpt;
       nu = Checkpoint.to_params (module Mlp) ~prefix:"optim.nu" ~like ckpt;
-      c1 = Nx.Ptree.unpack Nx.float64 (Checkpoint.get "optim.c1" ckpt);
-      c2 = Nx.Ptree.unpack Nx.float64 (Checkpoint.get "optim.c2" ckpt);
-      step =
-        Nx.scalar Nx.int32
-          (Int32.of_int (Checkpoint.to_int "optim.step" ckpt));
+      step = Nx.Ptree.unpack Nx.int32 (Checkpoint.get "optim.step" ckpt);
     }
   in
   Sys.remove path;

--- a/packages/kaun/doc/05-pytorch-comparison.md
+++ b/packages/kaun/doc/05-pytorch-comparison.md
@@ -114,7 +114,7 @@ let step (params, ostate) (x, y) =
   let loss p = Loss.softmax_cross_entropy_sparse (Mlp.apply p x) y in
   let l, grads = Rune.value_and_grad mlp loss params in
   let params, ostate =
-    Vega.adamw_step mlp ~lr:1e-3 ostate ~params ~grads
+    Vega.adamw_step mlp ~lr:(Vega.lr 1e-3) ostate ~params ~grads
   in
   ((params, ostate), Nx.item [] l)
 ```

--- a/packages/kaun/doc/index.md
+++ b/packages/kaun/doc/index.md
@@ -57,7 +57,7 @@ let () =
   let step (params, ostate) =
     let l, grads = Rune.value_and_grad mlp loss params in
     let params, ostate =
-      Vega.adam_step mlp ~lr:0.05 ostate ~params ~grads
+      Vega.adam_step mlp ~lr:(Vega.lr 0.05) ostate ~params ~grads
     in
     ((params, ostate), Nx.item [] l)
   in

--- a/packages/kaun/examples/01-xor/main.ml
+++ b/packages/kaun/examples/01-xor/main.ml
@@ -51,7 +51,7 @@ let () =
   let step (params, ostate) =
     let l, grads = Rune.value_and_grad mlp loss params in
     let params, ostate =
-      Vega.adam_step mlp ~lr:0.05 ostate ~params ~grads
+      Vega.adam_step mlp ~lr:(Vega.lr 0.05) ostate ~params ~grads
     in
     ((params, ostate), Nx.item [] l)
   in

--- a/packages/kaun/examples/02-mnist/main.ml
+++ b/packages/kaun/examples/02-mnist/main.ml
@@ -58,7 +58,7 @@ let () =
         let loss p = Loss.softmax_cross_entropy_sparse (Mlp.apply p x) y in
         let l, grads = Rune.value_and_grad mlp loss params in
         let params, ostate =
-          Vega.adamw_step mlp ~lr ostate ~params ~grads
+          Vega.adamw_step mlp ~lr:(Vega.lr lr) ostate ~params ~grads
         in
         ((params, ostate), Nx.item [] l)
       in

--- a/packages/kaun/examples/03-mnist-cnn/main.ml
+++ b/packages/kaun/examples/03-mnist-cnn/main.ml
@@ -86,10 +86,7 @@ let save_training_state path (params, (ostate : Nx.float32_t Cnn.t Vega.adam_sta
          Checkpoint.of_params (module Cnn) ~prefix:"model" params;
          Checkpoint.of_params (module Cnn) ~prefix:"optim.mu" ostate.mu;
          Checkpoint.of_params (module Cnn) ~prefix:"optim.nu" ostate.nu;
-         Checkpoint.of_tensor "optim.c1" ostate.c1;
-         Checkpoint.of_tensor "optim.c2" ostate.c2;
-         Checkpoint.of_int "optim.step"
-           (Int32.to_int (Nx.item [] ostate.step));
+         Checkpoint.of_tensor "optim.step" ostate.step;
        ])
 
 let load_training_state path =
@@ -107,11 +104,7 @@ let load_training_state path =
         Checkpoint.to_params
           (module Cnn)
           ~prefix:"optim.nu" ~like:like_ostate.nu ckpt;
-      c1 = Nx.Ptree.unpack Nx.float64 (Checkpoint.get "optim.c1" ckpt);
-      c2 = Nx.Ptree.unpack Nx.float64 (Checkpoint.get "optim.c2" ckpt);
-      step =
-        Nx.scalar Nx.int32
-          (Int32.of_int (Checkpoint.to_int "optim.step" ckpt));
+      step = Nx.Ptree.unpack Nx.int32 (Checkpoint.get "optim.step" ckpt);
     }
   in
   (params, ostate)

--- a/packages/kaun/examples/03-mnist-cnn/main.ml
+++ b/packages/kaun/examples/03-mnist-cnn/main.ml
@@ -86,7 +86,10 @@ let save_training_state path (params, (ostate : Nx.float32_t Cnn.t Vega.adam_sta
          Checkpoint.of_params (module Cnn) ~prefix:"model" params;
          Checkpoint.of_params (module Cnn) ~prefix:"optim.mu" ostate.mu;
          Checkpoint.of_params (module Cnn) ~prefix:"optim.nu" ostate.nu;
-         Checkpoint.of_int "optim.step" ostate.step;
+         Checkpoint.of_tensor "optim.c1" ostate.c1;
+         Checkpoint.of_tensor "optim.c2" ostate.c2;
+         Checkpoint.of_int "optim.step"
+           (Int32.to_int (Nx.item [] ostate.step));
        ])
 
 let load_training_state path =
@@ -104,7 +107,11 @@ let load_training_state path =
         Checkpoint.to_params
           (module Cnn)
           ~prefix:"optim.nu" ~like:like_ostate.nu ckpt;
-      step = Checkpoint.to_int "optim.step" ckpt;
+      c1 = Nx.Ptree.unpack Nx.float64 (Checkpoint.get "optim.c1" ckpt);
+      c2 = Nx.Ptree.unpack Nx.float64 (Checkpoint.get "optim.c2" ckpt);
+      step =
+        Nx.scalar Nx.int32
+          (Int32.of_int (Checkpoint.to_int "optim.step" ckpt));
     }
   in
   (params, ostate)
@@ -130,7 +137,7 @@ let () =
         in
         let l, grads = Rune.value_and_grad cnn loss params in
         let params, ostate =
-          Vega.adamw_step cnn ~lr ostate ~params ~grads
+          Vega.adamw_step cnn ~lr:(Vega.lr lr) ostate ~params ~grads
         in
         ((params, ostate), Nx.item [] l)
       in
@@ -163,5 +170,5 @@ let () =
       let restored_params, restored_ostate = load_training_state path in
       Printf.printf "restored accuracy: %.2f%% (optimizer step %d)\n"
         (100. *. accuracy restored_params test)
-        restored_ostate.step;
+        (Int32.to_int (Nx.item [] restored_ostate.step));
       Sys.remove path

--- a/packages/kaun/examples/04-gpt2/train.ml
+++ b/packages/kaun/examples/04-gpt2/train.ml
@@ -11,8 +11,11 @@
    targets columns 1..64, the same batch every step - mean cross-entropy over
    all 4*64 positions - plain SGD, lr 1e-4, no momentum; the LM head is tied to
    [wte] so the embedding's gradient accumulates from both of its uses - the
-   whole step (forward, backward, update) compiles as one [Rune.jit2] program;
-   the loss recorded at step i is computed before update i - [--devices]
+   whole step (forward, backward, update) compiles as one [Rune.jit2] program,
+   [~donate:true] so each step releases the previous generation's unread
+   buffers (the metrics read a few leaves per step; donation consumes only
+   unread resident inputs); the loss recorded at step i is computed before
+   update i - [--devices]
    switches the step to data-parallel [Rune.pmap2]: parameters replicated on
    every device, the batch sharded on axis 0, gradients allreduced by
    construction — same numbers as the single-device step up to fp32 reduction
@@ -166,7 +169,7 @@ let train_step objective params =
      update exactly [w - lr * g] and needs no threading across steps. *)
   let state = Vega.sgd_init gpt2_tree params in
   let params =
-    fst (Vega.sgd_step gpt2_tree ~lr state ~params ~grads)
+    fst (Vega.sgd_step gpt2_tree ~lr:(Vega.lr lr) state ~params ~grads)
   in
   { Step_out.params; loss }
 
@@ -271,7 +274,7 @@ let train_step_scaled objective { Scaled_in.params; ls; key } =
   let finite = Vega.Loss_scale.grads_finite gpt2_tree grads in
   let state = Vega.sgd_init gpt2_tree params in
   let params' =
-    fst (Vega.sgd_step gpt2_tree ~lr state ~params ~grads)
+    fst (Vega.sgd_step gpt2_tree ~lr:(Vega.lr lr) state ~params ~grads)
   in
   let params =
     Gpt2.Params.map2 (fun p p' -> Nx.where finite p' p) params params'
@@ -550,7 +553,7 @@ let () =
     if !devices = "" then
       if !compute_dtype = "float16" then begin
         let f =
-          Rune.jit2 ~device:!device
+          Rune.jit2 ~device:!device ~donate:true
             (module Scaled_in)
             (module Scaled_out)
             (train_step_scaled (fun key -> obj key inputs targets))
@@ -563,7 +566,7 @@ let () =
       end
       else
         let f =
-          Rune.jit2 ~device:!device
+          Rune.jit2 ~device:!device ~donate:true
             (module Keyed_in)
             (module Step_out)
             (fun { Keyed_in.params; key } ->
@@ -587,7 +590,7 @@ let () =
         @ (if rate = 0.0 then [] else [ None ])
       in
       let f =
-        Rune.pmap2 ~devices:devs ~in_axes
+        Rune.pmap2 ~devices:devs ~in_axes ~donate:true
           (module Step_in)
           (module Step_out)
           (fun { Step_in.params; inputs; targets; key } ->

--- a/packages/kaun/lib/batch_norm.mli
+++ b/packages/kaun/lib/batch_norm.mli
@@ -27,7 +27,7 @@
       in
       let loss, grads, stats' = Rune.value_and_grad_aux model objective params in
       let params, ostate =
-        Vega.adam_step model ~lr:1e-3 ostate ~params ~grads
+        Vega.adam_step model ~lr:(Vega.lr 1e-3) ostate ~params ~grads
       in
       ((params, stats', ostate), Nx.item [] loss)
     ]}

--- a/packages/kaun/lib/checkpoint.mli
+++ b/packages/kaun/lib/checkpoint.mli
@@ -27,10 +27,7 @@
            Checkpoint.of_params (module Model) ~prefix:"model" params;
            Checkpoint.of_params (module Model) ~prefix:"optim.mu" st.mu;
            Checkpoint.of_params (module Model) ~prefix:"optim.nu" st.nu;
-           Checkpoint.of_tensor "optim.c1" st.c1;
-           Checkpoint.of_tensor "optim.c2" st.c2;
-           Checkpoint.of_int "optim.step"
-             (Int32.to_int (Nx.item [] st.step));
+           Checkpoint.of_tensor "optim.step" st.step;
          ])
     ]}
 

--- a/packages/kaun/lib/checkpoint.mli
+++ b/packages/kaun/lib/checkpoint.mli
@@ -27,7 +27,10 @@
            Checkpoint.of_params (module Model) ~prefix:"model" params;
            Checkpoint.of_params (module Model) ~prefix:"optim.mu" st.mu;
            Checkpoint.of_params (module Model) ~prefix:"optim.nu" st.nu;
-           Checkpoint.of_int "optim.step" st.step;
+           Checkpoint.of_tensor "optim.c1" st.c1;
+           Checkpoint.of_tensor "optim.c2" st.c2;
+           Checkpoint.of_int "optim.step"
+             (Int32.to_int (Nx.item [] st.step));
          ])
     ]}
 

--- a/packages/kaun/lib/kaun.mli
+++ b/packages/kaun/lib/kaun.mli
@@ -20,7 +20,7 @@
       let loss p = Loss.softmax_cross_entropy_sparse (Model.apply p x) y in
       let l, grads = Rune.value_and_grad model loss params in
       let params, ostate =
-        Vega.adamw_step model ~lr:1e-3 ostate ~params ~grads
+        Vega.adamw_step model ~lr:(Vega.lr 1e-3) ostate ~params ~grads
       in
       ((params, ostate), Nx.item [] l)
     ]}

--- a/packages/kaun/test/dune
+++ b/packages/kaun/test/dune
@@ -12,6 +12,7 @@
   test_attention
   test_data
   test_pmap_dp
+  test_jit_state
   test_half)
  (package kaun)
  (libraries kaun rune vega nx nx.core windtrap))

--- a/packages/kaun/test/test_checkpoint.ml
+++ b/packages/kaun/test/test_checkpoint.ml
@@ -143,7 +143,7 @@ let loss (p : Nx.float32_t Lin.t) =
 
 let adam_train_step (p, st) =
   let grads = Rune.grad lin loss p in
-  Vega.adam_step lin ~lr:0.05 st ~params:p ~grads
+  Vega.adam_step lin ~lr:(Vega.lr 0.05) st ~params:p ~grads
 
 let rec train_adam_steps n s =
   if n = 0 then s else train_adam_steps (n - 1) (adam_train_step s)
@@ -160,7 +160,10 @@ let test_resume_training () =
          Checkpoint.of_params (module Lin) ~prefix:"model" p3;
          Checkpoint.of_params (module Lin) ~prefix:"optim.mu" st3.Vega.mu;
          Checkpoint.of_params (module Lin) ~prefix:"optim.nu" st3.Vega.nu;
-         Checkpoint.of_int "optim.step" st3.Vega.step;
+         Checkpoint.of_tensor "optim.c1" st3.Vega.c1;
+         Checkpoint.of_tensor "optim.c2" st3.Vega.c2;
+         Checkpoint.of_int "optim.step"
+           (Int32.to_int (Nx.item [] st3.Vega.step));
        ]);
   let expected, _ = train_adam_steps 2 (p3, st3) in
   (* Restore into freshly initialized values and continue training. *)
@@ -177,7 +180,10 @@ let test_resume_training () =
         Checkpoint.to_params
           (module Lin)
           ~prefix:"optim.nu" ~like:like.Vega.nu ckpt;
-      step = Checkpoint.to_int "optim.step" ckpt;
+      c1 = Nx.Ptree.unpack Nx.float64 (Checkpoint.get "optim.c1" ckpt);
+      c2 = Nx.Ptree.unpack Nx.float64 (Checkpoint.get "optim.c2" ckpt);
+      step =
+        Nx.scalar Nx.int32 (Int32.of_int (Checkpoint.to_int "optim.step" ckpt));
     }
   in
   let resumed, _ = train_adam_steps 2 (p3', st3') in
@@ -191,7 +197,7 @@ let test_resume_training () =
 
 let sgd_train_step (p, st) =
   let grads = Rune.grad lin loss p in
-  Vega.sgd_step lin ~lr:0.05 ~momentum:0.9 st ~params:p ~grads
+  Vega.sgd_step lin ~lr:(Vega.lr 0.05) ~momentum:0.9 st ~params:p ~grads
 
 let rec train_sgd_steps n s =
   if n = 0 then s else train_sgd_steps (n - 1) (sgd_train_step s)
@@ -284,8 +290,8 @@ let test_ptree_paths () =
   equal ~msg:"layers.1.w" (array float_exact) [| 2.0 |] (leaf "layers.1.w");
   equal ~msg:"head" (array float_exact) [| 3.0 |] (leaf "head")
 
-(* A one-leaf structure whose payload sits at its own root: without a prefix
-   its name is empty. *)
+(* A one-leaf structure whose payload sits at its own root: without a prefix its
+   name is empty. *)
 module Root = struct
   type 'a t = 'a
 
@@ -322,7 +328,8 @@ let test_missing_entry () =
         Checkpoint.of_tensor "scale" (vec64 [| 1.0 |]);
       ]
   in
-  raises (Invalid_argument "Checkpoint.to_packed: missing entry \"b\"") (fun () ->
+  raises (Invalid_argument "Checkpoint.to_packed: missing entry \"b\"")
+    (fun () ->
       Checkpoint.to_packed (module Params) ~like:(fresh_params ()) ckpt)
 
 let test_extra_entries_ignored () =
@@ -346,7 +353,8 @@ let test_shape_mismatch () =
       ]
   in
   raises
-    (Invalid_argument "Checkpoint.to_packed: shape mismatch for \"b\": expected [1], got [2]")
+    (Invalid_argument
+       "Checkpoint.to_packed: shape mismatch for \"b\": expected [1], got [2]")
     (fun () ->
       Checkpoint.to_packed (module Params) ~like:(fresh_params ()) ckpt)
 
@@ -360,8 +368,9 @@ let test_dtype_mismatch_and_cast () =
       ]
   in
   raises
-    (Invalid_argument "Checkpoint.to_packed: dtype mismatch for \"scale\": expected float64, got \
-     float32 (pass ~cast:true to convert)") (fun () ->
+    (Invalid_argument
+       "Checkpoint.to_packed: dtype mismatch for \"scale\": expected float64, \
+        got float32 (pass ~cast:true to convert)") (fun () ->
       Checkpoint.to_packed (module Params) ~like:(fresh_params ()) ckpt);
   let p =
     Checkpoint.to_packed (module Params) ~cast:true ~like:(fresh_params ()) ckpt
@@ -385,9 +394,10 @@ module Duplicated = struct
 end
 
 let test_duplicate_names () =
-  raises (Invalid_argument "Checkpoint.of_packed: duplicate name \"w\"") (fun () ->
-      Checkpoint.of_packed (module Duplicated) (params ()));
-  raises (Invalid_argument "Checkpoint.to_packed: duplicate name \"w\"") (fun () ->
+  raises (Invalid_argument "Checkpoint.of_packed: duplicate name \"w\"")
+    (fun () -> Checkpoint.of_packed (module Duplicated) (params ()));
+  raises (Invalid_argument "Checkpoint.to_packed: duplicate name \"w\"")
+    (fun () ->
       Checkpoint.to_packed
         (module Duplicated)
         ~like:(params ()) Checkpoint.empty)
@@ -404,12 +414,14 @@ let test_to_int_errors () =
         Checkpoint.of_tensor "v" (Nx.create Nx.int32 [| 2 |] [| 1l; 2l |]);
       ]
   in
-  raises (Invalid_argument "Checkpoint.to_int: no entry named \"step\"") (fun () ->
-      Checkpoint.to_int "step" ckpt);
+  raises (Invalid_argument "Checkpoint.to_int: no entry named \"step\"")
+    (fun () -> Checkpoint.to_int "step" ckpt);
   raises
-    (Invalid_argument "Checkpoint.to_int: \"w\" is not an int32 entry (dtype float32)") (fun () ->
-      Checkpoint.to_int "w" ckpt);
-  raises (Invalid_argument "Checkpoint.to_int: \"v\" is not a scalar (shape [2])")
+    (Invalid_argument
+       "Checkpoint.to_int: \"w\" is not an int32 entry (dtype float32)")
+    (fun () -> Checkpoint.to_int "w" ckpt);
+  raises
+    (Invalid_argument "Checkpoint.to_int: \"v\" is not a scalar (shape [2])")
     (fun () -> Checkpoint.to_int "v" ckpt)
 
 let () =

--- a/packages/kaun/test/test_checkpoint.ml
+++ b/packages/kaun/test/test_checkpoint.ml
@@ -209,6 +209,7 @@ let test_resume_sgd_momentum () =
          Checkpoint.of_params
            (module Lin)
            ~prefix:"optim.velocity" st3.Vega.velocity;
+         Checkpoint.of_tensor "optim.step" st3.Vega.step;
        ]);
   let expected, _ = train_sgd_steps 2 (p3, st3) in
   let ckpt = Checkpoint.load path in
@@ -220,6 +221,7 @@ let test_resume_sgd_momentum () =
         Checkpoint.to_params
           (module Lin)
           ~prefix:"optim.velocity" ~like:like.Vega.velocity ckpt;
+      step = Nx.Ptree.unpack Nx.int32 (Checkpoint.get "optim.step" ckpt);
     }
   in
   let resumed, _ = train_sgd_steps 2 (p3', st3') in

--- a/packages/kaun/test/test_checkpoint.ml
+++ b/packages/kaun/test/test_checkpoint.ml
@@ -160,10 +160,7 @@ let test_resume_training () =
          Checkpoint.of_params (module Lin) ~prefix:"model" p3;
          Checkpoint.of_params (module Lin) ~prefix:"optim.mu" st3.Vega.mu;
          Checkpoint.of_params (module Lin) ~prefix:"optim.nu" st3.Vega.nu;
-         Checkpoint.of_tensor "optim.c1" st3.Vega.c1;
-         Checkpoint.of_tensor "optim.c2" st3.Vega.c2;
-         Checkpoint.of_int "optim.step"
-           (Int32.to_int (Nx.item [] st3.Vega.step));
+         Checkpoint.of_tensor "optim.step" st3.Vega.step;
        ]);
   let expected, _ = train_adam_steps 2 (p3, st3) in
   (* Restore into freshly initialized values and continue training. *)
@@ -180,10 +177,7 @@ let test_resume_training () =
         Checkpoint.to_params
           (module Lin)
           ~prefix:"optim.nu" ~like:like.Vega.nu ckpt;
-      c1 = Nx.Ptree.unpack Nx.float64 (Checkpoint.get "optim.c1" ckpt);
-      c2 = Nx.Ptree.unpack Nx.float64 (Checkpoint.get "optim.c2" ckpt);
-      step =
-        Nx.scalar Nx.int32 (Int32.of_int (Checkpoint.to_int "optim.step" ckpt));
+      step = Nx.Ptree.unpack Nx.int32 (Checkpoint.get "optim.step" ckpt);
     }
   in
   let resumed, _ = train_adam_steps 2 (p3', st3') in

--- a/packages/kaun/test/test_jit_state.ml
+++ b/packages/kaun/test/test_jit_state.ml
@@ -6,16 +6,16 @@
 (* The whole training step — forward, backward, Vega optimizer update — as one
    compiled program, with the optimizer state threaded through it.
 
-   This is the regression suite for Vega's jit ergonomics. The optimizer state
-   is a parameter tree ([Vega.Adam_state.Make (Model)]), so it is one field of
-   the step's input and output records, walked by its own traversals — no
-   duplicated model structure, no option plumbing. The bias corrections and the
-   step counter are scalar tensor leaves advanced inside the compiled program,
-   so the jitted trajectory matches the eager one and the counter reads [n]
-   after [n] compiled calls — a host-int counter would burn [t] into the trace
-   and replay it stale. The learning rate derives inside the step from a tensor
-   schedule evaluated at the state's own step leaf, and a [pmap2] run with the
-   state replicated matches the single-device one.
+   This is the regression suite for Vega's jit ergonomics: the optimizer state
+   is a parameter tree ([Vega.Adam_state (Model)]) sitting as one field of the
+   step's input and output records, and the learning rate derives inside the
+   step from the schedule applied to the state's own counter. The step records'
+   traversals are one-line delegations to the field modules (ppx_ptree derives
+   the same shape for users who prefer). The counter is a tensor leaf advanced
+   inside the compiled program, so the jitted trajectory matches the eager one
+   and the counter reads [n] after [n] compiled calls — a host-int counter
+   would burn the step into the trace and replay it stale. A [pmap2] run with
+   the state replicated matches the single-device one.
 
    Deterministic init (no RNG) so every run sees identical weights and data. *)
 
@@ -30,55 +30,36 @@ let hidden = 16
 let outputs = 3
 let steps = 8
 
-type model = { l1 : Nx.float32_t Linear.t; l2 : Nx.float32_t Linear.t }
+module Mlp = struct
+  type 'a t = { l1 : 'a Linear.t; l2 : 'a Linear.t }
 
-module Model = struct
-  type t = model
+  let map f { l1; l2 } = { l1 = Linear.map f l1; l2 = Linear.map f l2 }
 
-  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) m =
-    { l1 = Linear.map f m.l1; l2 = Linear.map f m.l2 }
+  let map2 f p q =
+    { l1 = Linear.map2 f p.l1 q.l1; l2 = Linear.map2 f p.l2 q.l2 }
 
-  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) a b =
-    { l1 = Linear.map2 f a.l1 b.l1; l2 = Linear.map2 f a.l2 b.l2 }
+  let iter f { l1; l2 } =
+    Linear.iter f l1;
+    Linear.iter f l2
 
-  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) m =
-    Linear.iter f m.l1;
-    Linear.iter f m.l2
+  let apply p x = Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))
 end
 
-module Opt = Vega.Adam_state.Make (Model)
+module Model =
+  (val Kaun.ptree (module Mlp) : Nx.Ptree.S with type t = Nx.float32_t Mlp.t)
 
-let fill i n =
-  Array.init n (fun j -> sin (float_of_int ((i * 7919) + j)) *. 0.3)
+module Opt = Vega.Adam_state (Model)
 
-let mat i r c = Nx.create Nx.float32 [| r; c |] (fill i (r * c))
-let vec i n = Nx.create Nx.float32 [| n |] (fill i n)
-
-let model_init () =
-  {
-    l1 = { Linear.w = mat 3 inputs hidden; b = Some (vec 4 hidden) };
-    l2 = { Linear.w = mat 5 hidden outputs; b = Some (vec 6 outputs) };
-  }
-
-let data_init () =
-  ( Nx.create Nx.float32 [| batch; inputs |] (fill 7 (batch * inputs)),
-    Nx.create Nx.float32 [| batch; outputs |] (fill 8 (batch * outputs)) )
-
-let loss_fn x y p =
-  Loss.mse (Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))) y
-
-(* The step record: parameters, the optimizer state, the batch. The state field
-   is walked by [Opt]'s own parameter tree. *)
-
-type step_in = {
-  params : model;
-  opt : Opt.t;
-  x : Nx.float32_t;
-  y : Nx.float32_t;
-}
+(* The step records: parameters, the optimizer state, the batch. Each field
+   is walked by its own module's traversals. *)
 
 module Step_in = struct
-  type t = step_in
+  type t = {
+    params : Model.t;
+    opt : Opt.t;
+    x : Nx.float32_t;
+    y : Nx.float32_t;
+  }
 
   let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) s =
     {
@@ -103,60 +84,72 @@ module Step_in = struct
     f s.y
 end
 
-type step_out = { params' : model; opt' : Opt.t; loss : Nx.float32_t }
-
 module Step_out = struct
-  type t = step_out
+  type t = { params : Model.t; opt : Opt.t; loss : Nx.float32_t }
 
   let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) s =
-    {
-      params' = Model.map f s.params';
-      opt' = Opt.map f s.opt';
-      loss = f s.loss;
-    }
+    { params = Model.map f s.params; opt = Opt.map f s.opt; loss = f s.loss }
 
   let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) a b =
     {
-      params' = Model.map2 f a.params' b.params';
-      opt' = Opt.map2 f a.opt' b.opt';
+      params = Model.map2 f a.params b.params;
+      opt = Opt.map2 f a.opt b.opt;
       loss = f a.loss b.loss;
     }
 
   let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) s =
-    Model.iter f s.params';
-    Opt.iter f s.opt';
+    Model.iter f s.params;
+    Opt.iter f s.opt;
     f s.loss
 end
+
+let fill i n =
+  Array.init n (fun j -> sin (float_of_int ((i * 7919) + j)) *. 0.3)
+
+let mat i r c = Nx.create Nx.float32 [| r; c |] (fill i (r * c))
+let vec i n = Nx.create Nx.float32 [| n |] (fill i n)
+
+let model_init () =
+  {
+    Mlp.l1 = { Linear.w = mat 3 inputs hidden; b = Some (vec 4 hidden) };
+    l2 = { Linear.w = mat 5 hidden outputs; b = Some (vec 6 outputs) };
+  }
+
+let data_init () =
+  ( Nx.create Nx.float32 [| batch; inputs |] (fill 7 (batch * inputs)),
+    Nx.create Nx.float32 [| batch; outputs |] (fill 8 (batch * outputs)) )
+
+let loss_fn x y p = Loss.mse (Mlp.apply p x) y
+let sched = Vega.Schedule.cosine_decay ~init_value:0.05 ~decay_steps:64 ()
 
 (* One training step: value_and_grad, gradient clipping, a scheduled learning
    rate derived from the state's counter, one Adam update. Run eagerly and,
    through [Rune.jit2], compiled. *)
-let train_step { params; opt; x; y } =
+let train_step { Step_in.params; opt; x; y } =
   let loss, grads = Rune.value_and_grad (module Model) (loss_fn x y) params in
   let grads = Vega.clip_by_global_norm (module Model) ~max_norm:2.0 grads in
-  let lr =
-    Vega.Schedule.cosine_decay_t ~init_value:0.05 ~decay_steps:64 opt.step
+  let params, opt =
+    Vega.adam_step (module Model) ~lr:(sched opt.step) opt ~params ~grads
   in
-  let params', opt' = Vega.adam_step (module Model) ~lr opt ~params ~grads in
-  { params'; opt'; loss }
+  { Step_out.params; opt; loss }
 
 let init () =
   let params = model_init () in
   let opt = Vega.adam_init (module Model) params in
   let x, y = data_init () in
-  { params; opt; x; y }
+  { Step_in.params; opt; x; y }
 
 let advance step0 s =
   let out = step0 !s in
-  s := { !s with params = out.params'; opt = out.opt' };
-  (Nx.item [] out.loss, out.params')
+  s := { !s with Step_in.params = out.Step_out.params; opt = out.Step_out.opt };
+  (Nx.item [] out.Step_out.loss, out.Step_out.params)
 
 let run_traj ~step0 n s0 =
   let s = ref s0 in
   Array.init n (fun _ -> advance step0 s)
 
-let check_trajectory ~msg eps (a : (float * model) array)
-    (b : (float * model) array) =
+let check_trajectory ~msg eps (a : (float * Model.t) array)
+    (b : (float * Model.t) array) =
   Array.iteri
     (fun i (la, _) ->
       equal
@@ -200,23 +193,21 @@ let test_state_advances_across_compiled_calls () =
   for _ = 1 to steps do
     ignore (advance jitted s)
   done;
-  let opt = !s.opt in
+  let opt = !s.Step_in.opt in
   equal ~msg:"counter reads n after n calls" int steps
     (Int32.to_int (Nx.item [] opt.step));
-  (* The corrections must match the closed form at t = n, computed inside the
-     compiled program: c1 = 1 - 0.9^n, c2 = 1 - 0.999^n. *)
-  let c1 = Nx.item [] opt.c1 and c2 = Nx.item [] opt.c2 in
-  is_true ~msg:"c1 matches the closed form"
-    (Float.abs (c1 -. (1.0 -. (0.9 ** float_of_int steps))) < 1e-6);
-  is_true ~msg:"c2 matches the closed form"
-    (Float.abs (c2 -. (1.0 -. (0.999 ** float_of_int steps))) < 1e-6);
   (* The moments are not zero: the state genuinely updates. *)
   let abs_sum (type a b) (t : (a, b) Nx.t) : float =
     Nx.item [] (Nx.sum (Nx.abs (Nx.cast Nx.float64 t)))
   in
   let moved = ref false in
-  ignore (Model.iter (fun t -> if abs_sum t > 0.0 then moved := true) opt.mu);
-  is_true ~msg:"moments moved" !moved
+  Model.iter (fun t -> if abs_sum t > 0.0 then moved := true) opt.mu;
+  is_true ~msg:"moments moved" !moved;
+  (* The schedule tracks the counter: the compiled program's rate at the next
+     step matches the schedule read on the host. *)
+  equal ~msg:"schedule follows the counter" (float 1e-6)
+    (Vega.Schedule.eval sched steps)
+    (Nx.item [] (sched opt.step))
 
 let test_pmap_matches_jit () =
   let jit =
@@ -248,7 +239,7 @@ let tests =
     group "jitted optimizer state"
       [
         test "jit step matches the eager trajectory" test_jit_matches_eager;
-        test "corrections and counter advance across compiled calls"
+        test "counter and schedule advance across compiled calls"
           test_state_advances_across_compiled_calls;
         test "pmap with replicated state matches jit" test_pmap_matches_jit;
       ];

--- a/packages/kaun/test/test_jit_state.ml
+++ b/packages/kaun/test/test_jit_state.ml
@@ -1,0 +1,257 @@
+(*---------------------------------------------------------------------------
+  Copyright (c) 2026 The Raven authors. All rights reserved.
+  SPDX-License-Identifier: ISC
+  ---------------------------------------------------------------------------*)
+
+(* The whole training step — forward, backward, Vega optimizer update — as one
+   compiled program, with the optimizer state threaded through it.
+
+   This is the regression suite for Vega's jit ergonomics. The optimizer state
+   is a parameter tree ([Vega.Adam_state.Make (Model)]), so it is one field of
+   the step's input and output records, walked by its own traversals — no
+   duplicated model structure, no option plumbing. The bias corrections and the
+   step counter are scalar tensor leaves advanced inside the compiled program,
+   so the jitted trajectory matches the eager one and the counter reads [n]
+   after [n] compiled calls — a host-int counter would burn [t] into the trace
+   and replay it stale. The learning rate derives inside the step from a tensor
+   schedule evaluated at the state's own step leaf, and a [pmap2] run with the
+   state replicated matches the single-device one.
+
+   Deterministic init (no RNG) so every run sees identical weights and data. *)
+
+open Windtrap
+open Kaun
+
+let dev = "CPU"
+let devs2 = [ "CPU:1"; "CPU:2" ]
+let batch = 8
+let inputs = 8
+let hidden = 16
+let outputs = 3
+let steps = 8
+
+type model = { l1 : Nx.float32_t Linear.t; l2 : Nx.float32_t Linear.t }
+
+module Model = struct
+  type t = model
+
+  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) m =
+    { l1 = Linear.map f m.l1; l2 = Linear.map f m.l2 }
+
+  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) a b =
+    { l1 = Linear.map2 f a.l1 b.l1; l2 = Linear.map2 f a.l2 b.l2 }
+
+  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) m =
+    Linear.iter f m.l1;
+    Linear.iter f m.l2
+end
+
+module Opt = Vega.Adam_state.Make (Model)
+
+let fill i n =
+  Array.init n (fun j -> sin (float_of_int ((i * 7919) + j)) *. 0.3)
+
+let mat i r c = Nx.create Nx.float32 [| r; c |] (fill i (r * c))
+let vec i n = Nx.create Nx.float32 [| n |] (fill i n)
+
+let model_init () =
+  {
+    l1 = { Linear.w = mat 3 inputs hidden; b = Some (vec 4 hidden) };
+    l2 = { Linear.w = mat 5 hidden outputs; b = Some (vec 6 outputs) };
+  }
+
+let data_init () =
+  ( Nx.create Nx.float32 [| batch; inputs |] (fill 7 (batch * inputs)),
+    Nx.create Nx.float32 [| batch; outputs |] (fill 8 (batch * outputs)) )
+
+let loss_fn x y p =
+  Loss.mse (Linear.apply p.l2 (Fn.relu (Linear.apply p.l1 x))) y
+
+(* The step record: parameters, the optimizer state, the batch. The state field
+   is walked by [Opt]'s own parameter tree. *)
+
+type step_in = {
+  params : model;
+  opt : Opt.t;
+  x : Nx.float32_t;
+  y : Nx.float32_t;
+}
+
+module Step_in = struct
+  type t = step_in
+
+  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) s =
+    {
+      params = Model.map f s.params;
+      opt = Opt.map f s.opt;
+      x = f s.x;
+      y = f s.y;
+    }
+
+  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) a b =
+    {
+      params = Model.map2 f a.params b.params;
+      opt = Opt.map2 f a.opt b.opt;
+      x = f a.x b.x;
+      y = f a.y b.y;
+    }
+
+  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) s =
+    Model.iter f s.params;
+    Opt.iter f s.opt;
+    f s.x;
+    f s.y
+end
+
+type step_out = { params' : model; opt' : Opt.t; loss : Nx.float32_t }
+
+module Step_out = struct
+  type t = step_out
+
+  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) s =
+    {
+      params' = Model.map f s.params';
+      opt' = Opt.map f s.opt';
+      loss = f s.loss;
+    }
+
+  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) a b =
+    {
+      params' = Model.map2 f a.params' b.params';
+      opt' = Opt.map2 f a.opt' b.opt';
+      loss = f a.loss b.loss;
+    }
+
+  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) s =
+    Model.iter f s.params';
+    Opt.iter f s.opt';
+    f s.loss
+end
+
+(* One training step: value_and_grad, gradient clipping, a scheduled learning
+   rate derived from the state's counter, one Adam update. Run eagerly and,
+   through [Rune.jit2], compiled. *)
+let train_step { params; opt; x; y } =
+  let loss, grads = Rune.value_and_grad (module Model) (loss_fn x y) params in
+  let grads = Vega.clip_by_global_norm (module Model) ~max_norm:2.0 grads in
+  let lr =
+    Vega.Schedule.cosine_decay_t ~init_value:0.05 ~decay_steps:64 opt.step
+  in
+  let params', opt' = Vega.adam_step (module Model) ~lr opt ~params ~grads in
+  { params'; opt'; loss }
+
+let init () =
+  let params = model_init () in
+  let opt = Vega.adam_init (module Model) params in
+  let x, y = data_init () in
+  { params; opt; x; y }
+
+let advance step0 s =
+  let out = step0 !s in
+  s := { !s with params = out.params'; opt = out.opt' };
+  (Nx.item [] out.loss, out.params')
+
+let run_traj ~step0 n s0 =
+  let s = ref s0 in
+  Array.init n (fun _ -> advance step0 s)
+
+let check_trajectory ~msg eps (a : (float * model) array)
+    (b : (float * model) array) =
+  Array.iteri
+    (fun i (la, _) ->
+      equal
+        ~msg:(Printf.sprintf "%s: loss at step %d" msg (i + 1))
+        (float eps) la
+        (fst b.(i)))
+    a;
+  let _, last_a = a.(Array.length a - 1) in
+  let _, last_b = b.(Array.length b - 1) in
+  let leaf = ref 0 in
+  ignore
+    (Model.map2
+       (fun (type a b) (x : (a, b) Nx.t) (y : (a, b) Nx.t) : (a, b) Nx.t ->
+         incr leaf;
+         let d =
+           Nx.item [] (Nx.cast Nx.float64 (Nx.max (Nx.abs (Nx.sub x y))))
+         in
+         is_true
+           ~msg:
+             (Printf.sprintf "%s: leaf %d, max |eager - compiled| = %g" msg
+                !leaf d)
+           (d <= eps);
+         x)
+       last_a last_b)
+
+let test_jit_matches_eager () =
+  let eager = run_traj ~step0:train_step steps (init ()) in
+  let compiled =
+    run_traj
+      ~step0:
+        (Rune.jit2 ~device:dev (module Step_in) (module Step_out) train_step)
+      steps (init ())
+  in
+  check_trajectory ~msg:"jit adam" 1e-6 eager compiled
+
+let test_state_advances_across_compiled_calls () =
+  let jitted =
+    Rune.jit2 ~device:dev (module Step_in) (module Step_out) train_step
+  in
+  let s = ref (init ()) in
+  for _ = 1 to steps do
+    ignore (advance jitted s)
+  done;
+  let opt = !s.opt in
+  equal ~msg:"counter reads n after n calls" int steps
+    (Int32.to_int (Nx.item [] opt.step));
+  (* The corrections must match the closed form at t = n, computed inside the
+     compiled program: c1 = 1 - 0.9^n, c2 = 1 - 0.999^n. *)
+  let c1 = Nx.item [] opt.c1 and c2 = Nx.item [] opt.c2 in
+  is_true ~msg:"c1 matches the closed form"
+    (Float.abs (c1 -. (1.0 -. (0.9 ** float_of_int steps))) < 1e-6);
+  is_true ~msg:"c2 matches the closed form"
+    (Float.abs (c2 -. (1.0 -. (0.999 ** float_of_int steps))) < 1e-6);
+  (* The moments are not zero: the state genuinely updates. *)
+  let abs_sum (type a b) (t : (a, b) Nx.t) : float =
+    Nx.item [] (Nx.sum (Nx.abs (Nx.cast Nx.float64 t)))
+  in
+  let moved = ref false in
+  ignore (Model.iter (fun t -> if abs_sum t > 0.0 then moved := true) opt.mu);
+  is_true ~msg:"moments moved" !moved
+
+let test_pmap_matches_jit () =
+  let jit =
+    run_traj
+      ~step0:
+        (Rune.jit2 ~device:dev (module Step_in) (module Step_out) train_step)
+      steps (init ())
+  in
+  (* Everything replicated except the batch, sharded on axis 0. *)
+  let in_axes s =
+    let n = ref 0 in
+    Step_in.iter (fun _ -> incr n) s;
+    List.init (!n - 2) (fun _ -> None) @ [ Some 0; Some 0 ]
+  in
+  let pmapped =
+    run_traj
+      ~step0:
+        (Rune.pmap2 ~devices:devs2
+           ~in_axes:(in_axes (init ()))
+           (module Step_in)
+           (module Step_out)
+           train_step)
+      steps (init ())
+  in
+  check_trajectory ~msg:"pmap adam" 1e-5 jit pmapped
+
+let tests =
+  [
+    group "jitted optimizer state"
+      [
+        test "jit step matches the eager trajectory" test_jit_matches_eager;
+        test "corrections and counter advance across compiled calls"
+          test_state_advances_across_compiled_calls;
+        test "pmap with replicated state matches jit" test_pmap_matches_jit;
+      ];
+  ]
+
+let () = run "kaun jit state" tests

--- a/packages/kaun/test/test_kaun.ml
+++ b/packages/kaun/test/test_kaun.ml
@@ -49,7 +49,7 @@ let test_xor_trains () =
   let step (params, ostate) =
     let l, grads = Rune.value_and_grad mlp loss params in
     let params, ostate =
-      Vega.adam_step mlp ~lr:0.05 ostate ~params ~grads
+      Vega.adam_step mlp ~lr:(Vega.lr 0.05) ostate ~params ~grads
     in
     ((params, ostate), Nx.item [] l)
   in
@@ -86,7 +86,7 @@ let test_sgd_decreases_loss () =
     let params, ostate = !state in
     let _, grads = Rune.value_and_grad mlp loss params in
     state :=
-      Vega.sgd_step mlp ~lr:0.1 ~momentum:0.9 ostate ~params ~grads
+      Vega.sgd_step mlp ~lr:(Vega.lr 0.1) ~momentum:0.9 ostate ~params ~grads
   done;
   let l1 = Nx.item [] (loss (fst !state)) in
   is_true ~msg:"sgd decreases the loss" (l1 < l0 *. 0.5)

--- a/packages/kaun/test/test_pmap_dp.ml
+++ b/packages/kaun/test/test_pmap_dp.ml
@@ -8,9 +8,10 @@
    replicated and the batch sharded over two CPU devices. The loss trajectory
    and final weights must match the single-device [Rune.jit2] step up to fp32
    reduction order (the cross-device gradient allreduce reorders the batch sum).
-   A momentum run checks that replicated optimizer state threaded through the
-   pmapped step stays coherent across devices. Runs on CPU device instances; no
-   pretrained weights involved. *)
+   Momentum runs thread a real [Vega.Sgd_state] through the step — the state is
+   a parameter tree ([Vega.Sgd_state.Make (Model)]) whose leaves replicate like
+   the parameters — and the pmapped trajectory must match the jitted one. Runs
+   on CPU device instances; no pretrained weights involved. *)
 
 open Windtrap
 open Kaun
@@ -87,13 +88,15 @@ let loss_fn x tgt m =
   in
   Loss.softmax_cross_entropy_sparse (Linear.apply m.head h) tgt
 
-(* Step structures for pmap2: the batch joins the parameters (and, for the
-   momentum run, the velocity) as leaves so it can be sharded on axis 0 while
-   everything else replicates. *)
+(* Step structures for pmap2: the batch joins the parameters (and the optimizer
+   state) as leaves so it can be sharded on axis 0 while everything else
+   replicates. The state rides as one field, walked by its own parameter tree —
+   [Opt.map f s.opt] — instead of a duplicated model structure. *)
+module Opt = Vega.Sgd_state.Make (Model)
 
 type step_in = {
   m : model;
-  v : model option;
+  opt : Opt.t;
   x : Nx.float32_t;
   tgt : (int32, Nx.int32_elt) Nx.t;
 }
@@ -102,86 +105,59 @@ module Step_in = struct
   type t = step_in
 
   let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) s =
-    {
-      m = Model.map f s.m;
-      v = Option.map (Model.map f) s.v;
-      x = f s.x;
-      tgt = f s.tgt;
-    }
+    { m = Model.map f s.m; opt = Opt.map f s.opt; x = f s.x; tgt = f s.tgt }
 
   let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) a b =
     {
       m = Model.map2 f a.m b.m;
-      v =
-        (match (a.v, b.v) with
-        | Some va, Some vb -> Some (Model.map2 f va vb)
-        | None, None -> None
-        | _ -> invalid_arg "Step_in.map2: velocity mismatch");
+      opt = Opt.map2 f a.opt b.opt;
       x = f a.x b.x;
       tgt = f a.tgt b.tgt;
     }
 
   let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) s =
     Model.iter f s.m;
-    Option.iter (Model.iter f) s.v;
+    Opt.iter f s.opt;
     f s.x;
     f s.tgt
 end
 
-type step_out = { m' : model; v' : model option; loss : Nx.float32_t }
+type step_out = { m' : model; opt' : Opt.t; loss : Nx.float32_t }
 
 module Step_out = struct
   type t = step_out
 
   let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) s =
-    {
-      m' = Model.map f s.m';
-      v' = Option.map (Model.map f) s.v';
-      loss = f s.loss;
-    }
+    { m' = Model.map f s.m'; opt' = Opt.map f s.opt'; loss = f s.loss }
 
   let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) a b =
     {
       m' = Model.map2 f a.m' b.m';
-      v' =
-        (match (a.v', b.v') with
-        | Some va, Some vb -> Some (Model.map2 f va vb)
-        | None, None -> None
-        | _ -> invalid_arg "Step_out.map2: velocity mismatch");
+      opt' = Opt.map2 f a.opt' b.opt';
       loss = f a.loss b.loss;
     }
 
   let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) s =
     Model.iter f s.m';
-    Option.iter (Model.iter f) s.v';
+    Opt.iter f s.opt';
     f s.loss
 end
 
 (* One SGD step: value_and_grad inside the (jitted or pmapped) function, so
-   under pmap the gradients allreduce across devices before the update. *)
-let train_step ~momentum { m; v; x; tgt } =
+   under pmap the gradients allreduce across devices before the update. With
+   momentum 0 the velocity is never read; with momentum the state advances from
+   the replicated leaves on every device, identically. *)
+let train_step ~momentum { m; opt; x; tgt } =
   let loss, grads = Rune.value_and_grad (module Model) (loss_fn x tgt) m in
-  match v with
-  | None ->
-      let st = Vega.sgd_init (module Model) m in
-      let m', _ = Vega.sgd_step (module Model) ~lr st ~params:m ~grads in
-      { m'; v' = None; loss }
-  | Some velocity ->
-      let m', st =
-        Vega.sgd_step
-          (module Model)
-          ~lr ~momentum { Vega.velocity } ~params:m ~grads
-      in
-      { m'; v' = Some st.Vega.velocity; loss }
+  let m', opt' =
+    Vega.sgd_step (module Model) ~lr:(Vega.lr lr) ~momentum opt ~params:m ~grads
+  in
+  { m'; opt'; loss }
 
-let init ~momentum =
+let init ~momentum:_ =
   let m = model_init () in
-  {
-    m;
-    v = (if momentum then Some (Model.map Nx.zeros_like m) else None);
-    x = x_init ();
-    tgt = tgt_init ();
-  }
+  let opt = Vega.sgd_init (module Model) m in
+  { m; opt; x = x_init (); tgt = tgt_init () }
 
 (* One [in_axes] entry per leaf: everything replicated except the two batch
    leaves, sharded on axis 0. *)
@@ -194,7 +170,7 @@ let trajectory ~momentum ~steps step0 =
   let s = ref (init ~momentum) in
   Array.init steps (fun _ ->
       let out = step0 !s in
-      s := { !s with m = out.m'; v = out.v' };
+      s := { !s with m = out.m'; opt = out.opt' };
       (Nx.item [] out.loss, out.m'))
 
 let run_both ~momentum ~steps =

--- a/packages/kaun/test/test_pmap_dp.ml
+++ b/packages/kaun/test/test_pmap_dp.ml
@@ -9,7 +9,7 @@
    and final weights must match the single-device [Rune.jit2] step up to fp32
    reduction order (the cross-device gradient allreduce reorders the batch sum).
    Momentum runs thread a real [Vega.Sgd_state] through the step — the state is
-   a parameter tree ([Vega.Sgd_state.Make (Model)]) whose leaves replicate like
+   a parameter tree ([Vega.Sgd_state (Model)]) whose leaves replicate like
    the parameters — and the pmapped trajectory must match the jitted one. Runs
    on CPU device instances; no pretrained weights involved. *)
 
@@ -92,7 +92,7 @@ let loss_fn x tgt m =
    state) as leaves so it can be sharded on axis 0 while everything else
    replicates. The state rides as one field, walked by its own parameter tree —
    [Opt.map f s.opt] — instead of a duplicated model structure. *)
-module Opt = Vega.Sgd_state.Make (Model)
+module Opt = Vega.Sgd_state (Model)
 
 type step_in = {
   m : model;

--- a/packages/kaun/test/test_stateful.ml
+++ b/packages/kaun/test/test_stateful.ml
@@ -214,7 +214,7 @@ let test_bn_train_step_roundtrip () =
       Rune.value_and_grad_aux model objective params
     in
     let params, ostate =
-      Vega.adam_step model ~lr:0.02 ostate ~params ~grads
+      Vega.adam_step model ~lr:(Vega.lr 0.02) ostate ~params ~grads
     in
     ((params, stats', ostate), Nx.item [] loss)
   in

--- a/packages/munin/examples/x-kaun-mnist-jit/main.ml
+++ b/packages/munin/examples/x-kaun-mnist-jit/main.ml
@@ -216,11 +216,15 @@ let () =
   let train_step { Step_in.params; x; y } =
     let loss_fn p = Loss.softmax_cross_entropy_sparse (Cnn.apply p x) y in
     let loss, grads = Rune.value_and_grad cnn loss_fn params in
-    let params, _ = Vega.sgd_step cnn ~lr:!lr state ~params ~grads in
+    let params, _ = Vega.sgd_step cnn ~lr:(Vega.lr !lr) state ~params ~grads in
     { Step_out.params; loss }
   in
+  (* ~donate:true releases the previous generation's device buffers once each
+     call completes — the loop reads only the fresh loss, never the pre-step
+     state, so the resident loop turns over about two generations of buffers. *)
   let step =
-    Rune.jit2 ~device:!device (module Step_in) (module Step_out) train_step
+    Rune.jit2 ~device:!device ~donate:true (module Step_in) (module Step_out)
+      train_step
   in
   let forward =
     Rune.jit ~device:!device

--- a/packages/munin/examples/x-kaun-mnist/main.ml
+++ b/packages/munin/examples/x-kaun-mnist/main.ml
@@ -122,7 +122,7 @@ let () =
     let loss_fn p = Loss.softmax_cross_entropy_sparse (Cnn.apply p x) y in
     let l, grads = Rune.value_and_grad cnn loss_fn !params in
     let params', ostate' =
-      Vega.adam_step cnn ~lr !ostate ~params:!params ~grads
+      Vega.adam_step cnn ~lr:(Vega.lr lr) !ostate ~params:!params ~grads
     in
     params := params';
     ostate := ostate';

--- a/packages/ppx_ptree/test/test_integration.ml
+++ b/packages/ppx_ptree/test/test_integration.ml
@@ -83,7 +83,7 @@ let test_vega_optimizer_step () =
   let updated, state =
     Vega.sgd_step
       (module Optimizer_params)
-      ~lr:0.1 state ~params ~grads:gradients
+      ~lr:(Vega.lr 0.1) state ~params ~grads:gradients
   in
   equal (array (float 1e-6)) [| 0.8; -1.6 |] (Nx.to_array updated.weight);
   equal (array (float 1e-6)) [| 0.4 |] (Nx.to_array updated.bias);

--- a/packages/vega/doc/03-schedules.md
+++ b/packages/vega/doc/03-schedules.md
@@ -2,19 +2,25 @@
 
 A learning rate schedule controls how the learning rate changes over the
 course of training. In Vega, a schedule is simply a function from step
-number to learning rate.
+counter to learning rate.
 
 ## How Schedules Work
 
-`Schedule.t` is `int -> float`. Given a 1-based step number, it returns
-the learning rate for that step:
+`Schedule.t` maps a scalar `int32` step tensor to a scalar `float32` rate
+tensor — tensor arithmetic, so a schedule computes eagerly and traces inside
+a `Rune.jit`-compiled training step alike. In a structural loop, apply it to
+the optimizer state's own counter; `Schedule.eval` reads a schedule at a host
+step number:
 
 <!-- $MDX skip -->
 ```ocaml
 let lr = Vega.Schedule.constant 0.001 in
-Printf.printf "step 1:   %f\n" (lr 1);    (* 0.001 *)
-Printf.printf "step 100: %f\n" (lr 100)   (* 0.001 *)
+Printf.printf "step 1:   %f\n" (Vega.Schedule.eval lr 1);    (* 0.001 *)
+Printf.printf "step 100: %f\n" (Vega.Schedule.eval lr 100)   (* 0.001 *)
 ```
+
+In the per-tensor tier, schedules are evaluated at the chain's own update
+count, starting at 1 on the first update.
 
 Schedules plug into optimizers as the last positional argument:
 
@@ -189,13 +195,15 @@ Vega.Schedule.join [
 
 ### Custom Schedules
 
-Since `Schedule.t` is just `int -> float`, you can write arbitrary functions:
+Since `Schedule.t` is just a function on a scalar step tensor, you can write
+arbitrary ones with `Nx` arithmetic:
 
 <!-- $MDX skip -->
 ```ocaml
 (* Step decay: halve every 1000 steps *)
 let step_decay : Vega.Schedule.t = fun step ->
-  0.01 *. (0.5 ** float_of_int (step / 1000))
+  let k = Nx.floor (Nx.div_s (Nx.cast Nx.float32 step) 1000.) in
+  Nx.mul_s (Nx.rpow_s 0.5 k) 0.01
 ```
 
 ## Using Schedules with Optimizers

--- a/packages/vega/doc/04-optax-comparison.md
+++ b/packages/vega/doc/04-optax-comparison.md
@@ -116,7 +116,7 @@ let tx =
 |--------|-------|------|
 | Language | Python/JAX | OCaml/Nx |
 | State type | PyTree of arrays | Typed `('a, 'b) state` |
-| Learning rate | Float or schedule | Always `Schedule.t` (`int -> float`) |
+| Learning rate | Float or schedule | Always `Schedule.t` (step tensor to rate tensor) |
 | Weight decay rate | Float | `Schedule.t` (dynamic decay) |
 | Noise eta | Float | `Schedule.t` (dynamic noise) |
 | Gradient clipping | Global norm across all params | Per-tensor `clip_by_norm`; structural `clip_by_global_norm` |

--- a/packages/vega/doc/index.md
+++ b/packages/vega/doc/index.md
@@ -8,7 +8,7 @@ Vega provides composable gradient-based optimizers for OCaml. Each optimizer is 
 - **Composable primitives** — `scale_by_adam`, `trace`, `add_decayed_weights`, `clip_by_norm`, and more, combined via `chain`
 - **Structural steps** — `sgd_step`, `adam_step`, `adamw_step` over any `Nx.Ptree.S` parameter structure; the state is a parameter tree too (`Sgd_state`, `Adam_state`)
 - **Jit-compilable steps** — every time-varying scalar is a tensor leaf, so a whole training step compiles as one `Rune.jit2` program
-- **Learning rate schedules** — `constant`, `cosine_decay`, `warmup_cosine_decay`, `one_cycle`, `piecewise_constant`, `join`; tensor mirrors (`*_t`) of the same formulas for use inside compiled steps
+- **Learning rate schedules** — `constant`, `cosine_decay`, `warmup_cosine_decay`, `one_cycle`, `piecewise_constant`, `join` — tensor arithmetic over a step counter, so one family serves eager and compiled loops alike
 - **Gradient processing** — clipping, centralization, noise injection
 - **Robustness** — `apply_if_finite` skips NaN/Inf updates automatically
 - **Serialization** — `state_to_tensors` / `state_of_tensors` for checkpointing
@@ -38,31 +38,35 @@ let () =
 
 ## Jit-Compiled Training Steps
 
-The structural optimizers' state is a parameter tree like the parameters themselves: `Vega.Adam_state.Make (Model)` turns the Adam state over your model into an `Nx.Ptree.S` you can embed in a compiled step's input and output records. Everything that changes across steps — the moments, the bias corrections, the step counter, the learning rate — is a tensor leaf; everything fixed (`b1`, `b2`, `eps`, `weight_decay`) is an ordinary float the compiler captures as a constant. So the forward pass, the backward pass and the update compile into a single program with no host round-trips:
+The structural optimizers' state is a parameter tree like the parameters themselves: `Vega.Adam_state (Model)` is the Adam state over your model as an `Nx.Ptree.S`, one field of a compiled step's input and output records. Everything that changes across steps — the moments, the step counter, the learning rate — is a tensor leaf or derived from one; everything fixed (`b1`, `b2`, `eps`, `weight_decay`) is an ordinary float the compiler captures as a constant. So the forward pass, the backward pass and the update compile into a single program with no host round-trips:
 
 <!-- $MDX skip -->
 ```ocaml
-module Opt = Vega.Adam_state.Make (Model)
+module Opt = Vega.Adam_state (Model)
 
-type step_in = {
-  params : Model.t;
-  opt : Opt.t;                      (* [\[@ptree.using Opt\]] with ppx_ptree *)
-  inputs : Nx.float32_t;
-  targets : (int32, Nx.int32_elt) Nx.t;
-}
+module Step_in = struct
+  type t = {
+    params : Model.t;
+    opt : Opt.t;
+    inputs : Nx.float32_t;
+    targets : (int32, Nx.int32_elt) Nx.t;
+  }
 
-(* step_out carries params, opt and the loss; both records derive
-   map/map2/iter by hand or with ppx_ptree. *)
+  (* map/map2/iter: one-line delegations to Model and Opt over the fields —
+     or [@@deriving ptree] with ppx_ptree. Step_out carries params, opt and
+     the loss the same way. *)
+end
 
-let train_step { params; opt; inputs; targets } =
+let sched = Vega.Schedule.cosine_decay ~init_value:1e-3 ~decay_steps:1000 ()
+
+let train_step { Step_in.params; opt; inputs; targets } =
   let loss, grads =
     Rune.value_and_grad model (objective inputs targets) params
   in
   let grads = Vega.clip_by_global_norm model ~max_norm:1.0 grads in
-  let lr =
-    Vega.Schedule.cosine_decay_t ~init_value:1e-3 ~decay_steps:1000 opt.step
+  let params, opt =
+    Vega.adamw_step model ~lr:(sched opt.step) opt ~params ~grads
   in
-  let params, opt = Vega.adamw_step model ~lr opt ~params ~grads in
   { Step_out.params; opt; loss }
 
 (* ~donate:true releases the previous generation's device buffers once the
@@ -73,7 +77,7 @@ let step =
 
 Looping `step` over batches compiles once and replays: the state flows out and back in as leaves, and the schedule derives from the state's own counter inside the program. `~donate:true` keeps the loop at about two generations of device buffers instead of one per call awaiting collection — it consumes the handles it frees, so leave it off while the loop still reads the state it feeds in (on the CPU device it changes nothing). The same record works for data-parallel `Rune.pmap2` — replicate the parameters and the state, shard the batch.
 
-The scalar schedule family (`int -> float`) remains for eager loops, which evaluate it at their own step counter; the `*_t` mirrors compute the same formulas from a step tensor for compiled loops.
+Schedules are tensor arithmetic over the counter, so the same schedule drives an eager loop; `Schedule.eval` reads one at a host step number for logging.
 
 ## Next Steps
 

--- a/packages/vega/doc/index.md
+++ b/packages/vega/doc/index.md
@@ -6,7 +6,9 @@ Vega provides composable gradient-based optimizers for OCaml. Each optimizer is 
 
 - **Optimizer aliases** — `adam`, `adamw`, `sgd`, `rmsprop`, `adagrad`, `lamb`, `lion`, `radam`, `lars`, `adan`, `adafactor`
 - **Composable primitives** — `scale_by_adam`, `trace`, `add_decayed_weights`, `clip_by_norm`, and more, combined via `chain`
-- **Learning rate schedules** — `constant`, `cosine_decay`, `warmup_cosine_decay`, `one_cycle`, `piecewise_constant`, `join`
+- **Structural steps** — `sgd_step`, `adam_step`, `adamw_step` over any `Nx.Ptree.S` parameter structure; the state is a parameter tree too (`Sgd_state`, `Adam_state`)
+- **Jit-compilable steps** — every time-varying scalar is a tensor leaf, so a whole training step compiles as one `Rune.jit2` program
+- **Learning rate schedules** — `constant`, `cosine_decay`, `warmup_cosine_decay`, `one_cycle`, `piecewise_constant`, `join`; tensor mirrors (`*_t`) of the same formulas for use inside compiled steps
 - **Gradient processing** — clipping, centralization, noise injection
 - **Robustness** — `apply_if_finite` skips NaN/Inf updates automatically
 - **Serialization** — `state_to_tensors` / `state_of_tensors` for checkpointing
@@ -33,6 +35,45 @@ let () =
       Printf.printf "step %3d  x = %s\n" i (Nx.to_string !param)
   done
 ```
+
+## Jit-Compiled Training Steps
+
+The structural optimizers' state is a parameter tree like the parameters themselves: `Vega.Adam_state.Make (Model)` turns the Adam state over your model into an `Nx.Ptree.S` you can embed in a compiled step's input and output records. Everything that changes across steps — the moments, the bias corrections, the step counter, the learning rate — is a tensor leaf; everything fixed (`b1`, `b2`, `eps`, `weight_decay`) is an ordinary float the compiler captures as a constant. So the forward pass, the backward pass and the update compile into a single program with no host round-trips:
+
+<!-- $MDX skip -->
+```ocaml
+module Opt = Vega.Adam_state.Make (Model)
+
+type step_in = {
+  params : Model.t;
+  opt : Opt.t;                      (* [\[@ptree.using Opt\]] with ppx_ptree *)
+  inputs : Nx.float32_t;
+  targets : (int32, Nx.int32_elt) Nx.t;
+}
+
+(* step_out carries params, opt and the loss; both records derive
+   map/map2/iter by hand or with ppx_ptree. *)
+
+let train_step { params; opt; inputs; targets } =
+  let loss, grads =
+    Rune.value_and_grad model (objective inputs targets) params
+  in
+  let grads = Vega.clip_by_global_norm model ~max_norm:1.0 grads in
+  let lr =
+    Vega.Schedule.cosine_decay_t ~init_value:1e-3 ~decay_steps:1000 opt.step
+  in
+  let params, opt = Vega.adamw_step model ~lr opt ~params ~grads in
+  { Step_out.params; opt; loss }
+
+(* ~donate:true releases the previous generation's device buffers once the
+   call completes — this loop never reads the pre-step state. *)
+let step =
+  Rune.jit2 ~donate:true (module Step_in) (module Step_out) train_step
+```
+
+Looping `step` over batches compiles once and replays: the state flows out and back in as leaves, and the schedule derives from the state's own counter inside the program. `~donate:true` keeps the loop at about two generations of device buffers instead of one per call awaiting collection — it consumes the handles it frees, so leave it off while the loop still reads the state it feeds in (on the CPU device it changes nothing). The same record works for data-parallel `Rune.pmap2` — replicate the parameters and the state, shard the batch.
+
+The scalar schedule family (`int -> float`) remains for eager loops, which evaluate it at their own step counter; the `*_t` mirrors compute the same formulas from a step tensor for compiled loops.
 
 ## Next Steps
 

--- a/packages/vega/examples/03-learning-rate-schedules/README.md
+++ b/packages/vega/examples/03-learning-rate-schedules/README.md
@@ -9,7 +9,7 @@ dune exec packages/vega/examples/03-learning-rate-schedules/main.exe
 
 ## What You'll Learn
 
-- That a schedule is simply `int -> float` (step number to learning rate)
+- That a schedule is simply a function from a step-counter tensor to a learning-rate tensor, read on the host with `Schedule.eval`
 - How `constant`, `cosine_decay`, `warmup_cosine_decay`, `one_cycle`, and
   `piecewise_constant` shape the learning rate curve
 - Composing schedules end-to-end with `Schedule.join`

--- a/packages/vega/examples/03-learning-rate-schedules/main.ml
+++ b/packages/vega/examples/03-learning-rate-schedules/main.ml
@@ -5,8 +5,9 @@
 
 (* Learning rate schedules control how the learning rate changes over training.
 
-   A schedule is simply a function [int -> float]: given a 1-based step number,
-   it returns the learning rate. This example evaluates several schedules and
+   A schedule maps a step counter to a learning rate in tensor arithmetic, so
+   the same schedule drives an eager loop and a compiled one; [Schedule.eval]
+   reads it at a host step number. This example evaluates several schedules and
    prints their values, then uses warmup + cosine decay in an optimization
    loop. *)
 
@@ -14,7 +15,7 @@ module S = Vega.Schedule
 
 let print_schedule name s steps =
   Printf.printf "  %-30s" name;
-  List.iter (fun step -> Printf.printf "  %3d:%.6f" step (s step)) steps;
+  List.iter (fun step -> Printf.printf "  %3d:%.6f" step (S.eval s step)) steps;
   Printf.printf "\n"
 
 let sample = [ 1; 25; 50; 75; 100 ]
@@ -71,6 +72,6 @@ let () =
     param := p;
     st := s;
     if i mod 20 = 0 then
-      Printf.printf "  step %3d  lr=%.6f  x = %s\n" i (lr i)
+      Printf.printf "  step %3d  lr=%.6f  x = %s\n" i (S.eval lr i)
         (Nx.to_string !param)
   done

--- a/packages/vega/lib/schedule.ml
+++ b/packages/vega/lib/schedule.ml
@@ -157,3 +157,150 @@ let join segments =
     done;
     let _, sched = segments.(!i) in
     sched !remaining
+
+(* Tensor schedules: the scalar formulas in tensor arithmetic over a scalar
+   int32 step counter, so a learning rate can be derived inside a jitted step
+   from the optimizer state's step leaf. Everything is [where]/[minimum]/[cos]
+   arithmetic on the counter — no host reads — so the schedules trace. *)
+
+let f32 = Nx.float32
+let step_f32 step = Nx.cast f32 step
+
+let clamp_ratio_t ctx param ~steps step =
+  if steps <= 0 then
+    invalid_arg (Printf.sprintf "Schedule.%s: %s must be positive" ctx param);
+  Nx.div_s
+    (Nx.minimum step (Nx.scalar f32 (float_of_int steps)))
+    (float_of_int steps)
+
+let constant_t value _step = Nx.scalar f32 value
+
+let linear_t ~init_value ~end_value ~steps step =
+  let ratio = clamp_ratio_t "linear_t" "steps" ~steps (step_f32 step) in
+  Nx.add_s (Nx.mul_s ratio (end_value -. init_value)) init_value
+
+let cosine_decay_t ~init_value ~decay_steps ?(alpha = 0.) step =
+  let ratio =
+    clamp_ratio_t "cosine_decay_t" "decay_steps" ~steps:decay_steps
+      (step_f32 step)
+  in
+  let cosine_val =
+    Nx.mul_s (Nx.add_s (Nx.cos (Nx.mul_s ratio Float.pi)) 1.0) 0.5
+  in
+  Nx.mul_s (Nx.add_s (Nx.mul_s cosine_val (1.0 -. alpha)) alpha) init_value
+
+let warmup_cosine_t ~init_value ~peak_value ~warmup_steps step =
+  let ratio =
+    clamp_ratio_t "warmup_cosine_t" "warmup_steps" ~steps:warmup_steps
+      (step_f32 step)
+  in
+  let cosine_val =
+    Nx.rsub_s 1.0
+      (Nx.mul_s (Nx.add_s (Nx.cos (Nx.mul_s ratio Float.pi)) 1.0) 0.5)
+  in
+  Nx.add_s (Nx.mul_s cosine_val (peak_value -. init_value)) init_value
+
+let warmup_cosine_decay_t ~init_value ~peak_value ~warmup_steps ~decay_steps
+    ?(end_value = 0.) step =
+  if warmup_steps <= 0 then
+    invalid_arg "Schedule.warmup_cosine_decay_t: warmup_steps must be positive";
+  let s = step_f32 step in
+  let warm_ratio =
+    Nx.div_s
+      (Nx.minimum s (Nx.scalar f32 (float_of_int warmup_steps)))
+      (float_of_int warmup_steps)
+  in
+  let linear_part =
+    Nx.add_s (Nx.mul_s warm_ratio (peak_value -. init_value)) init_value
+  in
+  let decay_step = Nx.maximum_s (Nx.sub_s s (float_of_int warmup_steps)) 0.0 in
+  let decay_ratio =
+    clamp_ratio_t "warmup_cosine_decay_t" "decay_steps" ~steps:decay_steps
+      decay_step
+  in
+  let cosine_val =
+    Nx.mul_s (Nx.add_s (Nx.cos (Nx.mul_s decay_ratio Float.pi)) 1.0) 0.5
+  in
+  let decay_part =
+    Nx.add_s (Nx.mul_s cosine_val (peak_value -. end_value)) end_value
+  in
+  Nx.where (Nx.greater_s s (float_of_int warmup_steps)) decay_part linear_part
+
+let one_cycle_t ~max_value ~total_steps ?(div_factor = 25.0)
+    ?(final_div_factor = 10000.0) ?(pct_start = 0.3) step =
+  if total_steps <= 0 then
+    invalid_arg "Schedule.one_cycle_t: total_steps must be positive";
+  let warmup_steps = int_of_float (pct_start *. float_of_int total_steps) in
+  let init_value = max_value /. div_factor in
+  let end_value = max_value /. final_div_factor in
+  let s = step_f32 step in
+  let decay_steps = total_steps - warmup_steps in
+  if warmup_steps <= 0 then
+    (* All decay: warmup is degenerate, the counter ramps straight down. *)
+    let decay_ratio =
+      clamp_ratio_t "one_cycle_t" "total_steps" ~steps:decay_steps s
+    in
+    let cosine_val =
+      Nx.mul_s (Nx.add_s (Nx.cos (Nx.mul_s decay_ratio Float.pi)) 1.0) 0.5
+    in
+    Nx.add_s (Nx.mul_s cosine_val (max_value -. end_value)) end_value
+  else if decay_steps <= 0 then
+    (* All warmup: the schedule never leaves its ramp. *)
+    let warm_ratio =
+      clamp_ratio_t "one_cycle_t" "total_steps" ~steps:warmup_steps s
+    in
+    Nx.add_s (Nx.mul_s warm_ratio (max_value -. init_value)) init_value
+  else
+    let decay_step =
+      Nx.maximum_s (Nx.sub_s s (float_of_int warmup_steps)) 0.0
+    in
+    let decay_ratio =
+      clamp_ratio_t "one_cycle_t" "total_steps" ~steps:decay_steps decay_step
+    in
+    let cosine_val =
+      Nx.mul_s (Nx.add_s (Nx.cos (Nx.mul_s decay_ratio Float.pi)) 1.0) 0.5
+    in
+    let decay_part =
+      Nx.add_s (Nx.mul_s cosine_val (max_value -. end_value)) end_value
+    in
+    let warm_ratio =
+      Nx.div_s
+        (Nx.minimum s (Nx.scalar f32 (float_of_int warmup_steps)))
+        (float_of_int warmup_steps)
+    in
+    let linear_part =
+      Nx.add_s (Nx.mul_s warm_ratio (max_value -. init_value)) init_value
+    in
+    Nx.where (Nx.greater_s s (float_of_int warmup_steps)) decay_part linear_part
+
+let piecewise_constant_t ~boundaries ~values step =
+  let n_boundaries = List.length boundaries in
+  let n_values = List.length values in
+  if n_values <> n_boundaries + 1 then
+    invalid_arg
+      (Printf.sprintf
+         "Schedule.piecewise_constant_t: expected %d values for %d boundaries, \
+          got %d"
+         (n_boundaries + 1) n_boundaries n_values);
+  let rec check_increasing = function
+    | [] | [ _ ] -> ()
+    | a :: (b :: _ as rest) ->
+        if b <= a then
+          invalid_arg
+            "Schedule.piecewise_constant_t: boundaries must be strictly \
+             increasing";
+        check_increasing rest
+  in
+  check_increasing boundaries;
+  let boundaries = Array.of_list boundaries in
+  let values = Array.of_list values in
+  let s = step_f32 step in
+  let acc = ref (Nx.scalar f32 values.(Array.length values - 1)) in
+  for i = Array.length boundaries - 1 downto 0 do
+    acc :=
+      Nx.where
+        (Nx.greater_equal_s s (float_of_int boundaries.(i) +. 1.0))
+        !acc
+        (Nx.scalar f32 values.(i))
+  done;
+  !acc

--- a/packages/vega/lib/schedule.ml
+++ b/packages/vega/lib/schedule.ml
@@ -3,118 +3,172 @@
   SPDX-License-Identifier: ISC
   ---------------------------------------------------------------------------*)
 
-type t = int -> float
+(* Schedules are tensor arithmetic over a scalar int32 step counter —
+   [where]/[minimum]/[cos]/[pow] on the counter, no host reads — so the same
+   schedule computes eagerly and traces inside a compiled step, where it
+   derives the learning rate from the optimizer state's own step leaf. *)
+
+type t = Nx.int32_t -> Nx.float32_t
+
+let f32 = Nx.float32
+let to_f32 step = Nx.cast f32 step
+let eval sched step = Nx.item [] (sched (Nx.scalar Nx.int32 (Int32.of_int step)))
 
 (* Cosine annealing factor: 1 -> 0 as ratio goes 0 -> 1. *)
-let cosine_decay_factor ratio = 0.5 *. (1. +. Stdlib.cos (Float.pi *. ratio))
-let constant value _ = value
+let cosine_factor ratio =
+  Nx.mul_s (Nx.add_s (Nx.cos (Nx.mul_s ratio Float.pi)) 1.0) 0.5
 
-let linear ~init_value ~end_value ~steps step =
+(* step / steps, clamped to 1. *)
+let clamp_ratio ~steps s =
+  Nx.div_s
+    (Nx.minimum s (Nx.scalar f32 (float_of_int steps)))
+    (float_of_int steps)
+
+(* [base ** p] for [base >= 0] and a constant exponent. Integer and
+   half-integer exponents stay [pow], which the compiler decomposes into
+   multiplications and square roots; other exponents go through exp/log, whose
+   limit at a zero base is the right value for positive [p]. *)
+let pow_const base p =
+  if Float.is_integer (2.0 *. p) then Nx.pow_s base p
+  else Nx.exp (Nx.mul_s (Nx.log base) p)
+
+let constant value _step = Nx.scalar f32 value
+
+let linear ~init_value ~end_value ~steps =
   if steps <= 0 then invalid_arg "Schedule.linear: steps must be positive";
-  if step >= steps then end_value
-  else
-    let ratio = float_of_int step /. float_of_int steps in
-    init_value +. ((end_value -. init_value) *. ratio)
+  fun step ->
+    let ratio = clamp_ratio ~steps (to_f32 step) in
+    Nx.add_s (Nx.mul_s ratio (end_value -. init_value)) init_value
 
-let cosine_decay ~init_value ~decay_steps ?(alpha = 0.) () step =
+let cosine_decay ~init_value ~decay_steps ?(alpha = 0.) () =
   if decay_steps <= 0 then
     invalid_arg "Schedule.cosine_decay: decay_steps must be positive";
-  if step >= decay_steps then alpha *. init_value
-  else
-    let ratio = float_of_int step /. float_of_int decay_steps in
-    let cosine_val = cosine_decay_factor ratio in
-    (((1. -. alpha) *. cosine_val) +. alpha) *. init_value
+  fun step ->
+    let ratio = clamp_ratio ~steps:decay_steps (to_f32 step) in
+    let cosine_val = cosine_factor ratio in
+    Nx.mul_s (Nx.add_s (Nx.mul_s cosine_val (1.0 -. alpha)) alpha) init_value
 
-let exponential_decay ~init_value ~decay_rate ~decay_steps step =
+let exponential_decay ~init_value ~decay_rate ~decay_steps =
   if decay_steps <= 0 then
     invalid_arg "Schedule.exponential_decay: decay_steps must be positive";
-  let ratio = float_of_int step /. float_of_int decay_steps in
-  init_value *. (decay_rate ** ratio)
+  if decay_rate <= 0.0 then
+    invalid_arg "Schedule.exponential_decay: decay_rate must be positive";
+  fun step ->
+    let ratio = Nx.div_s (to_f32 step) (float_of_int decay_steps) in
+    Nx.mul_s (Nx.rpow_s decay_rate ratio) init_value
 
-let polynomial_decay ~init_value ~end_value ~decay_steps ?(power = 1.0) () step
-    =
+let polynomial_decay ~init_value ~end_value ~decay_steps ?(power = 1.0) () =
   if decay_steps <= 0 then
     invalid_arg "Schedule.polynomial_decay: decay_steps must be positive";
-  if step >= decay_steps then end_value
-  else
-    let ratio = float_of_int step /. float_of_int decay_steps in
-    end_value +. ((init_value -. end_value) *. ((1. -. ratio) ** power))
+  fun step ->
+    let ratio = clamp_ratio ~steps:decay_steps (to_f32 step) in
+    let poly = pow_const (Nx.rsub_s 1.0 ratio) power in
+    Nx.add_s (Nx.mul_s poly (init_value -. end_value)) end_value
 
-let warmup_cosine ~init_value ~peak_value ~warmup_steps step =
+let warmup_cosine ~init_value ~peak_value ~warmup_steps =
   if warmup_steps <= 0 then
     invalid_arg "Schedule.warmup_cosine: warmup_steps must be positive";
-  if step >= warmup_steps then peak_value
-  else
-    let ratio = float_of_int step /. float_of_int warmup_steps in
-    let cosine_val = 1. -. cosine_decay_factor ratio in
-    init_value +. ((peak_value -. init_value) *. cosine_val)
+  fun step ->
+    let ratio = clamp_ratio ~steps:warmup_steps (to_f32 step) in
+    let cosine_val = Nx.rsub_s 1.0 (cosine_factor ratio) in
+    Nx.add_s (Nx.mul_s cosine_val (peak_value -. init_value)) init_value
 
 let warmup_cosine_decay ~init_value ~peak_value ~warmup_steps ~decay_steps
-    ?(end_value = 0.) () step =
+    ?(end_value = 0.) () =
   if warmup_steps <= 0 then
     invalid_arg "Schedule.warmup_cosine_decay: warmup_steps must be positive";
   if decay_steps <= 0 then
     invalid_arg "Schedule.warmup_cosine_decay: decay_steps must be positive";
-  if step <= warmup_steps then
-    let ratio = float_of_int step /. float_of_int warmup_steps in
-    init_value +. ((peak_value -. init_value) *. ratio)
-  else
-    let decay_step = step - warmup_steps in
-    if decay_step >= decay_steps then end_value
-    else
-      let ratio = float_of_int decay_step /. float_of_int decay_steps in
-      let cosine_val = cosine_decay_factor ratio in
-      end_value +. ((peak_value -. end_value) *. cosine_val)
+  fun step ->
+    let s = to_f32 step in
+    let warm_ratio = clamp_ratio ~steps:warmup_steps s in
+    let linear_part =
+      Nx.add_s (Nx.mul_s warm_ratio (peak_value -. init_value)) init_value
+    in
+    let decay_step =
+      Nx.maximum_s (Nx.sub_s s (float_of_int warmup_steps)) 0.0
+    in
+    let decay_ratio = clamp_ratio ~steps:decay_steps decay_step in
+    let decay_part =
+      Nx.add_s
+        (Nx.mul_s (cosine_factor decay_ratio) (peak_value -. end_value))
+        end_value
+    in
+    Nx.where (Nx.greater_s s (float_of_int warmup_steps)) decay_part linear_part
 
 let cosine_decay_restarts ~init_value ~decay_steps ?(t_mul = 1.0) ?(m_mul = 1.0)
     ?(alpha = 0.) () =
   if decay_steps <= 0 then
     invalid_arg "Schedule.cosine_decay_restarts: decay_steps must be positive";
-  fun step ->
-    (* Fast path for uniform period (exact float comparison is intentional: 1.0
-       is the unmodified default). *)
-    if t_mul = 1.0 then
-      let cycle = step / decay_steps in
-      let pos = step - (cycle * decay_steps) in
-      let amp = init_value *. (m_mul ** float_of_int cycle) in
-      let ratio = float_of_int pos /. float_of_int decay_steps in
-      let cosine_val = cosine_decay_factor ratio in
-      (((1. -. alpha) *. cosine_val) +. alpha) *. amp
-    else begin
-      (* Geometric period: find which cycle [step] falls in. *)
-      let remaining = ref step in
-      let cycle = ref 0 in
-      let period = ref (float_of_int decay_steps) in
-      while float_of_int !remaining >= !period do
-        remaining := !remaining - int_of_float !period;
-        period := !period *. t_mul;
-        incr cycle
-      done;
-      let amp = init_value *. (m_mul ** float_of_int !cycle) in
-      let ratio = float_of_int !remaining /. !period in
-      let cosine_val = cosine_decay_factor ratio in
-      (((1. -. alpha) *. cosine_val) +. alpha) *. amp
-    end
+  if t_mul < 1.0 then
+    invalid_arg "Schedule.cosine_decay_restarts: t_mul must be at least 1";
+  if m_mul <= 0.0 then
+    invalid_arg "Schedule.cosine_decay_restarts: m_mul must be positive";
+  let first = float_of_int decay_steps in
+  let anneal cycle ratio =
+    let amp = Nx.mul_s (Nx.rpow_s m_mul cycle) init_value in
+    Nx.mul (Nx.add_s (Nx.mul_s (cosine_factor ratio) (1.0 -. alpha)) alpha) amp
+  in
+  (* Exact float comparison is intentional: 1.0 is the unmodified default. *)
+  if t_mul = 1.0 then fun step ->
+    let s = to_f32 step in
+    let cycle = Nx.floor (Nx.div_s s first) in
+    let pos = Nx.sub s (Nx.mul_s cycle first) in
+    anneal cycle (Nx.div_s pos first)
+  else fun step ->
+    (* Geometric periods: cycle k spans [start k, start (k+1)) where
+       [start k = first * (t_mul^k - 1) / (t_mul - 1)]. Inverting gives
+       [k = floor (log q / log t_mul)] with [q = s*(t_mul-1)/first + 1]; the
+       two [where]s absorb any float slop at the cycle boundaries. *)
+    let s = to_f32 step in
+    let start k =
+      Nx.mul_s
+        (Nx.div_s (Nx.sub_s (Nx.rpow_s t_mul k) 1.0) (t_mul -. 1.0))
+        first
+    in
+    let q = Nx.add_s (Nx.mul_s s ((t_mul -. 1.0) /. first)) 1.0 in
+    let k = Nx.floor (Nx.div_s (Nx.log q) (Stdlib.log t_mul)) in
+    let k = Nx.where (Nx.less s (start k)) (Nx.sub_s k 1.0) k in
+    let k =
+      Nx.where (Nx.greater_equal s (start (Nx.add_s k 1.0))) (Nx.add_s k 1.0) k
+    in
+    let k = Nx.maximum_s k 0.0 in
+    let period = Nx.mul_s (Nx.rpow_s t_mul k) first in
+    let pos = Nx.sub s (start k) in
+    anneal k (Nx.div pos period)
 
 let one_cycle ~max_value ~total_steps ?(div_factor = 25.0)
     ?(final_div_factor = 10000.0) ?(pct_start = 0.3) () =
   if total_steps <= 0 then
     invalid_arg "Schedule.one_cycle: total_steps must be positive";
-  fun step ->
-    let warmup_steps = int_of_float (pct_start *. float_of_int total_steps) in
-    let init_value = max_value /. div_factor in
-    let end_value = max_value /. final_div_factor in
-    if step <= warmup_steps then
-      let ratio = float_of_int step /. float_of_int warmup_steps in
-      init_value +. ((max_value -. init_value) *. ratio)
-    else
-      let decay_steps = total_steps - warmup_steps in
-      let decay_step = step - warmup_steps in
-      if decay_step >= decay_steps then end_value
-      else
-        let ratio = float_of_int decay_step /. float_of_int decay_steps in
-        let cosine_val = cosine_decay_factor ratio in
-        end_value +. ((max_value -. end_value) *. cosine_val)
+  let warmup_steps = int_of_float (pct_start *. float_of_int total_steps) in
+  let decay_steps = total_steps - warmup_steps in
+  let init_value = max_value /. div_factor in
+  let end_value = max_value /. final_div_factor in
+  if warmup_steps <= 0 then fun step ->
+    (* All decay: warmup is degenerate, the counter ramps straight down. *)
+    let ratio = clamp_ratio ~steps:decay_steps (to_f32 step) in
+    Nx.add_s (Nx.mul_s (cosine_factor ratio) (max_value -. end_value)) end_value
+  else if decay_steps <= 0 then fun step ->
+    (* All warmup: the schedule never leaves its ramp. *)
+    let ratio = clamp_ratio ~steps:warmup_steps (to_f32 step) in
+    Nx.add_s (Nx.mul_s ratio (max_value -. init_value)) init_value
+  else fun step ->
+    let s = to_f32 step in
+    let warm_ratio = clamp_ratio ~steps:warmup_steps s in
+    let linear_part =
+      Nx.add_s (Nx.mul_s warm_ratio (max_value -. init_value)) init_value
+    in
+    let decay_step =
+      Nx.maximum_s (Nx.sub_s s (float_of_int warmup_steps)) 0.0
+    in
+    let decay_ratio = clamp_ratio ~steps:decay_steps decay_step in
+    let decay_part =
+      Nx.add_s
+        (Nx.mul_s (cosine_factor decay_ratio) (max_value -. end_value))
+        end_value
+    in
+    Nx.where (Nx.greater_s s (float_of_int warmup_steps)) decay_part linear_part
 
 let piecewise_constant ~boundaries ~values =
   let n_boundaries = List.length boundaries in
@@ -133,12 +187,16 @@ let piecewise_constant ~boundaries ~values =
         "Schedule.piecewise_constant: boundaries must be strictly increasing"
   done;
   fun step ->
-    let rec find i =
-      if i >= Array.length boundaries then values.(Array.length values - 1)
-      else if step <= boundaries.(i) then values.(i)
-      else find (i + 1)
-    in
-    find 0
+    let s = to_f32 step in
+    let acc = ref (Nx.scalar f32 values.(Array.length values - 1)) in
+    for i = Array.length boundaries - 1 downto 0 do
+      acc :=
+        Nx.where
+          (Nx.greater_s s (float_of_int boundaries.(i)))
+          !acc
+          (Nx.scalar f32 values.(i))
+    done;
+    !acc
 
 let join segments =
   if segments = [] then invalid_arg "Schedule.join: segments must not be empty";
@@ -148,159 +206,22 @@ let join segments =
         invalid_arg "Schedule.join: segment lengths must be positive")
     segments;
   let segments = Array.of_list segments in
-  fun step ->
-    let remaining = ref step in
-    let i = ref 0 in
-    while !i < Array.length segments - 1 && !remaining > fst segments.(!i) do
-      remaining := !remaining - fst segments.(!i);
-      incr i
-    done;
-    let _, sched = segments.(!i) in
-    sched !remaining
-
-(* Tensor schedules: the scalar formulas in tensor arithmetic over a scalar
-   int32 step counter, so a learning rate can be derived inside a jitted step
-   from the optimizer state's step leaf. Everything is [where]/[minimum]/[cos]
-   arithmetic on the counter — no host reads — so the schedules trace. *)
-
-let f32 = Nx.float32
-let step_f32 step = Nx.cast f32 step
-
-let clamp_ratio_t ctx param ~steps step =
-  if steps <= 0 then
-    invalid_arg (Printf.sprintf "Schedule.%s: %s must be positive" ctx param);
-  Nx.div_s
-    (Nx.minimum step (Nx.scalar f32 (float_of_int steps)))
-    (float_of_int steps)
-
-let constant_t value _step = Nx.scalar f32 value
-
-let linear_t ~init_value ~end_value ~steps step =
-  let ratio = clamp_ratio_t "linear_t" "steps" ~steps (step_f32 step) in
-  Nx.add_s (Nx.mul_s ratio (end_value -. init_value)) init_value
-
-let cosine_decay_t ~init_value ~decay_steps ?(alpha = 0.) step =
-  let ratio =
-    clamp_ratio_t "cosine_decay_t" "decay_steps" ~steps:decay_steps
-      (step_f32 step)
-  in
-  let cosine_val =
-    Nx.mul_s (Nx.add_s (Nx.cos (Nx.mul_s ratio Float.pi)) 1.0) 0.5
-  in
-  Nx.mul_s (Nx.add_s (Nx.mul_s cosine_val (1.0 -. alpha)) alpha) init_value
-
-let warmup_cosine_t ~init_value ~peak_value ~warmup_steps step =
-  let ratio =
-    clamp_ratio_t "warmup_cosine_t" "warmup_steps" ~steps:warmup_steps
-      (step_f32 step)
-  in
-  let cosine_val =
-    Nx.rsub_s 1.0
-      (Nx.mul_s (Nx.add_s (Nx.cos (Nx.mul_s ratio Float.pi)) 1.0) 0.5)
-  in
-  Nx.add_s (Nx.mul_s cosine_val (peak_value -. init_value)) init_value
-
-let warmup_cosine_decay_t ~init_value ~peak_value ~warmup_steps ~decay_steps
-    ?(end_value = 0.) step =
-  if warmup_steps <= 0 then
-    invalid_arg "Schedule.warmup_cosine_decay_t: warmup_steps must be positive";
-  let s = step_f32 step in
-  let warm_ratio =
-    Nx.div_s
-      (Nx.minimum s (Nx.scalar f32 (float_of_int warmup_steps)))
-      (float_of_int warmup_steps)
-  in
-  let linear_part =
-    Nx.add_s (Nx.mul_s warm_ratio (peak_value -. init_value)) init_value
-  in
-  let decay_step = Nx.maximum_s (Nx.sub_s s (float_of_int warmup_steps)) 0.0 in
-  let decay_ratio =
-    clamp_ratio_t "warmup_cosine_decay_t" "decay_steps" ~steps:decay_steps
-      decay_step
-  in
-  let cosine_val =
-    Nx.mul_s (Nx.add_s (Nx.cos (Nx.mul_s decay_ratio Float.pi)) 1.0) 0.5
-  in
-  let decay_part =
-    Nx.add_s (Nx.mul_s cosine_val (peak_value -. end_value)) end_value
-  in
-  Nx.where (Nx.greater_s s (float_of_int warmup_steps)) decay_part linear_part
-
-let one_cycle_t ~max_value ~total_steps ?(div_factor = 25.0)
-    ?(final_div_factor = 10000.0) ?(pct_start = 0.3) step =
-  if total_steps <= 0 then
-    invalid_arg "Schedule.one_cycle_t: total_steps must be positive";
-  let warmup_steps = int_of_float (pct_start *. float_of_int total_steps) in
-  let init_value = max_value /. div_factor in
-  let end_value = max_value /. final_div_factor in
-  let s = step_f32 step in
-  let decay_steps = total_steps - warmup_steps in
-  if warmup_steps <= 0 then
-    (* All decay: warmup is degenerate, the counter ramps straight down. *)
-    let decay_ratio =
-      clamp_ratio_t "one_cycle_t" "total_steps" ~steps:decay_steps s
-    in
-    let cosine_val =
-      Nx.mul_s (Nx.add_s (Nx.cos (Nx.mul_s decay_ratio Float.pi)) 1.0) 0.5
-    in
-    Nx.add_s (Nx.mul_s cosine_val (max_value -. end_value)) end_value
-  else if decay_steps <= 0 then
-    (* All warmup: the schedule never leaves its ramp. *)
-    let warm_ratio =
-      clamp_ratio_t "one_cycle_t" "total_steps" ~steps:warmup_steps s
-    in
-    Nx.add_s (Nx.mul_s warm_ratio (max_value -. init_value)) init_value
-  else
-    let decay_step =
-      Nx.maximum_s (Nx.sub_s s (float_of_int warmup_steps)) 0.0
-    in
-    let decay_ratio =
-      clamp_ratio_t "one_cycle_t" "total_steps" ~steps:decay_steps decay_step
-    in
-    let cosine_val =
-      Nx.mul_s (Nx.add_s (Nx.cos (Nx.mul_s decay_ratio Float.pi)) 1.0) 0.5
-    in
-    let decay_part =
-      Nx.add_s (Nx.mul_s cosine_val (max_value -. end_value)) end_value
-    in
-    let warm_ratio =
-      Nx.div_s
-        (Nx.minimum s (Nx.scalar f32 (float_of_int warmup_steps)))
-        (float_of_int warmup_steps)
-    in
-    let linear_part =
-      Nx.add_s (Nx.mul_s warm_ratio (max_value -. init_value)) init_value
-    in
-    Nx.where (Nx.greater_s s (float_of_int warmup_steps)) decay_part linear_part
-
-let piecewise_constant_t ~boundaries ~values step =
-  let n_boundaries = List.length boundaries in
-  let n_values = List.length values in
-  if n_values <> n_boundaries + 1 then
-    invalid_arg
-      (Printf.sprintf
-         "Schedule.piecewise_constant_t: expected %d values for %d boundaries, \
-          got %d"
-         (n_boundaries + 1) n_boundaries n_values);
-  let rec check_increasing = function
-    | [] | [ _ ] -> ()
-    | a :: (b :: _ as rest) ->
-        if b <= a then
-          invalid_arg
-            "Schedule.piecewise_constant_t: boundaries must be strictly \
-             increasing";
-        check_increasing rest
-  in
-  check_increasing boundaries;
-  let boundaries = Array.of_list boundaries in
-  let values = Array.of_list values in
-  let s = step_f32 step in
-  let acc = ref (Nx.scalar f32 values.(Array.length values - 1)) in
-  for i = Array.length boundaries - 1 downto 0 do
-    acc :=
-      Nx.where
-        (Nx.greater_equal_s s (float_of_int boundaries.(i) +. 1.0))
-        !acc
-        (Nx.scalar f32 values.(i))
+  let n_seg = Array.length segments in
+  let starts = Array.make n_seg 0 in
+  for i = 1 to n_seg - 1 do
+    starts.(i) <- starts.(i - 1) + fst segments.(i - 1)
   done;
-  !acc
+  fun step ->
+    (* Selected last to first: the earliest segment whose span covers the
+       relative counter wins. Inactive segments are still computed (at
+       out-of-range counters) and discarded by [where]. *)
+    let at i = snd segments.(i) (Nx.sub_s step (Int32.of_int starts.(i))) in
+    let acc = ref (at (n_seg - 1)) in
+    for i = n_seg - 2 downto 0 do
+      let rel = Nx.sub_s step (Int32.of_int starts.(i)) in
+      acc :=
+        Nx.where
+          (Nx.less_equal_s rel (Int32.of_int (fst segments.(i))))
+          (at i) !acc
+    done;
+    !acc

--- a/packages/vega/lib/schedule.mli
+++ b/packages/vega/lib/schedule.mli
@@ -5,21 +5,45 @@
 
 (** Learning-rate schedules.
 
-    A schedule maps a step counter to a learning rate. It is a plain function:
-    compose or define schedules directly. This is the single schedule vocabulary
-    for both of Vega's tiers — structural training loops evaluate a schedule at
-    the loop's step counter and pass the result as a step function's [~lr];
-    per-tensor transforms such as [Vega.scale_by_learning_rate] consume the
-    schedule value itself. *)
+    A schedule maps a step counter to a learning rate. The counter is a scalar
+    [int32] tensor and the result a scalar [float32] tensor, so a schedule is
+    ordinary tensor arithmetic: applied to an optimizer state's own [step] leaf
+    inside a compiled training step ({!Rune.val-jit}), the rate is derived
+    inside the program and tracks the state across calls; applied eagerly, it
+    computes the same value. One family serves both worlds — there is no
+    separate host-side variant, only {!eval} to read a schedule at a host
+    counter for logging or for loops that keep their own count.
 
-type t = int -> float
+    Structural steps take the schedule's result as their [~lr]:
+
+    {[
+      let sched =
+        Vega.Schedule.cosine_decay ~init_value:1e-3 ~decay_steps:1000 ()
+      in
+      let step (params, st) =
+        ...
+        Vega.adamw_step model ~lr:(sched st.step) st ~params ~grads
+    ]}
+
+    This is the single schedule vocabulary for both of Vega's tiers: the
+    per-tensor transforms ([Vega.scale_by_schedule],
+    [Vega.scale_by_learning_rate], [Vega.add_decayed_weights]) evaluate their
+    schedule at the chain's own update count. *)
+
+type t = Nx.int32_t -> Nx.float32_t
 (** The type for learning-rate schedules.
 
-    [s step] is the learning rate at step counter [step]. Schedules are defined
-    for [step >= 0] and constructors are at their initial value at [step = 0].
-    Per-tensor chains evaluate their schedules at the 1-based update count (the
-    first update evaluates at [1]); structural loops conventionally evaluate at
-    the number of completed steps, starting at [0]. *)
+    [s step] is the learning rate at the scalar counter [step], as a scalar
+    [float32] tensor. Schedules are defined for [step >= 0] and constructors
+    are at their initial value at [step = 0]. Per-tensor chains evaluate their
+    schedules at the 1-based update count (the first update evaluates at [1]);
+    structural loops evaluate at the state's number of completed steps,
+    starting at [0]. *)
+
+val eval : t -> int -> float
+(** [eval s step] is the schedule's value at the host counter [step], as a
+    host float. Use it for logging a schedule, plotting one, or driving an
+    eager loop from its own [int] counter. *)
 
 (** {1:basic Basic} *)
 
@@ -29,7 +53,9 @@ val constant : float -> t
 val linear : init_value:float -> end_value:float -> steps:int -> t
 (** [linear ~init_value ~end_value ~steps] interpolates linearly from
     [init_value] to [end_value] over [steps]. Clamps to [end_value] after
-    [steps]. *)
+    [steps].
+
+    Raises [Invalid_argument] if [steps] is not positive. *)
 
 (** {1:decay Decay} *)
 
@@ -38,12 +64,17 @@ val cosine_decay :
 (** [cosine_decay ~init_value ~decay_steps ?alpha ()] is cosine decay from
     [init_value] to [alpha * init_value] over [decay_steps].
 
-    [alpha] defaults to [0.]. *)
+    [alpha] defaults to [0.].
+
+    Raises [Invalid_argument] if [decay_steps] is not positive. *)
 
 val exponential_decay :
   init_value:float -> decay_rate:float -> decay_steps:int -> t
 (** [exponential_decay ~init_value ~decay_rate ~decay_steps] is
-    [init_value * decay_rate{^ (step / decay_steps)}]. *)
+    [init_value * decay_rate{^ (step / decay_steps)}].
+
+    Raises [Invalid_argument] if [decay_steps] or [decay_rate] is not
+    positive. *)
 
 val polynomial_decay :
   init_value:float ->
@@ -57,7 +88,9 @@ val polynomial_decay :
     [end_value + (init_value - end_value) * (1 - step/decay_steps)^power].
 
     [power] defaults to [1.0] (linear decay). Clamps to [end_value] after
-    [decay_steps]. *)
+    [decay_steps].
+
+    Raises [Invalid_argument] if [decay_steps] is not positive. *)
 
 (** {1:warmup Warmup} *)
 
@@ -65,7 +98,9 @@ val warmup_cosine :
   init_value:float -> peak_value:float -> warmup_steps:int -> t
 (** [warmup_cosine ~init_value ~peak_value ~warmup_steps] is cosine warmup from
     [init_value] to [peak_value] over [warmup_steps]. Clamps to [peak_value]
-    after [warmup_steps]. *)
+    after [warmup_steps].
+
+    Raises [Invalid_argument] if [warmup_steps] is not positive. *)
 
 val warmup_cosine_decay :
   init_value:float ->
@@ -79,7 +114,10 @@ val warmup_cosine_decay :
      ?end_value ()] is linear warmup from [init_value] to [peak_value] over
     [warmup_steps], then cosine decay to [end_value] over [decay_steps].
 
-    [end_value] defaults to [0.]. *)
+    [end_value] defaults to [0.].
+
+    Raises [Invalid_argument] if [warmup_steps] or [decay_steps] is not
+    positive. *)
 
 (** {1:restarts Warm Restarts} *)
 
@@ -98,7 +136,10 @@ val cosine_decay_restarts :
     amplitude by [m_mul]. [alpha] is the minimum fraction of [init_value].
 
     [t_mul] defaults to [1.0]. [m_mul] defaults to [1.0]. [alpha] defaults to
-    [0.0]. *)
+    [0.0].
+
+    Raises [Invalid_argument] if [decay_steps] is not positive, [t_mul < 1.0],
+    or [m_mul] is not positive. *)
 
 val one_cycle :
   max_value:float ->
@@ -116,7 +157,9 @@ val one_cycle :
     [max_value / final_div_factor] over the remaining steps.
 
     [div_factor] defaults to [25.0]. [final_div_factor] defaults to [10000.0].
-    [pct_start] defaults to [0.3]. *)
+    [pct_start] defaults to [0.3].
+
+    Raises [Invalid_argument] if [total_steps] is not positive. *)
 
 (** {1:composition Composition} *)
 
@@ -135,113 +178,7 @@ val piecewise_constant : boundaries:int list -> values:float list -> t
 
 val join : (int * t) list -> t
 (** [join segments] sequences schedules end-to-end. Each [(n, s)] runs [s] for
-    [n] steps. Step numbers are restarted from 1 within each segment. The last
-    segment's schedule is used for all steps beyond the total.
+    [n] steps, evaluated at the counter relative to the segment's start. The
+    last segment's schedule is used for all steps beyond the total.
 
     Raises [Invalid_argument] if [segments] is empty or any [n <= 0]. *)
-
-(** {1:tensor Tensor schedules}
-
-    The scalar family above evaluates on the host: inside a {!Rune.val-jit}ed
-    step a schedule value would be a compile-time constant, replayed stale on
-    every call. The [*_t] mirrors below compute the same formulas in tensor
-    arithmetic from a step counter that is itself a tensor — the [step] leaf of
-    an optimizer state ({!Adam_state}) — so the learning rate is derived
-    {e inside} the compiled program and tracks the state across calls.
-
-    Each [*_t] function takes the counter as its final argument, a scalar
-    [int32] tensor of completed steps (0-based, the structural loops'
-    convention), and returns a scalar [float32] tensor. At every integer step
-    the tensor value matches the scalar schedule's (to float32 rounding); a
-    property the test suites hold both families to. The subset covers the
-    schedules expressible with tensor arithmetic; [exponential_decay],
-    [polynomial_decay] and [cosine_decay_restarts] need [pow] and integer
-    division on tensors and remain scalar-only.
-
-    {[
-      let st = Vega.adam_init model params in
-      let step p st =
-        let lr = Vega.Schedule.cosine_decay_t ~init_value:1e-3
-            ~decay_steps:1000 st.step in
-        Vega.adam_step model ~lr st ~params:p ~grads
-    ]} *)
-
-val constant_t : float -> (int32, Nx.int32_elt) Nx.t -> Nx.float32_t
-(** [constant_t v step] is the scalar-tensor mirror of {!constant}. *)
-
-val linear_t :
-  init_value:float ->
-  end_value:float ->
-  steps:int ->
-  (int32, Nx.int32_elt) Nx.t ->
-  Nx.float32_t
-(** [linear_t] is the tensor mirror of {!linear}: linear interpolation from
-    [init_value] to [end_value] over [steps], clamped to [end_value] after.
-
-    Raises [Invalid_argument] if [steps] is not positive. *)
-
-val cosine_decay_t :
-  init_value:float ->
-  decay_steps:int ->
-  ?alpha:float ->
-  (int32, Nx.int32_elt) Nx.t ->
-  Nx.float32_t
-(** [cosine_decay_t] is the tensor mirror of {!cosine_decay}: cosine decay from
-    [init_value] to [alpha * init_value] over [decay_steps], clamped.
-
-    [alpha] defaults to [0.].
-
-    Raises [Invalid_argument] if [decay_steps] is not positive. *)
-
-val warmup_cosine_t :
-  init_value:float ->
-  peak_value:float ->
-  warmup_steps:int ->
-  (int32, Nx.int32_elt) Nx.t ->
-  Nx.float32_t
-(** [warmup_cosine_t] is the tensor mirror of {!warmup_cosine}: cosine warmup
-    from [init_value] to [peak_value] over [warmup_steps], clamped.
-
-    Raises [Invalid_argument] if [warmup_steps] is not positive. *)
-
-val warmup_cosine_decay_t :
-  init_value:float ->
-  peak_value:float ->
-  warmup_steps:int ->
-  decay_steps:int ->
-  ?end_value:float ->
-  (int32, Nx.int32_elt) Nx.t ->
-  Nx.float32_t
-(** [warmup_cosine_decay_t] is the tensor mirror of {!warmup_cosine_decay}:
-    linear warmup from [init_value] to [peak_value] over [warmup_steps], then
-    cosine decay to [end_value] over [decay_steps].
-
-    [end_value] defaults to [0.].
-
-    Raises [Invalid_argument] if [warmup_steps] or [decay_steps] is not
-    positive. *)
-
-val one_cycle_t :
-  max_value:float ->
-  total_steps:int ->
-  ?div_factor:float ->
-  ?final_div_factor:float ->
-  ?pct_start:float ->
-  (int32, Nx.int32_elt) Nx.t ->
-  Nx.float32_t
-(** [one_cycle_t] is the tensor mirror of {!one_cycle}.
-
-    [div_factor] defaults to [25.0], [final_div_factor] to [10000.0] and
-    [pct_start] to [0.3].
-
-    Raises [Invalid_argument] if [total_steps] is not positive. *)
-
-val piecewise_constant_t :
-  boundaries:int list ->
-  values:float list ->
-  (int32, Nx.int32_elt) Nx.t ->
-  Nx.float32_t
-(** [piecewise_constant_t] is the tensor mirror of {!piecewise_constant}.
-
-    Raises [Invalid_argument] under the same conditions as
-    {!piecewise_constant}. *)

--- a/packages/vega/lib/schedule.mli
+++ b/packages/vega/lib/schedule.mli
@@ -139,3 +139,109 @@ val join : (int * t) list -> t
     segment's schedule is used for all steps beyond the total.
 
     Raises [Invalid_argument] if [segments] is empty or any [n <= 0]. *)
+
+(** {1:tensor Tensor schedules}
+
+    The scalar family above evaluates on the host: inside a {!Rune.val-jit}ed
+    step a schedule value would be a compile-time constant, replayed stale on
+    every call. The [*_t] mirrors below compute the same formulas in tensor
+    arithmetic from a step counter that is itself a tensor — the [step] leaf of
+    an optimizer state ({!Adam_state}) — so the learning rate is derived
+    {e inside} the compiled program and tracks the state across calls.
+
+    Each [*_t] function takes the counter as its final argument, a scalar
+    [int32] tensor of completed steps (0-based, the structural loops'
+    convention), and returns a scalar [float32] tensor. At every integer step
+    the tensor value matches the scalar schedule's (to float32 rounding); a
+    property the test suites hold both families to. The subset covers the
+    schedules expressible with tensor arithmetic; [exponential_decay],
+    [polynomial_decay] and [cosine_decay_restarts] need [pow] and integer
+    division on tensors and remain scalar-only.
+
+    {[
+      let st = Vega.adam_init model params in
+      let step p st =
+        let lr = Vega.Schedule.cosine_decay_t ~init_value:1e-3
+            ~decay_steps:1000 st.step in
+        Vega.adam_step model ~lr st ~params:p ~grads
+    ]} *)
+
+val constant_t : float -> (int32, Nx.int32_elt) Nx.t -> Nx.float32_t
+(** [constant_t v step] is the scalar-tensor mirror of {!constant}. *)
+
+val linear_t :
+  init_value:float ->
+  end_value:float ->
+  steps:int ->
+  (int32, Nx.int32_elt) Nx.t ->
+  Nx.float32_t
+(** [linear_t] is the tensor mirror of {!linear}: linear interpolation from
+    [init_value] to [end_value] over [steps], clamped to [end_value] after.
+
+    Raises [Invalid_argument] if [steps] is not positive. *)
+
+val cosine_decay_t :
+  init_value:float ->
+  decay_steps:int ->
+  ?alpha:float ->
+  (int32, Nx.int32_elt) Nx.t ->
+  Nx.float32_t
+(** [cosine_decay_t] is the tensor mirror of {!cosine_decay}: cosine decay from
+    [init_value] to [alpha * init_value] over [decay_steps], clamped.
+
+    [alpha] defaults to [0.].
+
+    Raises [Invalid_argument] if [decay_steps] is not positive. *)
+
+val warmup_cosine_t :
+  init_value:float ->
+  peak_value:float ->
+  warmup_steps:int ->
+  (int32, Nx.int32_elt) Nx.t ->
+  Nx.float32_t
+(** [warmup_cosine_t] is the tensor mirror of {!warmup_cosine}: cosine warmup
+    from [init_value] to [peak_value] over [warmup_steps], clamped.
+
+    Raises [Invalid_argument] if [warmup_steps] is not positive. *)
+
+val warmup_cosine_decay_t :
+  init_value:float ->
+  peak_value:float ->
+  warmup_steps:int ->
+  decay_steps:int ->
+  ?end_value:float ->
+  (int32, Nx.int32_elt) Nx.t ->
+  Nx.float32_t
+(** [warmup_cosine_decay_t] is the tensor mirror of {!warmup_cosine_decay}:
+    linear warmup from [init_value] to [peak_value] over [warmup_steps], then
+    cosine decay to [end_value] over [decay_steps].
+
+    [end_value] defaults to [0.].
+
+    Raises [Invalid_argument] if [warmup_steps] or [decay_steps] is not
+    positive. *)
+
+val one_cycle_t :
+  max_value:float ->
+  total_steps:int ->
+  ?div_factor:float ->
+  ?final_div_factor:float ->
+  ?pct_start:float ->
+  (int32, Nx.int32_elt) Nx.t ->
+  Nx.float32_t
+(** [one_cycle_t] is the tensor mirror of {!one_cycle}.
+
+    [div_factor] defaults to [25.0], [final_div_factor] to [10000.0] and
+    [pct_start] to [0.3].
+
+    Raises [Invalid_argument] if [total_steps] is not positive. *)
+
+val piecewise_constant_t :
+  boundaries:int list ->
+  values:float list ->
+  (int32, Nx.int32_elt) Nx.t ->
+  Nx.float32_t
+(** [piecewise_constant_t] is the tensor mirror of {!piecewise_constant}.
+
+    Raises [Invalid_argument] under the same conditions as
+    {!piecewise_constant}. *)

--- a/packages/vega/lib/vega.ml
+++ b/packages/vega/lib/vega.ml
@@ -137,7 +137,7 @@ let scale_by_schedule sched =
       prim_update =
         (fun count _st updates _param ->
           let dt = Nx.dtype updates in
-          let s = sched count in
+          let s = Schedule.eval sched count in
           (Nx.mul updates (scalar dt s), [||]));
     };
   ]
@@ -150,7 +150,7 @@ let scale_by_learning_rate lr =
       prim_update =
         (fun count _st updates _param ->
           let dt = Nx.dtype updates in
-          let s = -.lr count in
+          let s = -.Schedule.eval lr count in
           (Nx.mul updates (scalar dt s), [||]));
     };
   ]
@@ -513,7 +513,7 @@ let add_decayed_weights ?(rate = Schedule.constant 0.01) () =
       prim_update =
         (fun count _st updates param ->
           let dt = Nx.dtype updates in
-          let r = rate count in
+          let r = Schedule.eval rate count in
           (Nx.add updates (Nx.mul param (scalar dt r)), [||]));
     };
   ]
@@ -582,7 +582,7 @@ let add_noise ~eta ?(gamma = 0.55) () =
         (fun count _st updates _param ->
           let dt = Nx.dtype updates in
           let variance =
-            eta count /. Float.pow (1. +. float_of_int count) gamma
+            Schedule.eval eta count /. Float.pow (1. +. float_of_int count) gamma
           in
           let noise =
             Nx.mul (randn dt (Nx.shape updates)) (scalar dt (sqrt variance))
@@ -749,17 +749,17 @@ let clip_by_global_norm (type p) (module P : Nx.Ptree.S with type t = p)
     ~max_norm (grads : P.t) : P.t =
   validate_positive "Vega.clip_by_global_norm" "max_norm" max_norm;
   (* The norm and the scale factor stay in tensor arithmetic — no [Nx.item] — so
-     the transform traces under jit. The accumulation is float64, exactly like
-     [global_norm]. *)
-  let sq = ref (Nx.scalar Nx.float64 0.0) in
+     the transform traces under jit. The accumulation is float32: every device
+     computes it, unlike [global_norm]'s float64 host read. *)
+  let sq = ref (Nx.scalar Nx.float32 0.0) in
   P.iter
-    (fun g -> sq := Nx.add !sq (Nx.sum (Nx.square (Nx.cast Nx.float64 g))))
+    (fun g -> sq := Nx.add !sq (Nx.sum (Nx.square (Nx.cast Nx.float32 g))))
     grads;
   let norm = Nx.sqrt !sq in
   let factor =
     Nx.where
       (Nx.greater_s norm max_norm)
-      (Nx.rdiv_s max_norm norm) (Nx.scalar Nx.float64 1.0)
+      (Nx.rdiv_s max_norm norm) (Nx.scalar Nx.float32 1.0)
   in
   P.map (fun g -> Nx.mul g (Nx.cast (Nx.dtype g) factor)) grads
 
@@ -835,41 +835,24 @@ end
 
 (* Learning rates *)
 
-let lr v = Nx.scalar Nx.float64 v
+let lr v = Nx.scalar Nx.float32 v
 
 (* SGD *)
 
 type 'p sgd_state = { velocity : 'p }
 
-module Sgd_state = struct
-  type 'p t = 'p sgd_state
+module Sgd_state (P : Nx.Ptree.S) = struct
+  type t = P.t sgd_state
 
-  let map (type p) (module P : Nx.Ptree.S with type t = p)
-      (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (st : p t) : p t =
+  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (st : t) : t =
     { velocity = P.map f st.velocity }
 
-  let map2 (type p) (module P : Nx.Ptree.S with type t = p)
-      (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (a : p t)
-      (b : p t) : p t =
+  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (a : t)
+      (b : t) : t =
     { velocity = P.map2 f a.velocity b.velocity }
 
-  let iter (type p) (module P : Nx.Ptree.S with type t = p)
-      (f : 'a 'b. ('a, 'b) Nx.t -> unit) (st : p t) : unit =
+  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) (st : t) : unit =
     P.iter f st.velocity
-
-  module Make (P : Nx.Ptree.S) = struct
-    type t = P.t sgd_state
-
-    let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (st : t) : t =
-      map (module P) f st
-
-    let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t)
-        (a : t) (b : t) : t =
-      map2 (module P) f a b
-
-    let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) (st : t) : unit =
-      iter (module P) f st
-  end
 end
 
 let sgd_init (type p) (module P : Nx.Ptree.S with type t = p) (params : P.t) :
@@ -901,83 +884,42 @@ let sgd_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr
 
 (* Adam and AdamW *)
 
-type 'p adam_state = {
-  mu : 'p;
-  nu : 'p;
-  c1 : Nx.float64_t;
-  c2 : Nx.float64_t;
-  step : Nx.int32_t;
-}
+type 'p adam_state = { mu : 'p; nu : 'p; step : Nx.int32_t }
 
-module Adam_state = struct
-  type 'p t = 'p adam_state
+module Adam_state (P : Nx.Ptree.S) = struct
+  type t = P.t adam_state
 
-  let map (type p) (module P : Nx.Ptree.S with type t = p)
-      (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (st : p t) : p t =
-    {
-      mu = P.map f st.mu;
-      nu = P.map f st.nu;
-      c1 = f st.c1;
-      c2 = f st.c2;
-      step = f st.step;
-    }
+  let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (st : t) : t =
+    { mu = P.map f st.mu; nu = P.map f st.nu; step = f st.step }
 
-  let map2 (type p) (module P : Nx.Ptree.S with type t = p)
-      (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (a : p t)
-      (b : p t) : p t =
+  let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (a : t)
+      (b : t) : t =
     {
       mu = P.map2 f a.mu b.mu;
       nu = P.map2 f a.nu b.nu;
-      c1 = f a.c1 b.c1;
-      c2 = f a.c2 b.c2;
       step = f a.step b.step;
     }
 
-  let iter (type p) (module P : Nx.Ptree.S with type t = p)
-      (f : 'a 'b. ('a, 'b) Nx.t -> unit) (st : p t) : unit =
+  let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) (st : t) : unit =
     P.iter f st.mu;
     P.iter f st.nu;
-    f st.c1;
-    f st.c2;
     f st.step
-
-  module Make (P : Nx.Ptree.S) = struct
-    type t = P.t adam_state
-
-    let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (st : t) : t =
-      map (module P) f st
-
-    let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t)
-        (a : t) (b : t) : t =
-      map2 (module P) f a b
-
-    let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) (st : t) : unit =
-      iter (module P) f st
-  end
 end
 
 let adam_init (type p) (module P : Nx.Ptree.S with type t = p) (params : P.t) :
     P.t adam_state =
   let zeros () = P.map (fun leaf -> Nx.zeros_like leaf) params in
-  {
-    mu = zeros ();
-    nu = zeros ();
-    c1 = Nx.scalar Nx.float64 0.0;
-    c2 = Nx.scalar Nx.float64 0.0;
-    step = Nx.scalar Nx.int32 0l;
-  }
+  { mu = zeros (); nu = zeros (); step = Nx.scalar Nx.int32 0l }
 
 (* Advances the moments and computes the bias-corrected update direction shared
-   by [adam_step] and [adamw_step]. The corrections advance by affine recurrence
-   — [c(k+1) = (1 - b) + b*c(k)], since [1 - b^(k+1)] expands that way — so the
-   step is pure tensor arithmetic: no [pow] on a tensor exponent, no
-   int-to-float casts, and nothing read on the host. Seeded at zero, the first
-   step yields exactly [1 - b]. *)
+   by [adam_step] and [adamw_step]. The bias corrections [1 - b^t] are derived
+   from the counter per leaf, at the leaf's dtype like every other scalar in
+   the step — tensor arithmetic with a constant base, which compiles to [exp2]
+   on every device — so the whole step traces under jit and the state carries
+   nothing the counter does not already determine. *)
 let adam_direction (type p) (module P : Nx.Ptree.S with type t = p) ~b1 ~b2 ~eps
     (st : P.t adam_state) ~(grads : P.t) : P.t * P.t adam_state =
   let step = Nx.add_s st.step 1l in
-  let c1 = Nx.add_s (Nx.mul_s st.c1 b1) (1.0 -. b1) in
-  let c2 = Nx.add_s (Nx.mul_s st.c2 b2) (1.0 -. b2) in
   let mu =
     P.map2
       (fun m g ->
@@ -1003,13 +945,16 @@ let adam_direction (type p) (module P : Nx.Ptree.S with type t = p) ~b1 ~b2 ~eps
       (fun m n ->
         let dt = Nx.dtype m in
         if updates m then
-          let mu_hat = Nx.div m (Nx.cast dt c1) in
-          let nu_hat = Nx.div n (Nx.cast dt c2) in
+          let t = Nx.cast dt step in
+          let c1 = Nx.sub (scalar dt 1.0) (Nx.pow (scalar dt b1) t) in
+          let c2 = Nx.sub (scalar dt 1.0) (Nx.pow (scalar dt b2) t) in
+          let mu_hat = Nx.div m c1 in
+          let nu_hat = Nx.div n c2 in
           Nx.div mu_hat (Nx.add (Nx.sqrt nu_hat) (scalar dt eps))
         else m)
       mu nu
   in
-  (direction, { mu; nu; c1; c2; step })
+  (direction, { mu; nu; step })
 
 let adam_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr ?(b1 = 0.9)
     ?(b2 = 0.999) ?(eps = 1e-8) (st : P.t adam_state) ~(params : P.t)

--- a/packages/vega/lib/vega.ml
+++ b/packages/vega/lib/vega.ml
@@ -14,9 +14,9 @@ let scalar (type a b) (dt : (a, b) Dtype.t) x =
 (* A parameter structure may carry leaves that are not parameters: an RNG key
    threaded through a compiled step, a step counter, a batch of indices. Rune
    does not differentiate them — their slot in the gradient structure holds
-   zeros — and an optimizer must not update them either. Adam's square root
-   over an integer leaf is meaningless, and even plain descent would round its
-   step into the value. Carry them instead. *)
+   zeros — and an optimizer must not update them either. Adam's square root over
+   an integer leaf is meaningless, and even plain descent would round its step
+   into the value. Carry them instead. *)
 let updates (type a b) (p : (a, b) Nx.t) = Dtype.is_float (Nx.dtype p)
 
 let float_of_scalar (type a b) (dt : (a, b) Dtype.t) (v : a) : float =
@@ -730,11 +730,14 @@ let state_of_tensors tx ~count tensors =
 
 (* Structural optimizers over parameter structures (Nx.Ptree.S). Optimizer state
    is itself parameter-shaped: updates are pure map2 compositions, fully typed,
-   with no positional pairing. *)
+   with no positional pairing. Every scalar that changes across steps — the bias
+   corrections, the step counter — is a tensor leaf, so a training step is a
+   pure function of (params, state) that traces under Rune.jit. *)
 
 (* Gradient transformations *)
 
-let global_norm (type p) (module P : Nx.Ptree.S with type t = p) (grads : P.t) : float =
+let global_norm (type p) (module P : Nx.Ptree.S with type t = p) (grads : P.t) :
+    float =
   let acc = ref 0.0 in
   P.iter
     (fun g ->
@@ -742,15 +745,26 @@ let global_norm (type p) (module P : Nx.Ptree.S with type t = p) (grads : P.t) :
     grads;
   Stdlib.sqrt !acc
 
-let clip_by_global_norm (type p) (module P : Nx.Ptree.S with type t = p) ~max_norm (grads : P.t) : P.t =
+let clip_by_global_norm (type p) (module P : Nx.Ptree.S with type t = p)
+    ~max_norm (grads : P.t) : P.t =
   validate_positive "Vega.clip_by_global_norm" "max_norm" max_norm;
-  let norm = global_norm (module P) grads in
-  if norm <= max_norm then grads
-  else
-    let c = max_norm /. norm in
-    P.map (fun g -> Nx.mul g (scalar (Nx.dtype g) c)) grads
+  (* The norm and the scale factor stay in tensor arithmetic — no [Nx.item] — so
+     the transform traces under jit. The accumulation is float64, exactly like
+     [global_norm]. *)
+  let sq = ref (Nx.scalar Nx.float64 0.0) in
+  P.iter
+    (fun g -> sq := Nx.add !sq (Nx.sum (Nx.square (Nx.cast Nx.float64 g))))
+    grads;
+  let norm = Nx.sqrt !sq in
+  let factor =
+    Nx.where
+      (Nx.greater_s norm max_norm)
+      (Nx.rdiv_s max_norm norm) (Nx.scalar Nx.float64 1.0)
+  in
+  P.map (fun g -> Nx.mul g (Nx.cast (Nx.dtype g) factor)) grads
 
-let clip_by_value (type p) (module P : Nx.Ptree.S with type t = p) ~max (grads : P.t) : P.t =
+let clip_by_value (type p) (module P : Nx.Ptree.S with type t = p) ~max
+    (grads : P.t) : P.t =
   validate_positive "Vega.clip_by_value" "max" max;
   P.map
     (fun g ->
@@ -788,10 +802,12 @@ module Loss_scale = struct
 
   let scale t x = Nx.mul x (Nx.cast (Nx.dtype x) t.scale)
 
-  let unscale (type p) (module P : Nx.Ptree.S with type t = p) t (grads : P.t) : P.t =
+  let unscale (type p) (module P : Nx.Ptree.S with type t = p) t (grads : P.t) :
+      P.t =
     P.map (fun g -> Nx.div g (Nx.cast (Nx.dtype g) t.scale)) grads
 
-  let grads_finite (type p) (module P : Nx.Ptree.S with type t = p) (grads : P.t) =
+  let grads_finite (type p) (module P : Nx.Ptree.S with type t = p)
+      (grads : P.t) =
     let acc = ref (Nx.scalar Nx.bool true) in
     P.iter (fun g -> acc := Nx.logical_and !acc (Nx.all (Nx.isfinite g))) grads;
     !acc
@@ -817,15 +833,52 @@ module Loss_scale = struct
     }
 end
 
+(* Learning rates *)
+
+let lr v = Nx.scalar Nx.float64 v
+
 (* SGD *)
 
 type 'p sgd_state = { velocity : 'p }
 
-let sgd_init (type p) (module P : Nx.Ptree.S with type t = p) (params : P.t) : P.t sgd_state =
+module Sgd_state = struct
+  type 'p t = 'p sgd_state
+
+  let map (type p) (module P : Nx.Ptree.S with type t = p)
+      (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (st : p t) : p t =
+    { velocity = P.map f st.velocity }
+
+  let map2 (type p) (module P : Nx.Ptree.S with type t = p)
+      (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (a : p t)
+      (b : p t) : p t =
+    { velocity = P.map2 f a.velocity b.velocity }
+
+  let iter (type p) (module P : Nx.Ptree.S with type t = p)
+      (f : 'a 'b. ('a, 'b) Nx.t -> unit) (st : p t) : unit =
+    P.iter f st.velocity
+
+  module Make (P : Nx.Ptree.S) = struct
+    type t = P.t sgd_state
+
+    let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (st : t) : t =
+      map (module P) f st
+
+    let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t)
+        (a : t) (b : t) : t =
+      map2 (module P) f a b
+
+    let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) (st : t) : unit =
+      iter (module P) f st
+  end
+end
+
+let sgd_init (type p) (module P : Nx.Ptree.S with type t = p) (params : P.t) :
+    P.t sgd_state =
   { velocity = P.map (fun leaf -> Nx.zeros_like leaf) params }
 
-let sgd_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr ?(momentum = 0.0) (st : P.t sgd_state)
-    ~(params : P.t) ~(grads : P.t) : P.t * P.t sgd_state =
+let sgd_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr
+    ?(momentum = 0.0) (st : P.t sgd_state) ~(params : P.t) ~(grads : P.t) :
+    P.t * P.t sgd_state =
   let velocity =
     (* Plain gradient descent: the velocity is exactly the gradient. Skipping
        the [momentum * v + g] arithmetic avoids touching (and, under [jit],
@@ -841,24 +894,90 @@ let sgd_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr ?(momentum = 0
   let params =
     P.map2
       (fun p v ->
-        if updates p then Nx.sub p (Nx.mul v (scalar (Nx.dtype v) lr)) else p)
+        if updates p then Nx.sub p (Nx.mul v (Nx.cast (Nx.dtype p) lr)) else p)
       params velocity
   in
   (params, { velocity })
 
 (* Adam and AdamW *)
 
-type 'p adam_state = { mu : 'p; nu : 'p; step : int }
+type 'p adam_state = {
+  mu : 'p;
+  nu : 'p;
+  c1 : Nx.float64_t;
+  c2 : Nx.float64_t;
+  step : Nx.int32_t;
+}
 
-let adam_init (type p) (module P : Nx.Ptree.S with type t = p) (params : P.t) : P.t adam_state =
+module Adam_state = struct
+  type 'p t = 'p adam_state
+
+  let map (type p) (module P : Nx.Ptree.S with type t = p)
+      (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (st : p t) : p t =
+    {
+      mu = P.map f st.mu;
+      nu = P.map f st.nu;
+      c1 = f st.c1;
+      c2 = f st.c2;
+      step = f st.step;
+    }
+
+  let map2 (type p) (module P : Nx.Ptree.S with type t = p)
+      (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (a : p t)
+      (b : p t) : p t =
+    {
+      mu = P.map2 f a.mu b.mu;
+      nu = P.map2 f a.nu b.nu;
+      c1 = f a.c1 b.c1;
+      c2 = f a.c2 b.c2;
+      step = f a.step b.step;
+    }
+
+  let iter (type p) (module P : Nx.Ptree.S with type t = p)
+      (f : 'a 'b. ('a, 'b) Nx.t -> unit) (st : p t) : unit =
+    P.iter f st.mu;
+    P.iter f st.nu;
+    f st.c1;
+    f st.c2;
+    f st.step
+
+  module Make (P : Nx.Ptree.S) = struct
+    type t = P.t adam_state
+
+    let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (st : t) : t =
+      map (module P) f st
+
+    let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t)
+        (a : t) (b : t) : t =
+      map2 (module P) f a b
+
+    let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) (st : t) : unit =
+      iter (module P) f st
+  end
+end
+
+let adam_init (type p) (module P : Nx.Ptree.S with type t = p) (params : P.t) :
+    P.t adam_state =
   let zeros () = P.map (fun leaf -> Nx.zeros_like leaf) params in
-  { mu = zeros (); nu = zeros (); step = 0 }
+  {
+    mu = zeros ();
+    nu = zeros ();
+    c1 = Nx.scalar Nx.float64 0.0;
+    c2 = Nx.scalar Nx.float64 0.0;
+    step = Nx.scalar Nx.int32 0l;
+  }
 
 (* Advances the moments and computes the bias-corrected update direction shared
-   by [adam_step] and [adamw_step]. *)
-let adam_direction (type p) (module P : Nx.Ptree.S with type t = p) ~b1 ~b2 ~eps (st : P.t adam_state)
-    ~(grads : P.t) : P.t * P.t adam_state =
-  let step = st.step + 1 in
+   by [adam_step] and [adamw_step]. The corrections advance by affine recurrence
+   — [c(k+1) = (1 - b) + b*c(k)], since [1 - b^(k+1)] expands that way — so the
+   step is pure tensor arithmetic: no [pow] on a tensor exponent, no
+   int-to-float casts, and nothing read on the host. Seeded at zero, the first
+   step yields exactly [1 - b]. *)
+let adam_direction (type p) (module P : Nx.Ptree.S with type t = p) ~b1 ~b2 ~eps
+    (st : P.t adam_state) ~(grads : P.t) : P.t * P.t adam_state =
+  let step = Nx.add_s st.step 1l in
+  let c1 = Nx.add_s (Nx.mul_s st.c1 b1) (1.0 -. b1) in
+  let c2 = Nx.add_s (Nx.mul_s st.c2 b2) (1.0 -. b2) in
   let mu =
     P.map2
       (fun m g ->
@@ -879,39 +998,38 @@ let adam_direction (type p) (module P : Nx.Ptree.S with type t = p) ~b1 ~b2 ~eps
         else n)
       st.nu grads
   in
-  let c1 = 1.0 -. (b1 ** float_of_int step) in
-  let c2 = 1.0 -. (b2 ** float_of_int step) in
   let direction =
     P.map2
       (fun m n ->
         let dt = Nx.dtype m in
         if updates m then
-          let mu_hat = Nx.div m (scalar dt c1) in
-          let nu_hat = Nx.div n (scalar dt c2) in
+          let mu_hat = Nx.div m (Nx.cast dt c1) in
+          let nu_hat = Nx.div n (Nx.cast dt c2) in
           Nx.div mu_hat (Nx.add (Nx.sqrt nu_hat) (scalar dt eps))
         else m)
       mu nu
   in
-  (direction, { mu; nu; step })
+  (direction, { mu; nu; c1; c2; step })
 
-let adam_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr ?(b1 = 0.9) ?(b2 = 0.999)
-    ?(eps = 1e-8) (st : P.t adam_state) ~(params : P.t) ~(grads : P.t) :
-    P.t * P.t adam_state =
+let adam_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr ?(b1 = 0.9)
+    ?(b2 = 0.999) ?(eps = 1e-8) (st : P.t adam_state) ~(params : P.t)
+    ~(grads : P.t) : P.t * P.t adam_state =
   let direction, st = adam_direction (module P) ~b1 ~b2 ~eps st ~grads in
   let params =
     P.map2
       (fun p d ->
-        if updates p then Nx.sub p (Nx.mul d (scalar (Nx.dtype p) lr)) else p)
+        if updates p then Nx.sub p (Nx.mul d (Nx.cast (Nx.dtype p) lr)) else p)
       params direction
   in
   (params, st)
 
-let adamw_init (type p) (module P : Nx.Ptree.S with type t = p) (params : P.t) : P.t adam_state =
+let adamw_init (type p) (module P : Nx.Ptree.S with type t = p) (params : P.t) :
+    P.t adam_state =
   adam_init (module P) params
 
-let adamw_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr ?(b1 = 0.9) ?(b2 = 0.999)
-    ?(eps = 1e-8) ?(weight_decay = 0.01) (st : P.t adam_state) ~(params : P.t)
-    ~(grads : P.t) : P.t * P.t adam_state =
+let adamw_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr ?(b1 = 0.9)
+    ?(b2 = 0.999) ?(eps = 1e-8) ?(weight_decay = 0.01) (st : P.t adam_state)
+    ~(params : P.t) ~(grads : P.t) : P.t * P.t adam_state =
   let direction, st = adam_direction (module P) ~b1 ~b2 ~eps st ~grads in
   let params =
     P.map2
@@ -919,7 +1037,7 @@ let adamw_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr ?(b1 = 0.9) 
         let dt = Nx.dtype p in
         if updates p then
           let decayed = Nx.add d (Nx.mul p (scalar dt weight_decay)) in
-          Nx.sub p (Nx.mul decayed (scalar dt lr))
+          Nx.sub p (Nx.mul decayed (Nx.cast dt lr))
         else p)
       params direction
   in

--- a/packages/vega/lib/vega.ml
+++ b/packages/vega/lib/vega.ml
@@ -117,6 +117,19 @@ let step st ~grad ~param =
 
 (* Scaling transforms *)
 
+(* A chain evaluates its schedule once per parameter per update, and the count
+   only moves once per step: remembering the last evaluation turns N tensor
+   evaluations per step into one. *)
+let memo_eval sched =
+  let last = ref (-1, 0.0) in
+  fun count ->
+    let c, v = !last in
+    if c = count then v
+    else
+      let v = Schedule.eval sched count in
+      last := (count, v);
+      v
+
 let scale s =
   [
     {
@@ -130,6 +143,7 @@ let scale s =
   ]
 
 let scale_by_schedule sched =
+  let sched = memo_eval sched in
   [
     {
       n_tensors = 0;
@@ -137,12 +151,13 @@ let scale_by_schedule sched =
       prim_update =
         (fun count _st updates _param ->
           let dt = Nx.dtype updates in
-          let s = Schedule.eval sched count in
+          let s = sched count in
           (Nx.mul updates (scalar dt s), [||]));
     };
   ]
 
 let scale_by_learning_rate lr =
+  let lr = memo_eval lr in
   [
     {
       n_tensors = 0;
@@ -150,7 +165,7 @@ let scale_by_learning_rate lr =
       prim_update =
         (fun count _st updates _param ->
           let dt = Nx.dtype updates in
-          let s = -.Schedule.eval lr count in
+          let s = -.lr count in
           (Nx.mul updates (scalar dt s), [||]));
     };
   ]
@@ -506,6 +521,7 @@ let trace ?(decay = 0.9) ?(nesterov = false) () =
 (* Regularization transforms *)
 
 let add_decayed_weights ?(rate = Schedule.constant 0.01) () =
+  let rate = memo_eval rate in
   [
     {
       n_tensors = 0;
@@ -513,7 +529,7 @@ let add_decayed_weights ?(rate = Schedule.constant 0.01) () =
       prim_update =
         (fun count _st updates param ->
           let dt = Nx.dtype updates in
-          let r = Schedule.eval rate count in
+          let r = rate count in
           (Nx.add updates (Nx.mul param (scalar dt r)), [||]));
     };
   ]
@@ -574,6 +590,7 @@ let centralize =
   ]
 
 let add_noise ~eta ?(gamma = 0.55) () =
+  let eta = memo_eval eta in
   [
     {
       n_tensors = 0;
@@ -582,7 +599,7 @@ let add_noise ~eta ?(gamma = 0.55) () =
         (fun count _st updates _param ->
           let dt = Nx.dtype updates in
           let variance =
-            Schedule.eval eta count /. Float.pow (1. +. float_of_int count) gamma
+            eta count /. Float.pow (1. +. float_of_int count) gamma
           in
           let noise =
             Nx.mul (randn dt (Nx.shape updates)) (scalar dt (sqrt variance))
@@ -839,25 +856,29 @@ let lr v = Nx.scalar Nx.float32 v
 
 (* SGD *)
 
-type 'p sgd_state = { velocity : 'p }
+type 'p sgd_state = { velocity : 'p; step : Nx.int32_t }
 
 module Sgd_state (P : Nx.Ptree.S) = struct
   type t = P.t sgd_state
 
   let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (st : t) : t =
-    { velocity = P.map f st.velocity }
+    { velocity = P.map f st.velocity; step = f st.step }
 
   let map2 (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) (a : t)
       (b : t) : t =
-    { velocity = P.map2 f a.velocity b.velocity }
+    { velocity = P.map2 f a.velocity b.velocity; step = f a.step b.step }
 
   let iter (f : 'a 'b. ('a, 'b) Nx.t -> unit) (st : t) : unit =
-    P.iter f st.velocity
+    P.iter f st.velocity;
+    f st.step
 end
 
 let sgd_init (type p) (module P : Nx.Ptree.S with type t = p) (params : P.t) :
     P.t sgd_state =
-  { velocity = P.map (fun leaf -> Nx.zeros_like leaf) params }
+  {
+    velocity = P.map (fun leaf -> Nx.zeros_like leaf) params;
+    step = Nx.scalar Nx.int32 0l;
+  }
 
 let sgd_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr
     ?(momentum = 0.0) (st : P.t sgd_state) ~(params : P.t) ~(grads : P.t) :
@@ -865,7 +886,7 @@ let sgd_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr
   let velocity =
     (* Plain gradient descent: the velocity is exactly the gradient. Skipping
        the [momentum * v + g] arithmetic avoids touching (and, under [jit],
-       capturing) the state tensors at all. *)
+       capturing) the velocity tensors at all. *)
     if momentum = 0.0 then grads
     else
       P.map2
@@ -880,7 +901,7 @@ let sgd_step (type p) (module P : Nx.Ptree.S with type t = p) ~lr
         if updates p then Nx.sub p (Nx.mul v (Nx.cast (Nx.dtype p) lr)) else p)
       params velocity
   in
-  (params, { velocity })
+  (params, { velocity; step = Nx.add_s st.step 1l })
 
 (* Adam and AdamW *)
 

--- a/packages/vega/lib/vega.mli
+++ b/packages/vega/lib/vega.mli
@@ -16,35 +16,64 @@
     checkpointing an optimizer means saving a record of parameter-shaped values.
 
     There is no optimizer object; composition is function application. Transform
-    gradients before the step (for example {!clip_by_global_norm}) and evaluate
-    a {!Schedule.t} at the loop's step counter for that step's learning rate:
+    gradients before the step (for example {!clip_by_global_norm}) and derive
+    the step's learning rate from the state's step counter with a tensor
+    schedule ({!Schedule}). Because optimizer state is itself a parameter tree
+    ({!Adam_state}, {!Sgd_state}), a whole training step — forward, backward and
+    update — is an ordinary function of [(params, state)] that threads both
+    through one {!Rune.val-jit} call, so the step compiles into a single program
+    on any device and the state rides it as ordinary input and output leaves:
 
     {[
-      let sched =
-        Vega.Schedule.cosine_decay ~init_value:1e-3 ~decay_steps:1000 ()
+    module Opt = Vega.Adam_state.Make (Model)
+
+    type step_in = {
+      params : Model.t;
+      opt : Opt.t; (* [\[@ptree.using Opt\]] with ppx_ptree *)
+      inputs : Nx.float32_t;
+      targets : (int32, Nx.int32_elt) Nx.t;
+    }
+
+    (* step_out carries [params], [opt] and the loss; both records derive
+       [map]/[map2]/[iter] by hand or with [ppx_ptree]. *)
+
+    let train_step { params; opt; inputs; targets } =
+      let loss, grads =
+        Rune.value_and_grad model (objective inputs targets) params
       in
-      let step k (params, st) =
-        let loss, grads = value_and_grad (module Model) f params in
-        let grads =
-          Vega.clip_by_global_norm (module Model) ~max_norm:1.0 grads
-        in
-        let params, st =
-          Vega.adamw_step (module Model) ~lr:(sched k) st ~params ~grads
-        in
-        ((params, st), loss)
+      let grads = Vega.clip_by_global_norm model ~max_norm:1.0 grads in
+      let lr =
+        Vega.Schedule.cosine_decay_t ~init_value:1e-3 ~decay_steps:1000 opt.step
+      in
+      let params, opt = Vega.adamw_step model ~lr opt ~params ~grads in
+      { Step_out.params; opt; loss }
+
+    (* ~donate:true hands the previous generation's device buffers back to the
+       allocator once the call completes; the loop never reads the pre-step
+       state, so they are safe to release. *)
+    let step =
+      Rune.jit2 ~donate:true (module Step_in) (module Step_out) train_step
     ]}
 
-    Below the structural tier, the {{!section:chains}per-tensor tier} composes
-    Optax-style gradient transformations on single tensors via {!chain}. Use it
-    to build custom update rules from primitives, or from frameworks that manage
-    each parameter tensor separately.
+    Hyperparameters that do not change across steps ([b1], [b2], [eps],
+    [weight_decay], [max_norm]) are compile-time constants. Everything that does
+    — the moments, the bias corrections, the step counter, the learning rate —
+    is a tensor leaf, so the compiled program replays correctly on every call:
+    no data transfers, no retracing. [~donate:true] keeps the state-to-state
+    loop at about two generations of device buffers instead of one per call
+    awaiting collection; it consumes the handles it frees — reading the pre-step
+    state after the call raises — so leave it off while a loop still inspects
+    the state it feeds in. On the CPU device it changes nothing: outputs are
+    host tensors there. Steps are pure traversals — a step consumes a state and
+    returns the next one — so checkpointing an optimizer means saving a record
+    of parameter-shaped values plus three scalar leaves.
 
     {b Non-parameter leaves.} A structure may carry leaves that are not
     parameters — an {!Nx.Rng.key} threaded through a compiled step, a counter, a
     batch of indices. {!Rune.val-grad} does not differentiate them, and the
-    structural optimizers here do not update them: every step passes a
-    non-float leaf through unchanged. So one structure can serve the objective,
-    the gradient and the update without splitting the values that must reach a
+    structural optimizers here do not update them: every step passes a non-float
+    leaf through unchanged. So one structure can serve the objective, the
+    gradient and the update without splitting the values that must reach a
     compiled step from the values being trained. *)
 
 (** {1:schedules Learning-Rate Schedules}
@@ -73,9 +102,15 @@ val clip_by_global_norm :
     (including all-zero gradients) are returned unchanged; larger ones are
     scaled by [max_norm /. norm], preserving their direction.
 
+    The scale factor is computed in tensor arithmetic and selected with
+    {!Nx.where} — no host read — so the transform traces under {!Rune.val-jit}
+    and can sit between a jitted backward pass and a jitted optimizer step.
+    {!global_norm} remains the host-float read for reporting.
+
     Raises [Invalid_argument] if [max_norm <= 0.]. *)
 
-val clip_by_value : (module Nx.Ptree.S with type t = 'p) -> max:float -> 'p -> 'p
+val clip_by_value :
+  (module Nx.Ptree.S with type t = 'p) -> max:float -> 'p -> 'p
 (** [clip_by_value (module P) ~max grads] clips every gradient element to the
     interval \[[-. max];[max]\].
 
@@ -138,7 +173,8 @@ module Loss_scale : sig
       scale, at the leaf's dtype. Apply it to the gradients before any gradient
       transformation or optimizer step. *)
 
-  val grads_finite : (module Nx.Ptree.S with type t = 'p) -> 'p -> (bool, Nx.bool_elt) Nx.t
+  val grads_finite :
+    (module Nx.Ptree.S with type t = 'p) -> 'p -> (bool, Nx.bool_elt) Nx.t
   (** [grads_finite (module P) grads] is a scalar boolean tensor: [true] iff
       every element of every leaf of [grads] is finite (no NaN or infinity).
       Feed it to {!adjust} and use it to skip the parameter update of an
@@ -182,11 +218,74 @@ module Loss_scale : sig
   (** [iter f ls] applies [f] to both state tensors. *)
 end
 
+(** {1:lr Learning Rates}
+
+    A structural step applies its learning rate as a scalar tensor, cast to each
+    leaf's dtype. A constant rate is one call to {!lr}; a scheduled one is
+    derived from the state's step counter inside the step with a tensor schedule
+    ({!Schedule}), which is what makes schedules work under {!Rune.val-jit}. *)
+
+val lr : float -> Nx.float64_t
+(** [lr v] is the learning rate [v] as a scalar tensor, the form the step
+    functions' [~lr] argument takes. The value is cast to each leaf's dtype when
+    the step applies it, so one value serves any parameter dtype: [Vega.lr 1e-3]
+    is exactly [Nx.scalar Nx.float64 1e-3]. *)
+
 (** {1:sgd Stochastic Gradient Descent} *)
 
 type 'p sgd_state = { velocity : 'p }
 (** The state for {!sgd_step}: the momentum velocity, with the shape of the
     parameters. *)
+
+(** The state for {!sgd_step}, over a parameter structure ['p]. Optimizer state
+    is a parameter tree like the parameters themselves — it satisfies
+    {!Nx.Ptree.S} through {!Make}, in the fixed leaf order of the [velocity]
+    payload — so it can be a field of a {!Rune.val-jit}ed step's input and
+    output records and thread across compiled calls. *)
+module Sgd_state : sig
+  type 'p t = 'p sgd_state
+  (** The state type. *)
+
+  val map :
+    (module Nx.Ptree.S with type t = 'p) ->
+    ('a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) ->
+    'p t ->
+    'p t
+  (** [map (module P) f st] is [st] with [f] applied to every tensor leaf. *)
+
+  val map2 :
+    (module Nx.Ptree.S with type t = 'p) ->
+    ('a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) ->
+    'p t ->
+    'p t ->
+    'p t
+  (** [map2 (module P) f a b] combines [a] and [b] leafwise with [f].
+
+      Raises [Invalid_argument] if [a] and [b] are not structurally equal. *)
+
+  val iter :
+    (module Nx.Ptree.S with type t = 'p) ->
+    ('a 'b. ('a, 'b) Nx.t -> unit) ->
+    'p t ->
+    unit
+  (** [iter (module P) f st] applies [f] to every tensor leaf, in the state's
+      traversal order. *)
+
+  (** [Make (P)] is the state over the parameter tree [P] as a parameter tree
+      itself: its [t] is [P.t sgd_state] and its traversals walk the state's
+      leaves through [P]. Bind it once per model and embed it in a jitted step's
+      input/output records — directly, or via [ppx_ptree]'s [[@ptree.using]]
+      delegation:
+
+      {[
+        module Opt = Vega.Sgd_state.Make (Model)
+        type step_in = { params : Model.t; opt : Opt.t [\[@ptree.using Opt\]] }
+      ]}
+
+      The resulting leaf order — every leaf of [velocity], in [P]'s order — is
+      part of a compiled step's leaf signature and is fixed for good. *)
+  module Make (P : Nx.Ptree.S) : Nx.Ptree.S with type t = P.t sgd_state
+end
 
 val sgd_init : (module Nx.Ptree.S with type t = 'p) -> 'p -> 'p sgd_state
 (** [sgd_init (module P) params] is the initial state for optimizing [params]:
@@ -194,7 +293,7 @@ val sgd_init : (module Nx.Ptree.S with type t = 'p) -> 'p -> 'p sgd_state
 
 val sgd_step :
   (module Nx.Ptree.S with type t = 'p) ->
-  lr:float ->
+  lr:(float, 'b) Nx.t ->
   ?momentum:float ->
   'p sgd_state ->
   params:'p ->
@@ -208,24 +307,82 @@ val sgd_step :
     p' = p - lr * v'
     v}
 
-    [momentum] defaults to [0.], plain gradient descent: the velocity is then
-    the last gradient. *)
+    [lr] is a scalar tensor ({!lr}); [momentum] defaults to [0.], plain gradient
+    descent: the velocity is then the last gradient, and the input state is not
+    read at all. The whole step is tensor arithmetic over [(params, st)] — it
+    traces under {!Rune.val-jit}. *)
 
 (** {1:adam Adam and AdamW} *)
 
-type 'p adam_state = { mu : 'p; nu : 'p; step : int }
-(** The state for {!adam_step} and {!adamw_step}. [mu] and [nu] are the
-    exponential moving averages of gradients and of squared gradients (biased;
-    steps apply the correction when computing the update), each with the
-    parameters' shape. [step] is the number of completed steps. *)
+type 'p adam_state = {
+  mu : 'p;
+      (** Exponential moving average of gradients (biased; the correction
+          applies when computing the update), with the parameters' shape. *)
+  nu : 'p;
+      (** Exponential moving average of squared gradients, with the parameters'
+          shape. *)
+  c1 : Nx.float64_t;
+      (** Bias correction for [mu]: [1 - b1^step], a scalar tensor advanced by
+          an affine recurrence each step. *)
+  c2 : Nx.float64_t;
+      (** Bias correction for [nu]: [1 - b2^step], a scalar tensor. *)
+  step : Nx.int32_t;
+      (** Completed steps, a scalar tensor; also the counter tensor schedules
+          take. *)
+}
+
+(** The state for {!adam_step} and {!adamw_step}, over a parameter structure
+    ['p]. Like {!Sgd_state}, it is a parameter tree through {!Make} — the fixed
+    leaf order is [mu]'s leaves, then [nu]'s, then the three scalars [c1], [c2],
+    [step] — so it threads through compiled training steps. The bias corrections
+    and the counter are tensors, not host values: under {!Rune.val-jit} a host
+    [int] would be burned into the trace as a constant and replayed stale,
+    silently corrupting the corrections on every later call. *)
+module Adam_state : sig
+  type 'p t = 'p adam_state
+  (** The state type. *)
+
+  val map :
+    (module Nx.Ptree.S with type t = 'p) ->
+    ('a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) ->
+    'p t ->
+    'p t
+  (** [map (module P) f st] is [st] with [f] applied to every tensor leaf — the
+      leaves of [mu] and [nu] through the parameter tree, then the scalar leaves
+      [c1], [c2], [step]. *)
+
+  val map2 :
+    (module Nx.Ptree.S with type t = 'p) ->
+    ('a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) ->
+    'p t ->
+    'p t ->
+    'p t
+  (** [map2 (module P) f a b] combines [a] and [b] leafwise with [f].
+
+      Raises [Invalid_argument] if [a] and [b] are not structurally equal. *)
+
+  val iter :
+    (module Nx.Ptree.S with type t = 'p) ->
+    ('a 'b. ('a, 'b) Nx.t -> unit) ->
+    'p t ->
+    unit
+  (** [iter (module P) f st] applies [f] to every tensor leaf, in the state's
+      traversal order. *)
+
+  (** [Make (P)] is the state over the parameter tree [P] as a parameter tree
+      itself — see {!Sgd_state.Make}. The leaf order — every leaf of [mu] in
+      [P]'s order, every leaf of [nu], then [c1], [c2], [step] — is part of a
+      compiled step's leaf signature and is fixed for good. *)
+  module Make (P : Nx.Ptree.S) : Nx.Ptree.S with type t = P.t adam_state
+end
 
 val adam_init : (module Nx.Ptree.S with type t = 'p) -> 'p -> 'p adam_state
 (** [adam_init (module P) params] is the initial state for optimizing [params]:
-    all-zero moments and [step = 0]. *)
+    all-zero moments, zero bias corrections and [step = 0]. *)
 
 val adam_step :
   (module Nx.Ptree.S with type t = 'p) ->
-  lr:float ->
+  lr:(float, 'b) Nx.t ->
   ?b1:float ->
   ?b2:float ->
   ?eps:float ->
@@ -234,23 +391,27 @@ val adam_step :
   grads:'p ->
   'p * 'p adam_state
 (** [adam_step (module P) ~lr st ~params ~grads] is [(params', st')] after one
-    Adam step (Kingma and Ba, 2015). Per element, with [t = st.step + 1]:
+    Adam step (Kingma and Ba, 2015). Per element, with [t = st.step + 1] and the
+    corrections advanced in state:
 
     {v
-    mu' = b1 * mu + (1 - b1) * g
-    nu' = b2 * nu + (1 - b2) * g^2
-    d   = (mu' / (1 - b1^t)) / (sqrt (nu' / (1 - b2^t)) + eps)
+    c1' = (1 - b1) + b1 * c1        c2' = (1 - b2) + b2 * c2
+    mu' = b1 * mu + (1 - b1) * g    nu' = b2 * nu + (1 - b2) * g^2
+    d   = (mu' / c1') / (sqrt (nu' / c2') + eps)
     p'  = p - lr * d
     v}
 
-    [b1] defaults to [0.9], [b2] to [0.999], [eps] to [1e-8]. *)
+    [lr] is a scalar tensor ({!lr}). [b1] defaults to [0.9], [b2] to [0.999],
+    [eps] to [1e-8]; they are compile-time constants, safe captures under
+    {!Rune.val-jit}. The whole step is tensor arithmetic over [(params, st)] —
+    it traces, and the returned state feeds the next call. *)
 
 val adamw_init : (module Nx.Ptree.S with type t = 'p) -> 'p -> 'p adam_state
 (** [adamw_init] is {!adam_init}: AdamW shares Adam's state. *)
 
 val adamw_step :
   (module Nx.Ptree.S with type t = 'p) ->
-  lr:float ->
+  lr:(float, 'b) Nx.t ->
   ?b1:float ->
   ?b2:float ->
   ?eps:float ->

--- a/packages/vega/lib/vega.mli
+++ b/packages/vega/lib/vega.mli
@@ -17,35 +17,39 @@
 
     There is no optimizer object; composition is function application. Transform
     gradients before the step (for example {!clip_by_global_norm}) and derive
-    the step's learning rate from the state's step counter with a tensor
-    schedule ({!Schedule}). Because optimizer state is itself a parameter tree
+    the step's learning rate from the state's step counter with a schedule
+    ({!Schedule}). Because optimizer state is itself a parameter tree
     ({!Adam_state}, {!Sgd_state}), a whole training step — forward, backward and
     update — is an ordinary function of [(params, state)] that threads both
     through one {!Rune.val-jit} call, so the step compiles into a single program
     on any device and the state rides it as ordinary input and output leaves:
 
     {[
-    module Opt = Vega.Adam_state.Make (Model)
+    module Opt = Vega.Adam_state (Model)
 
-    type step_in = {
-      params : Model.t;
-      opt : Opt.t; (* [\[@ptree.using Opt\]] with ppx_ptree *)
-      inputs : Nx.float32_t;
-      targets : (int32, Nx.int32_elt) Nx.t;
-    }
+    module Step_in = struct
+      type t = {
+        params : Model.t;
+        opt : Opt.t;
+        inputs : Nx.float32_t;
+        targets : (int32, Nx.int32_elt) Nx.t;
+      }
 
-    (* step_out carries [params], [opt] and the loss; both records derive
-       [map]/[map2]/[iter] by hand or with [ppx_ptree]. *)
+      (* map/map2/iter: one-line delegations to [Model] and [Opt] over the
+         fields — or [@@deriving ptree] with ppx_ptree. [Step_out] carries
+         [params], [opt] and the loss the same way. *)
+    end
 
-    let train_step { params; opt; inputs; targets } =
+    let sched = Vega.Schedule.cosine_decay ~init_value:1e-3 ~decay_steps:1000 ()
+
+    let train_step { Step_in.params; opt; inputs; targets } =
       let loss, grads =
         Rune.value_and_grad model (objective inputs targets) params
       in
       let grads = Vega.clip_by_global_norm model ~max_norm:1.0 grads in
-      let lr =
-        Vega.Schedule.cosine_decay_t ~init_value:1e-3 ~decay_steps:1000 opt.step
+      let params, opt =
+        Vega.adamw_step model ~lr:(sched opt.step) opt ~params ~grads
       in
-      let params, opt = Vega.adamw_step model ~lr opt ~params ~grads in
       { Step_out.params; opt; loss }
 
     (* ~donate:true hands the previous generation's device buffers back to the
@@ -57,8 +61,8 @@
 
     Hyperparameters that do not change across steps ([b1], [b2], [eps],
     [weight_decay], [max_norm]) are compile-time constants. Everything that does
-    — the moments, the bias corrections, the step counter, the learning rate —
-    is a tensor leaf, so the compiled program replays correctly on every call:
+    — the moments, the step counter, the learning rate — is a tensor leaf or
+    derived from one, so the compiled program replays correctly on every call:
     no data transfers, no retracing. [~donate:true] keeps the state-to-state
     loop at about two generations of device buffers instead of one per call
     awaiting collection; it consumes the handles it frees — reading the pre-step
@@ -66,7 +70,7 @@
     the state it feeds in. On the CPU device it changes nothing: outputs are
     host tensors there. Steps are pure traversals — a step consumes a state and
     returns the next one — so checkpointing an optimizer means saving a record
-    of parameter-shaped values plus three scalar leaves.
+    of parameter-shaped values plus a step counter leaf.
 
     {b Non-parameter leaves.} A structure may carry leaves that are not
     parameters — an {!Nx.Rng.key} threaded through a compiled step, a counter, a
@@ -79,10 +83,12 @@
 (** {1:schedules Learning-Rate Schedules}
 
     A schedule maps a step counter to a learning rate; it is a plain function
-    [int -> float], shared by both tiers. Structural training loops evaluate a
-    schedule at the loop's step counter and pass the result as [~lr]; the
-    per-tensor {!scale_by_learning_rate} and {!scale_by_schedule} consume a
-    schedule value directly. *)
+    from a scalar [int32] step tensor to a scalar [float32] rate tensor, shared
+    by both tiers. Structural training loops apply a schedule to the state's
+    step counter and pass the result as [~lr] — tensor arithmetic, so the same
+    code runs eagerly and inside a compiled step; the per-tensor
+    {!scale_by_learning_rate} and {!scale_by_schedule} evaluate a schedule at
+    the chain's own update count. *)
 
 module Schedule = Schedule
 
@@ -102,10 +108,11 @@ val clip_by_global_norm :
     (including all-zero gradients) are returned unchanged; larger ones are
     scaled by [max_norm /. norm], preserving their direction.
 
-    The scale factor is computed in tensor arithmetic and selected with
+    The scale factor is computed in float32 tensor arithmetic and selected with
     {!Nx.where} — no host read — so the transform traces under {!Rune.val-jit}
-    and can sit between a jitted backward pass and a jitted optimizer step.
-    {!global_norm} remains the host-float read for reporting.
+    on any device and can sit between a jitted backward pass and a jitted
+    optimizer step. {!global_norm} remains the float64 host read for
+    reporting.
 
     Raises [Invalid_argument] if [max_norm <= 0.]. *)
 
@@ -221,15 +228,15 @@ end
 (** {1:lr Learning Rates}
 
     A structural step applies its learning rate as a scalar tensor, cast to each
-    leaf's dtype. A constant rate is one call to {!lr}; a scheduled one is
-    derived from the state's step counter inside the step with a tensor schedule
-    ({!Schedule}), which is what makes schedules work under {!Rune.val-jit}. *)
+    leaf's dtype. A constant rate is one call to {!lr}; a scheduled one is a
+    {!Schedule} applied to the state's step counter — tensor arithmetic either
+    way, which is what makes the rate track correctly under {!Rune.val-jit}. *)
 
-val lr : float -> Nx.float64_t
+val lr : float -> Nx.float32_t
 (** [lr v] is the learning rate [v] as a scalar tensor, the form the step
     functions' [~lr] argument takes. The value is cast to each leaf's dtype when
     the step applies it, so one value serves any parameter dtype: [Vega.lr 1e-3]
-    is exactly [Nx.scalar Nx.float64 1e-3]. *)
+    is exactly [Nx.scalar Nx.float32 1e-3]. *)
 
 (** {1:sgd Stochastic Gradient Descent} *)
 
@@ -237,55 +244,28 @@ type 'p sgd_state = { velocity : 'p }
 (** The state for {!sgd_step}: the momentum velocity, with the shape of the
     parameters. *)
 
-(** The state for {!sgd_step}, over a parameter structure ['p]. Optimizer state
-    is a parameter tree like the parameters themselves — it satisfies
-    {!Nx.Ptree.S} through {!Make}, in the fixed leaf order of the [velocity]
-    payload — so it can be a field of a {!Rune.val-jit}ed step's input and
-    output records and thread across compiled calls. *)
-module Sgd_state : sig
-  type 'p t = 'p sgd_state
-  (** The state type. *)
+(** [Sgd_state (P)] is the state over the parameter tree [P] as a parameter
+    tree itself: its [t] is [P.t sgd_state] and its traversals walk the state's
+    leaves through [P]. Bind it once per model and embed it in a jitted step's
+    input/output records, whose traversals delegate to it field by field
+    (by hand, or with [ppx_ptree]'s [@@deriving ptree]):
 
-  val map :
-    (module Nx.Ptree.S with type t = 'p) ->
-    ('a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) ->
-    'p t ->
-    'p t
-  (** [map (module P) f st] is [st] with [f] applied to every tensor leaf. *)
+    {[
+      module Opt = Vega.Sgd_state (Model)
 
-  val map2 :
-    (module Nx.Ptree.S with type t = 'p) ->
-    ('a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) ->
-    'p t ->
-    'p t ->
-    'p t
-  (** [map2 (module P) f a b] combines [a] and [b] leafwise with [f].
+      module Step_in = struct
+        type t = { params : Model.t; opt : Opt.t; x : Nx.float32_t }
 
-      Raises [Invalid_argument] if [a] and [b] are not structurally equal. *)
+        let map (f : 'a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) s =
+          { params = Model.map f s.params; opt = Opt.map f s.opt; x = f s.x }
 
-  val iter :
-    (module Nx.Ptree.S with type t = 'p) ->
-    ('a 'b. ('a, 'b) Nx.t -> unit) ->
-    'p t ->
-    unit
-  (** [iter (module P) f st] applies [f] to every tensor leaf, in the state's
-      traversal order. *)
+        (* map2 and iter: the same one-liners. *)
+      end
+    ]}
 
-  (** [Make (P)] is the state over the parameter tree [P] as a parameter tree
-      itself: its [t] is [P.t sgd_state] and its traversals walk the state's
-      leaves through [P]. Bind it once per model and embed it in a jitted step's
-      input/output records — directly, or via [ppx_ptree]'s [[@ptree.using]]
-      delegation:
-
-      {[
-        module Opt = Vega.Sgd_state.Make (Model)
-        type step_in = { params : Model.t; opt : Opt.t [\[@ptree.using Opt\]] }
-      ]}
-
-      The resulting leaf order — every leaf of [velocity], in [P]'s order — is
-      part of a compiled step's leaf signature and is fixed for good. *)
-  module Make (P : Nx.Ptree.S) : Nx.Ptree.S with type t = P.t sgd_state
-end
+    The resulting leaf order — every leaf of [velocity], in [P]'s order — is
+    part of a compiled step's leaf signature and is fixed for good. *)
+module Sgd_state (P : Nx.Ptree.S) : Nx.Ptree.S with type t = P.t sgd_state
 
 val sgd_init : (module Nx.Ptree.S with type t = 'p) -> 'p -> 'p sgd_state
 (** [sgd_init (module P) params] is the initial state for optimizing [params]:
@@ -321,64 +301,22 @@ type 'p adam_state = {
   nu : 'p;
       (** Exponential moving average of squared gradients, with the parameters'
           shape. *)
-  c1 : Nx.float64_t;
-      (** Bias correction for [mu]: [1 - b1^step], a scalar tensor advanced by
-          an affine recurrence each step. *)
-  c2 : Nx.float64_t;
-      (** Bias correction for [nu]: [1 - b2^step], a scalar tensor. *)
   step : Nx.int32_t;
-      (** Completed steps, a scalar tensor; also the counter tensor schedules
-          take. *)
+      (** Completed steps, a scalar tensor — not a host [int], which would be
+          burned into a compiled trace as a constant and replayed stale. The
+          steps derive their bias corrections from it, and it is the counter
+          schedules take. *)
 }
 
-(** The state for {!adam_step} and {!adamw_step}, over a parameter structure
-    ['p]. Like {!Sgd_state}, it is a parameter tree through {!Make} — the fixed
-    leaf order is [mu]'s leaves, then [nu]'s, then the three scalars [c1], [c2],
-    [step] — so it threads through compiled training steps. The bias corrections
-    and the counter are tensors, not host values: under {!Rune.val-jit} a host
-    [int] would be burned into the trace as a constant and replayed stale,
-    silently corrupting the corrections on every later call. *)
-module Adam_state : sig
-  type 'p t = 'p adam_state
-  (** The state type. *)
-
-  val map :
-    (module Nx.Ptree.S with type t = 'p) ->
-    ('a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t) ->
-    'p t ->
-    'p t
-  (** [map (module P) f st] is [st] with [f] applied to every tensor leaf — the
-      leaves of [mu] and [nu] through the parameter tree, then the scalar leaves
-      [c1], [c2], [step]. *)
-
-  val map2 :
-    (module Nx.Ptree.S with type t = 'p) ->
-    ('a 'b. ('a, 'b) Nx.t -> ('a, 'b) Nx.t -> ('a, 'b) Nx.t) ->
-    'p t ->
-    'p t ->
-    'p t
-  (** [map2 (module P) f a b] combines [a] and [b] leafwise with [f].
-
-      Raises [Invalid_argument] if [a] and [b] are not structurally equal. *)
-
-  val iter :
-    (module Nx.Ptree.S with type t = 'p) ->
-    ('a 'b. ('a, 'b) Nx.t -> unit) ->
-    'p t ->
-    unit
-  (** [iter (module P) f st] applies [f] to every tensor leaf, in the state's
-      traversal order. *)
-
-  (** [Make (P)] is the state over the parameter tree [P] as a parameter tree
-      itself — see {!Sgd_state.Make}. The leaf order — every leaf of [mu] in
-      [P]'s order, every leaf of [nu], then [c1], [c2], [step] — is part of a
-      compiled step's leaf signature and is fixed for good. *)
-  module Make (P : Nx.Ptree.S) : Nx.Ptree.S with type t = P.t adam_state
-end
+(** [Adam_state (P)] is the state over the parameter tree [P] as a parameter
+    tree itself — see {!Sgd_state}. The leaf order — every leaf of [mu] in
+    [P]'s order, every leaf of [nu], then [step] — is part of a compiled step's
+    leaf signature and is fixed for good. *)
+module Adam_state (P : Nx.Ptree.S) : Nx.Ptree.S with type t = P.t adam_state
 
 val adam_init : (module Nx.Ptree.S with type t = 'p) -> 'p -> 'p adam_state
 (** [adam_init (module P) params] is the initial state for optimizing [params]:
-    all-zero moments, zero bias corrections and [step = 0]. *)
+    all-zero moments and [step = 0]. *)
 
 val adam_step :
   (module Nx.Ptree.S with type t = 'p) ->
@@ -391,20 +329,20 @@ val adam_step :
   grads:'p ->
   'p * 'p adam_state
 (** [adam_step (module P) ~lr st ~params ~grads] is [(params', st')] after one
-    Adam step (Kingma and Ba, 2015). Per element, with [t = st.step + 1] and the
-    corrections advanced in state:
+    Adam step (Kingma and Ba, 2015). Per element, with [t = st.step + 1]:
 
     {v
-    c1' = (1 - b1) + b1 * c1        c2' = (1 - b2) + b2 * c2
-    mu' = b1 * mu + (1 - b1) * g    nu' = b2 * nu + (1 - b2) * g^2
-    d   = (mu' / c1') / (sqrt (nu' / c2') + eps)
+    mu' = b1 * mu + (1 - b1) * g
+    nu' = b2 * nu + (1 - b2) * g^2
+    d   = (mu' / (1 - b1^t)) / (sqrt (nu' / (1 - b2^t)) + eps)
     p'  = p - lr * d
     v}
 
     [lr] is a scalar tensor ({!lr}). [b1] defaults to [0.9], [b2] to [0.999],
     [eps] to [1e-8]; they are compile-time constants, safe captures under
-    {!Rune.val-jit}. The whole step is tensor arithmetic over [(params, st)] —
-    it traces, and the returned state feeds the next call. *)
+    {!Rune.val-jit}. The bias corrections are derived from the state's counter
+    per leaf, at the leaf's dtype, in tensor arithmetic — so the whole step
+    traces, and the returned state feeds the next call. *)
 
 val adamw_init : (module Nx.Ptree.S with type t = 'p) -> 'p -> 'p adam_state
 (** [adamw_init] is {!adam_init}: AdamW shares Adam's state. *)

--- a/packages/vega/lib/vega.mli
+++ b/packages/vega/lib/vega.mli
@@ -240,9 +240,11 @@ val lr : float -> Nx.float32_t
 
 (** {1:sgd Stochastic Gradient Descent} *)
 
-type 'p sgd_state = { velocity : 'p }
+type 'p sgd_state = { velocity : 'p; step : Nx.int32_t }
 (** The state for {!sgd_step}: the momentum velocity, with the shape of the
-    parameters. *)
+    parameters, and the number of completed steps as a scalar tensor. Every
+    structural state carries its counter, so a {!Schedule} applies to
+    [st.step] whichever optimizer is stepping. *)
 
 (** [Sgd_state (P)] is the state over the parameter tree [P] as a parameter
     tree itself: its [t] is [P.t sgd_state] and its traversals walk the state's
@@ -263,13 +265,14 @@ type 'p sgd_state = { velocity : 'p }
       end
     ]}
 
-    The resulting leaf order — every leaf of [velocity], in [P]'s order — is
-    part of a compiled step's leaf signature and is fixed for good. *)
+    The resulting leaf order — every leaf of [velocity], in [P]'s order, then
+    [step] — is part of a compiled step's leaf signature and is fixed for
+    good. *)
 module Sgd_state (P : Nx.Ptree.S) : Nx.Ptree.S with type t = P.t sgd_state
 
 val sgd_init : (module Nx.Ptree.S with type t = 'p) -> 'p -> 'p sgd_state
 (** [sgd_init (module P) params] is the initial state for optimizing [params]:
-    an all-zero velocity of [params]' shape. *)
+    an all-zero velocity of [params]' shape and [step = 0]. *)
 
 val sgd_step :
   (module Nx.Ptree.S with type t = 'p) ->
@@ -288,9 +291,9 @@ val sgd_step :
     v}
 
     [lr] is a scalar tensor ({!lr}); [momentum] defaults to [0.], plain gradient
-    descent: the velocity is then the last gradient, and the input state is not
-    read at all. The whole step is tensor arithmetic over [(params, st)] — it
-    traces under {!Rune.val-jit}. *)
+    descent: the velocity is then the last gradient, and the input velocity is
+    not read at all. The counter advances by one. The whole step is tensor
+    arithmetic over [(params, st)] — it traces under {!Rune.val-jit}. *)
 
 (** {1:adam Adam and AdamW} *)
 

--- a/packages/vega/test/test_uniform_vega.ml
+++ b/packages/vega/test/test_uniform_vega.ml
@@ -65,7 +65,7 @@ let grads =
 
 let test_adam_step_on_uniform () =
   let st = Vega.adam_init (module T) params in
-  let p', _ = Vega.adam_step (module T) ~lr:0.1 st ~params ~grads in
+  let p', _ = Vega.adam_step (module T) ~lr:(Vega.lr 0.1) st ~params ~grads in
   let { U.w = Nx.Ptree.P w'; b = Nx.Ptree.P b' } = p' in
   let w' = as_f32 w' and b' = as_f32 b' in
   check_t "w after adam step" [| 3 |] [| 0.9; -2.1; 2.9 |] w';

--- a/packages/vega/test/test_vega.ml
+++ b/packages/vega/test/test_vega.ml
@@ -33,51 +33,52 @@ let test_polynomial_decay () =
   let s =
     S.polynomial_decay ~init_value:1.0 ~end_value:0.0 ~decay_steps:100 ()
   in
-  equal ~msg:"step 0" (float 1e-10) 1.0 (s 0);
-  equal ~msg:"step 50 (power=1, linear)" (float 1e-6) 0.5 (s 50);
-  equal ~msg:"step 100" (float 1e-10) 0.0 (s 100);
-  equal ~msg:"clamps past end" (float 1e-10) 0.0 (s 200);
+  equal ~msg:"step 0" (float 1e-6) 1.0 (S.eval s 0);
+  equal ~msg:"step 50 (power=1, linear)" (float 1e-6) 0.5 (S.eval s 50);
+  equal ~msg:"step 100" (float 1e-6) 0.0 (S.eval s 100);
+  equal ~msg:"clamps past end" (float 1e-6) 0.0 (S.eval s 200);
   let s2 =
     S.polynomial_decay ~init_value:1.0 ~end_value:0.0 ~decay_steps:100
       ~power:2.0 ()
   in
-  equal ~msg:"power=2 at midpoint" (float 1e-6) 0.25 (s2 50)
+  equal ~msg:"power=2 at midpoint" (float 1e-6) 0.25 (S.eval s2 50)
 
 let test_warmup_cosine_decay () =
   let s =
     S.warmup_cosine_decay ~init_value:0.0 ~peak_value:1.0 ~warmup_steps:10
       ~decay_steps:90 ()
   in
-  equal ~msg:"step 0" (float 1e-10) 0.0 (s 0);
-  equal ~msg:"step 5 (warmup midpoint)" (float 1e-6) 0.5 (s 5);
-  equal ~msg:"step 10 (peak)" (float 1e-6) 1.0 (s 10);
-  equal ~msg:"step 100 (fully decayed)" (float 1e-10) 0.0 (s 100);
-  equal ~msg:"past end" (float 1e-10) 0.0 (s 200)
+  equal ~msg:"step 0" (float 1e-6) 0.0 (S.eval s 0);
+  equal ~msg:"step 5 (warmup midpoint)" (float 1e-6) 0.5 (S.eval s 5);
+  equal ~msg:"step 10 (peak)" (float 1e-6) 1.0 (S.eval s 10);
+  equal ~msg:"step 100 (fully decayed)" (float 1e-6) 0.0 (S.eval s 100);
+  equal ~msg:"past end" (float 1e-6) 0.0 (S.eval s 200)
 
 let test_piecewise_constant () =
   let s =
     S.piecewise_constant ~boundaries:[ 10; 20 ] ~values:[ 1.0; 0.1; 0.01 ]
   in
-  equal ~msg:"segment 1" (float 1e-10) 1.0 (s 5);
-  equal ~msg:"boundary" (float 1e-10) 1.0 (s 10);
-  equal ~msg:"segment 2" (float 1e-10) 0.1 (s 15);
-  equal ~msg:"segment 3" (float 1e-10) 0.01 (s 25)
+  equal ~msg:"segment 1" (float 1e-6) 1.0 (S.eval s 5);
+  equal ~msg:"boundary" (float 1e-6) 1.0 (S.eval s 10);
+  equal ~msg:"segment 2" (float 1e-6) 0.1 (S.eval s 15);
+  equal ~msg:"segment 3" (float 1e-6) 0.01 (S.eval s 25)
 
 let test_piecewise_constant_validation () =
   raises_match Exn.invalid_arg (fun () ->
-      ignore (S.piecewise_constant ~boundaries:[ 10 ] ~values:[ 1.0 ] 0));
+      ignore (S.piecewise_constant ~boundaries:[ 10 ] ~values:[ 1.0 ] : S.t));
   raises_match Exn.invalid_arg (fun () ->
       ignore
-        (S.piecewise_constant ~boundaries:[ 20; 10 ] ~values:[ 1.; 2.; 3. ] 0))
+        (S.piecewise_constant ~boundaries:[ 20; 10 ] ~values:[ 1.; 2.; 3. ]
+          : S.t))
 
 let test_join () =
   let s =
     S.join [ (10, S.constant 1.0); (10, S.constant 2.0); (10, S.constant 3.0) ]
   in
-  equal ~msg:"segment 1" (float 1e-10) 1.0 (s 5);
-  equal ~msg:"segment 2" (float 1e-10) 2.0 (s 15);
-  equal ~msg:"segment 3" (float 1e-10) 3.0 (s 25);
-  equal ~msg:"past end extends last" (float 1e-10) 3.0 (s 100)
+  equal ~msg:"segment 1" (float 1e-6) 1.0 (S.eval s 5);
+  equal ~msg:"segment 2" (float 1e-6) 2.0 (S.eval s 15);
+  equal ~msg:"segment 3" (float 1e-6) 3.0 (S.eval s 25);
+  equal ~msg:"past end extends last" (float 1e-6) 3.0 (S.eval s 100)
 
 let test_join_step_reset () =
   let calls = ref [] in
@@ -86,54 +87,54 @@ let test_join_step_reset () =
       [
         ( 5,
           fun step ->
-            calls := (name, step) :: !calls;
-            0. );
+            calls := (name, Int32.to_int (Nx.item [] step)) :: !calls;
+            Nx.scalar Nx.float32 0. );
       ]
   in
   let s = spy "a" in
-  ignore (s 3);
+  ignore (S.eval s 3);
   equal ~msg:"step passed to inner schedule"
     (list (pair string int))
     [ ("a", 3) ]
     (List.rev !calls)
 
 let test_join_validation () =
-  raises_match Exn.invalid_arg (fun () -> ignore (S.join [] 0));
+  raises_match Exn.invalid_arg (fun () -> ignore (S.join [] : S.t));
   raises_match Exn.invalid_arg (fun () ->
-      ignore (S.join [ (0, S.constant 1.0) ] 0))
+      ignore (S.join [ (0, S.constant 1.0) ] : S.t))
 
 let test_cosine_decay_restarts () =
   let s = S.cosine_decay_restarts ~init_value:1.0 ~decay_steps:100 () in
-  equal ~msg:"step 0 (peak)" (float 1e-10) 1.0 (s 0);
-  equal ~msg:"step 100 (restart)" (float 1e-6) 1.0 (s 100);
-  equal ~msg:"step 200 (second restart)" (float 1e-6) 1.0 (s 200);
-  equal ~msg:"step 50 (midpoint)" (float 1e-6) 0.5 (s 50)
+  equal ~msg:"step 0 (peak)" (float 1e-6) 1.0 (S.eval s 0);
+  equal ~msg:"step 100 (restart)" (float 1e-6) 1.0 (S.eval s 100);
+  equal ~msg:"step 200 (second restart)" (float 1e-6) 1.0 (S.eval s 200);
+  equal ~msg:"step 50 (midpoint)" (float 1e-6) 0.5 (S.eval s 50)
 
 let test_cosine_decay_restarts_t_mul () =
   let s =
     S.cosine_decay_restarts ~init_value:1.0 ~decay_steps:10 ~t_mul:2.0 ()
   in
   (* First cycle: 10 steps. Second: 20 steps. *)
-  equal ~msg:"step 0 (start)" (float 1e-6) 1.0 (s 0);
-  equal ~msg:"step 10 (second cycle start)" (float 1e-6) 1.0 (s 10);
-  equal ~msg:"step 30 (third cycle start)" (float 1e-6) 1.0 (s 30)
+  equal ~msg:"step 0 (start)" (float 1e-6) 1.0 (S.eval s 0);
+  equal ~msg:"step 10 (second cycle start)" (float 1e-6) 1.0 (S.eval s 10);
+  equal ~msg:"step 30 (third cycle start)" (float 1e-6) 1.0 (S.eval s 30)
 
 let test_cosine_decay_restarts_m_mul () =
   let s =
     S.cosine_decay_restarts ~init_value:1.0 ~decay_steps:100 ~m_mul:0.5 ()
   in
-  equal ~msg:"cycle 0 peak" (float 1e-6) 1.0 (s 0);
-  equal ~msg:"cycle 1 peak" (float 1e-6) 0.5 (s 100);
-  equal ~msg:"cycle 2 peak" (float 1e-6) 0.25 (s 200)
+  equal ~msg:"cycle 0 peak" (float 1e-6) 1.0 (S.eval s 0);
+  equal ~msg:"cycle 1 peak" (float 1e-6) 0.5 (S.eval s 100);
+  equal ~msg:"cycle 2 peak" (float 1e-6) 0.25 (S.eval s 200)
 
 let test_one_cycle () =
   let s = S.one_cycle ~max_value:1.0 ~total_steps:100 () in
   (* warmup: 30 steps (pct_start=0.3), init=1/25=0.04, peak=1.0 *)
-  equal ~msg:"step 0" (float 1e-6) 0.04 (s 0);
-  equal ~msg:"step 30 (peak)" (float 1e-6) 1.0 (s 30);
+  equal ~msg:"step 0" (float 1e-6) 0.04 (S.eval s 0);
+  equal ~msg:"step 30 (peak)" (float 1e-6) 1.0 (S.eval s 30);
   (* decay: 70 steps, from 1.0 to 1/10000=0.0001 *)
   let end_val = 1.0 /. 10000.0 in
-  equal ~msg:"step 100 (end)" (float 1e-6) end_val (s 100)
+  equal ~msg:"step 100 (end)" (float 1e-6) end_val (S.eval s 100)
 
 (* Schedule property tests — these are `test` values, placed directly in the
    group list below. *)
@@ -188,7 +189,7 @@ let test_add_decayed_weights () =
   equal ~msg:"wd" (array eps) [| 2.0; -0.5 |] (to_arr upd)
 
 let test_add_decayed_weights_scheduled () =
-  let rate step = 0.01 *. float_of_int step in
+  let rate step = Nx.mul_s (Nx.cast Nx.float32 step) 0.01 in
   let tx = Vega.add_decayed_weights ~rate () in
   let grad = vec [| 0.0 |] in
   let param = vec [| 10.0 |] in
@@ -388,8 +389,8 @@ let test_nan_skipped () =
   let grad = vec [| Float.nan; 1.0 |] in
   let upd, _ = Vega.update (Vega.init tx param) ~grad ~param in
   let v = to_arr upd in
-  equal ~msg:"nan → zero[0]" (float 1e-10) 0.0 v.(0);
-  equal ~msg:"nan → zero[1]" (float 1e-10) 0.0 v.(1)
+  equal ~msg:"nan → zero[0]" (float 1e-6) 0.0 v.(0);
+  equal ~msg:"nan → zero[1]" (float 1e-6) 0.0 v.(1)
 
 let test_inf_skipped () =
   let inner = Vega.scale 1.0 in
@@ -398,7 +399,7 @@ let test_inf_skipped () =
   let grad = vec [| Float.infinity; 1.0 |] in
   let upd, _ = Vega.update (Vega.init tx param) ~grad ~param in
   let v = to_arr upd in
-  equal ~msg:"inf → zero" (float 1e-10) 0.0 v.(0)
+  equal ~msg:"inf → zero" (float 1e-6) 0.0 v.(0)
 
 let test_nonfinite_counter () =
   let inner = Vega.scale 1.0 in
@@ -411,7 +412,7 @@ let test_nonfinite_counter () =
   let _, tensors = Vega.state_to_tensors st in
   (* Last tensor is the counter *)
   let counter = Nx.item [] tensors.(Array.length tensors - 1) in
-  equal ~msg:"2 consecutive non-finite" (float 1e-10) 2.0 counter
+  equal ~msg:"2 consecutive non-finite" (float 1e-6) 2.0 counter
 
 (* Serialization *)
 
@@ -476,9 +477,9 @@ let test_validation () =
   raises_match Exn.invalid_arg (fun () ->
       ignore (Vega.adan ~weight_decay:(-1.) lr01));
   raises_match Exn.invalid_arg (fun () ->
-      ignore (S.cosine_decay_restarts ~init_value:1. ~decay_steps:0 () 0));
+      ignore (S.cosine_decay_restarts ~init_value:1. ~decay_steps:0 () : S.t));
   raises_match Exn.invalid_arg (fun () ->
-      ignore (S.one_cycle ~max_value:1. ~total_steps:0 () 0))
+      ignore (S.one_cycle ~max_value:1. ~total_steps:0 () : S.t))
 
 (* Entry point *)
 
@@ -501,25 +502,27 @@ let () =
           test "one_cycle" test_one_cycle;
           prop "constant is constant"
             Gen.(pair float nat)
-            (fun (v, step) -> equal float_exact v (S.constant v step));
+            (fun (v, step) ->
+              let s = S.constant v in
+              equal float_exact (S.eval s 0) (S.eval s step));
           prop "cosine_decay bounded" Gen.nat (fun step ->
               let s = S.cosine_decay ~init_value:1.0 ~decay_steps:100 () in
-              let v = s step in
+              let v = S.eval s step in
               is_true ~msg:">=0" (v >= 0.0);
-              is_true ~msg:"<=1" (v <= 1.0 +. 1e-10));
+              is_true ~msg:"<=1" (v <= 1.0 +. 1e-6));
           prop "one_cycle bounded" Gen.nat (fun step ->
               let s = S.one_cycle ~max_value:1.0 ~total_steps:100 () in
-              let v = s step in
+              let v = S.eval s step in
               is_true ~msg:">=0" (v >= 0.0);
-              is_true ~msg:"<=max" (v <= 1.0 +. 1e-10));
+              is_true ~msg:"<=max" (v <= 1.0 +. 1e-6));
           prop "cosine_decay_restarts periodic" Gen.nat (fun step ->
               let period = 50 in
               let s =
                 S.cosine_decay_restarts ~init_value:1.0 ~decay_steps:period ()
               in
-              let v1 = s step in
-              let v2 = s (step + period) in
-              equal ~msg:"periodic" (float 1e-10) v1 v2);
+              let v1 = S.eval s step in
+              let v2 = S.eval s (step + period) in
+              equal ~msg:"periodic" (float 1e-5) v1 v2);
         ];
       group "primitives"
         [

--- a/packages/vega/test/test_vega_structural.ml
+++ b/packages/vega/test/test_vega_structural.ml
@@ -195,7 +195,8 @@ let test_sgd_velocity_threads () =
       ~lr:(lr64 0.1) ~momentum:0.5 st ~params ~grads:(vec [| 2.0 |])
   in
   (* v2 = 0.5 *. v1 +. g2 = 0.5 *. 1. +. 2. *)
-  check_vec [| 2.5 |] st.velocity
+  check_vec [| 2.5 |] st.velocity;
+  equal ~msg:"counter reads 2" int 2 (Int32.to_int (Nx.item [] st.step))
 
 let test_sgd_converges () =
   let params = Lazy.force bowl_start in
@@ -507,11 +508,11 @@ let test_state_traversals () =
   let st' = A.map2 (fun _ r -> r) st doubled in
   check_vec ~msg:"merged mu" [| 0.0 |] st'.mu.b;
   equal ~msg:"merged step" int32 0l (Nx.item [] st'.step);
-  (* The sgd state's single payload leaf. *)
+  (* The sgd state: 2 velocity leaves + step. *)
   let sst = Vega.sgd_init (module Pair) params in
   let n = ref 0 in
   Sg.iter (fun _ -> incr n) sst;
-  equal ~msg:"sgd leaf count" int 2 !n
+  equal ~msg:"sgd leaf count" int 3 !n
 
 let test_state_functor_is_a_ptree () =
   (* [Vega.Adam_state (P)] is an Nx.Ptree.S: the state can sit inside another

--- a/packages/vega/test/test_vega_structural.ml
+++ b/packages/vega/test/test_vega_structural.ml
@@ -101,8 +101,8 @@ let test_warmup_cosine () =
 
 let test_schedule_validation () =
   raises
-    (Invalid_argument
-       "Schedule.exponential_decay: decay_steps must be positive") (fun () ->
+    (Invalid_argument "Schedule.exponential_decay: decay_steps must be positive")
+    (fun () ->
       ignore
         (S.exponential_decay ~init_value:1.0 ~decay_rate:0.5 ~decay_steps:0 0));
   raises
@@ -154,9 +154,8 @@ let test_clip_by_value () =
 let test_clip_validation () =
   let grads = pair [| 1.0 |] [| 1.0 |] in
   raises
-    (Invalid_argument
-       "Vega.clip_by_global_norm: expected max_norm > 0.0, got 0") (fun () ->
-      Vega.clip_by_global_norm (module Pair) ~max_norm:0.0 grads);
+    (Invalid_argument "Vega.clip_by_global_norm: expected max_norm > 0.0, got 0")
+    (fun () -> Vega.clip_by_global_norm (module Pair) ~max_norm:0.0 grads);
   raises (Invalid_argument "Vega.clip_by_value: expected max > 0.0, got -1")
     (fun () -> Vega.clip_by_value (module Pair) ~max:(-1.0) grads)
 
@@ -168,7 +167,7 @@ let test_sgd_first_step () =
   let st = Vega.sgd_init (module Vec) params in
   (* Zero velocity: the first step is plain descent even with momentum. *)
   let params', st' =
-    Vega.sgd_step (module Vec) ~lr:0.1 ~momentum:0.9 st ~params ~grads
+    Vega.sgd_step (module Vec) ~lr:(Vega.lr 0.1) ~momentum:0.9 st ~params ~grads
   in
   check_vec [| 0.95; -1.9 |] params';
   check_vec ~msg:"velocity is the gradient" [| 0.5; -1.0 |] st'.velocity
@@ -179,12 +178,12 @@ let test_sgd_velocity_threads () =
   let params, st =
     Vega.sgd_step
       (module Vec)
-      ~lr:0.1 ~momentum:0.5 st ~params ~grads:(vec [| 1.0 |])
+      ~lr:(Vega.lr 0.1) ~momentum:0.5 st ~params ~grads:(vec [| 1.0 |])
   in
   let _, st =
     Vega.sgd_step
       (module Vec)
-      ~lr:0.1 ~momentum:0.5 st ~params ~grads:(vec [| 2.0 |])
+      ~lr:(Vega.lr 0.1) ~momentum:0.5 st ~params ~grads:(vec [| 2.0 |])
   in
   (* v2 = 0.5 *. v1 +. g2 = 0.5 *. 1. +. 2. *)
   check_vec [| 2.5 |] st.velocity
@@ -193,7 +192,7 @@ let test_sgd_converges () =
   let params = Lazy.force bowl_start in
   let step (params, st) =
     let grads = bowl_grads params in
-    Vega.sgd_step (module Pair) ~lr:0.1 st ~params ~grads
+    Vega.sgd_step (module Pair) ~lr:(Vega.lr 0.1) st ~params ~grads
   in
   let params, _ =
     descend ~steps:100 ~step (params, Vega.sgd_init (module Pair) params)
@@ -204,7 +203,9 @@ let test_sgd_momentum_converges () =
   let params = Lazy.force bowl_start in
   let step (params, st) =
     let grads = bowl_grads params in
-    Vega.sgd_step (module Pair) ~lr:0.05 ~momentum:0.9 st ~params ~grads
+    Vega.sgd_step
+      (module Pair)
+      ~lr:(Vega.lr 0.05) ~momentum:0.9 st ~params ~grads
   in
   let params, _ =
     descend ~steps:200 ~step (params, Vega.sgd_init (module Pair) params)
@@ -215,7 +216,9 @@ let test_sgd_pairs_leaves_structurally () =
   let params = pair [| 1.0; 2.0 |] [| 3.0 |] in
   let grads = pair [| 0.0; 0.0 |] [| 1.0 |] in
   let st = Vega.sgd_init (module Pair) params in
-  let params', _ = Vega.sgd_step (module Pair) ~lr:0.5 st ~params ~grads in
+  let params', _ =
+    Vega.sgd_step (module Pair) ~lr:(Vega.lr 0.5) st ~params ~grads
+  in
   check_vec ~eps:0. ~msg:"zero-gradient leaf untouched" [| 1.0; 2.0 |] params'.a;
   check_vec ~eps:0. [| 2.5 |] params'.b
 
@@ -227,7 +230,7 @@ let test_adam_first_step () =
   let params = vec [| 1.0; -2.0; 3.0 |] in
   let st = Vega.adam_init (module Vec) params in
   let params', st' =
-    Vega.adam_step (module Vec) ~lr st ~params ~grads:(vec g)
+    Vega.adam_step (module Vec) ~lr:(Vega.lr lr) st ~params ~grads:(vec g)
   in
   (* First step analytically: mu = (1-b1) g, nu = (1-b2) g^2, and the
      bias-corrected direction is g / (|g| + eps). *)
@@ -239,7 +242,7 @@ let test_adam_first_step () =
   check_vec expected params';
   check_vec ~msg:"mu" (Array.map (fun g -> (1. -. b1) *. g) g) st'.mu;
   check_vec ~msg:"nu" (Array.map (fun g -> (1. -. b2) *. g *. g) g) st'.nu;
-  equal ~msg:"step count" int 1 st'.step
+  equal ~msg:"step count" int 1 (Int32.to_int (Nx.item [] st'.step))
 
 let test_adam_reference_trajectory () =
   let b1 = 0.9 and b2 = 0.999 and eps = 1e-8 and lr = 0.05 in
@@ -263,7 +266,7 @@ let test_adam_reference_trajectory () =
     (fun i e ->
       let grads = Nx.mul_s (Nx.sub_s !params 1.0) 2.0 in
       let params', st' =
-        Vega.adam_step (module Vec) ~lr !st ~params:!params ~grads
+        Vega.adam_step (module Vec) ~lr:(Vega.lr lr) !st ~params:!params ~grads
       in
       params := params';
       st := st';
@@ -274,7 +277,7 @@ let test_adam_converges () =
   let params = Lazy.force bowl_start in
   let step (params, st) =
     let grads = bowl_grads params in
-    Vega.adam_step (module Pair) ~lr:0.02 st ~params ~grads
+    Vega.adam_step (module Pair) ~lr:(Vega.lr 0.02) st ~params ~grads
   in
   let params, _ =
     descend ~steps:800 ~step (params, Vega.adam_init (module Pair) params)
@@ -282,14 +285,15 @@ let test_adam_converges () =
   is_true ~msg:"reaches the bottom of the bowl" (bowl_distance params < 0.05)
 
 let test_adam_with_schedule_converges () =
-  let sched = S.cosine_decay ~init_value:0.1 ~decay_steps:300 () in
+  (* The learning rate comes from the state's own step counter via a tensor
+     schedule — the jitted loop's shape, run eagerly. *)
   let params = Lazy.force bowl_start in
-  let st = Vega.adam_init (module Pair) params in
-  let state = ref (params, st) in
-  for k = 0 to 299 do
+  let state = ref (params, Vega.adam_init (module Pair) params) in
+  for _k = 1 to 300 do
     let params, st = !state in
     let grads = bowl_grads params in
-    state := Vega.adam_step (module Pair) ~lr:(sched k) st ~params ~grads
+    let lr = S.cosine_decay_t ~init_value:0.1 ~decay_steps:300 st.step in
+    state := Vega.adam_step (module Pair) ~lr st ~params ~grads
   done;
   is_true ~msg:"decayed steps settle at the bottom"
     (bowl_distance (fst !state) < 0.02)
@@ -298,17 +302,24 @@ let test_adam_zero_grads () =
   let params = vec [| 1.0; -2.0 |] in
   let st = Vega.adam_init (module Vec) params in
   let params', st' =
-    Vega.adam_step (module Vec) ~lr:0.1 st ~params ~grads:(vec [| 0.0; 0.0 |])
+    Vega.adam_step
+      (module Vec)
+      ~lr:(Vega.lr 0.1) st ~params
+      ~grads:(vec [| 0.0; 0.0 |])
   in
   check_vec ~eps:0. ~msg:"parameters unchanged" [| 1.0; -2.0 |] params';
-  equal ~msg:"step still advances" int 1 st'.step
+  equal ~msg:"step still advances" int 1 (Int32.to_int (Nx.item [] st'.step))
 
 let test_adam_step_is_pure () =
   let params = vec [| 3.0; -1.0 |] in
   let grads = vec [| 0.7; 0.3 |] in
   let st = Vega.adam_init (module Vec) params in
-  let once, _ = Vega.adam_step (module Vec) ~lr:0.1 st ~params ~grads in
-  let again, _ = Vega.adam_step (module Vec) ~lr:0.1 st ~params ~grads in
+  let once, _ =
+    Vega.adam_step (module Vec) ~lr:(Vega.lr 0.1) st ~params ~grads
+  in
+  let again, _ =
+    Vega.adam_step (module Vec) ~lr:(Vega.lr 0.1) st ~params ~grads
+  in
   check_vec ~eps:0. ~msg:"same state, same step" (Nx.to_array once) again
 
 (* AdamW *)
@@ -327,11 +338,13 @@ let test_adamw_zero_decay_is_adam () =
   in
   let adam =
     run (fun st ~params ~grads ->
-        Vega.adam_step (module Vec) ~lr:0.1 st ~params ~grads)
+        Vega.adam_step (module Vec) ~lr:(Vega.lr 0.1) st ~params ~grads)
   in
   let adamw =
     run (fun st ~params ~grads ->
-        Vega.adamw_step (module Vec) ~lr:0.1 ~weight_decay:0.0 st ~params ~grads)
+        Vega.adamw_step
+          (module Vec)
+          ~lr:(Vega.lr 0.1) ~weight_decay:0.0 st ~params ~grads)
   in
   check_vec ~eps:0. (Nx.to_array adam) adamw
 
@@ -346,7 +359,7 @@ let test_adamw_decays_weights () =
     let params', st' =
       Vega.adamw_step
         (module Vec)
-        ~lr ~weight_decay:wd !st ~params:!params
+        ~lr:(Vega.lr lr) ~weight_decay:wd !st ~params:!params
         ~grads:(vec [| 0.0; 0.0 |])
     in
     params := params';
@@ -359,19 +372,20 @@ let test_adamw_converges () =
   let params = Lazy.force bowl_start in
   let step (params, st) =
     let grads = bowl_grads params in
-    Vega.adamw_step (module Pair) ~lr:0.02 ~weight_decay:1e-3 st ~params ~grads
+    Vega.adamw_step
+      (module Pair)
+      ~lr:(Vega.lr 0.02) ~weight_decay:1e-3 st ~params ~grads
   in
   let params, _ =
     descend ~steps:800 ~step (params, Vega.adamw_init (module Pair) params)
   in
   is_true ~msg:"reaches the bottom of the bowl" (bowl_distance params < 0.05)
 
-(* A parameter structure may carry leaves that are not parameters. The
-   canonical one is an RNG key, which has to sit in the structure to reach a
-   compiled step as an input but is not something to optimize. Rune leaves its
-   gradient slot at zero; the optimizers must leave the value alone. Adam is
-   where it would show: its direction runs each leaf through a square root and
-   a division. *)
+(* A parameter structure may carry leaves that are not parameters. The canonical
+   one is an RNG key, which has to sit in the structure to reach a compiled step
+   as an input but is not something to optimize. Rune leaves its gradient slot
+   at zero; the optimizers must leave the value alone. Adam is where it would
+   show: its direction runs each leaf through a square root and a division. *)
 module Stepper = struct
   type t = { w : Nx.float64_t; key : Nx.Rng.key }
 
@@ -414,7 +428,7 @@ let test_optimizers_carry_a_non_parameter_leaf () =
   let sgd, _ =
     Vega.sgd_step
       (module Stepper)
-      ~lr:0.1
+      ~lr:(Vega.lr 0.1)
       (Vega.sgd_init (module Stepper) params)
       ~params ~grads
   in
@@ -422,7 +436,7 @@ let test_optimizers_carry_a_non_parameter_leaf () =
   let momentum, _ =
     Vega.sgd_step
       (module Stepper)
-      ~lr:0.1 ~momentum:0.9
+      ~lr:(Vega.lr 0.1) ~momentum:0.9
       (Vega.sgd_init (module Stepper) params)
       ~params ~grads
   in
@@ -430,7 +444,7 @@ let test_optimizers_carry_a_non_parameter_leaf () =
   let adam, _ =
     Vega.adam_step
       (module Stepper)
-      ~lr:0.1
+      ~lr:(Vega.lr 0.1)
       (Vega.adam_init (module Stepper) params)
       ~params ~grads
   in
@@ -438,11 +452,141 @@ let test_optimizers_carry_a_non_parameter_leaf () =
   let adamw, _ =
     Vega.adamw_step
       (module Stepper)
-      ~lr:0.1
+      ~lr:(Vega.lr 0.1)
       (Vega.adamw_init (module Stepper) params)
       ~params ~grads
   in
   check "adamw" adamw
+
+(* Optimizer state as a parameter tree *)
+
+let test_adam_state_scalars_advance () =
+  let params = vec [| 1.0 |] in
+  let grads = vec [| 1.0 |] in
+  let st = ref (Vega.adam_init (module Vec) params) in
+  let lr = Vega.lr 0.1 in
+  (* After k steps the corrections are the closed-form 1 - b^k. *)
+  let b1 = 0.9 and b2 = 0.999 in
+  List.iter
+    (fun k ->
+      (* Advance until the counter reads [k]. *)
+      while Int32.to_int (Nx.item [] !st.step) < k do
+        let _, st' = Vega.adam_step (module Vec) ~lr !st ~params ~grads in
+        st := st'
+      done;
+      equal
+        ~msg:(Printf.sprintf "step after %d" k)
+        int k
+        (Int32.to_int (Nx.item [] !st.step));
+      check_vec
+        ~msg:(Printf.sprintf "c1 at %d" k)
+        [| 1.0 -. (b1 ** float_of_int k) |]
+        !st.c1;
+      check_vec
+        ~msg:(Printf.sprintf "c2 at %d" k)
+        [| 1.0 -. (b2 ** float_of_int k) |]
+        !st.c2)
+    [ 1; 2; 5 ]
+
+let test_state_traversals () =
+  (* Both state modules are parameter trees: map/map2/iter walk every tensor
+     leaf — payload leaves and the scalar leaves — in a fixed order. *)
+  let double (type a b) (t : (a, b) Nx.t) : (a, b) Nx.t =
+    Nx.cast (Nx.dtype t) (Nx.mul_s (Nx.cast Nx.float64 t) 2.0)
+  in
+  let params = pair [| 1.0; 2.0 |] [| 3.0 |] in
+  let st = Vega.adam_init (module Pair) params in
+  (* map doubles everything; iter counts the leaves it visits. *)
+  let doubled = Vega.Adam_state.map (module Pair) double st in
+  check_vec ~msg:"mu doubled" [| 0.0; 0.0 |] doubled.mu.a;
+  equal ~msg:"c1 doubled" (float 1e-12) 0.0 (Nx.item [] doubled.c1);
+  let n = ref 0 in
+  Vega.Adam_state.iter (module Pair) (fun _ -> incr n) st;
+  (* 2 mu leaves + 2 nu leaves + c1 + c2 + step. *)
+  equal ~msg:"adam leaf count" int 7 !n;
+  (* map2 merges leafwise: take the right state everywhere. *)
+  let st' = Vega.Adam_state.map2 (module Pair) (fun _ r -> r) st doubled in
+  check_vec ~msg:"merged mu" [| 0.0 |] st'.mu.b;
+  equal ~msg:"merged step" int32 0l (Nx.item [] st'.step);
+  (* The sgd state's single payload leaf. *)
+  let sst = Vega.sgd_init (module Pair) params in
+  let n = ref 0 in
+  Vega.Sgd_state.iter (module Pair) (fun _ -> incr n) sst;
+  equal ~msg:"sgd leaf count" int 2 !n
+
+let test_state_make_is_a_ptree () =
+  (* [Make] produces an Nx.Ptree.S: the state can sit inside another tree — the
+     shape a jitted step's input record takes. *)
+  let module Opt = Vega.Adam_state.Make (Pair) in
+  let params = pair [| 1.0 |] [| 2.0 |] in
+  let grads = pair [| 0.5 |] [| -0.5 |] in
+  let st = Vega.adam_init (module Pair) params in
+  (* Run the step through the state's own walker: embedding the state in an
+     outer record and mapping over it must reproduce the state exactly. *)
+  let roundtrip =
+    Opt.map (fun t -> t) (Opt.map2 (fun _ r -> r) (Opt.map (fun t -> t) st) st)
+  in
+  let params', _ =
+    Vega.adam_step (module Pair) ~lr:(Vega.lr 0.1) roundtrip ~params ~grads
+  in
+  let expected, _ =
+    Vega.adam_step (module Pair) ~lr:(Vega.lr 0.1) st ~params ~grads
+  in
+  check_vec ~msg:"roundtrip state steps identically" (Nx.to_array expected.a)
+    params'.a
+
+(* Tensor schedules match the scalar family at integer steps. *)
+
+let parity ~msg sched sched_t =
+  List.iter
+    (fun k ->
+      let scalar = sched k in
+      let tensor = Nx.item [] (sched_t (Nx.scalar Nx.int32 (Int32.of_int k))) in
+      equal ~msg:(Printf.sprintf "%s at %d" msg k) (float 1e-6) scalar tensor)
+    [ 0; 1; 3; 7; 50; 99; 100; 250 ]
+
+let test_tensor_schedules_match_scalar () =
+  parity ~msg:"constant" (S.constant 0.1) (S.constant_t 0.1);
+  parity ~msg:"linear"
+    (S.linear ~init_value:0.2 ~end_value:0.001 ~steps:100)
+    (S.linear_t ~init_value:0.2 ~end_value:0.001 ~steps:100);
+  parity ~msg:"cosine decay"
+    (S.cosine_decay ~init_value:0.1 ~decay_steps:100 ~alpha:0.1 ())
+    (S.cosine_decay_t ~init_value:0.1 ~decay_steps:100 ~alpha:0.1);
+  parity ~msg:"warmup cosine"
+    (S.warmup_cosine ~init_value:0.0 ~peak_value:1.0 ~warmup_steps:50)
+    (S.warmup_cosine_t ~init_value:0.0 ~peak_value:1.0 ~warmup_steps:50);
+  parity ~msg:"warmup cosine decay"
+    (S.warmup_cosine_decay ~init_value:0.0 ~peak_value:1.0 ~warmup_steps:10
+       ~decay_steps:100 ())
+    (S.warmup_cosine_decay_t ~init_value:0.0 ~peak_value:1.0 ~warmup_steps:10
+       ~decay_steps:100);
+  parity ~msg:"one cycle"
+    (S.one_cycle ~max_value:0.1 ~total_steps:120 ())
+    (S.one_cycle_t ~max_value:0.1 ~total_steps:120);
+  parity ~msg:"piecewise constant"
+    (S.piecewise_constant ~boundaries:[ 10; 50 ] ~values:[ 0.1; 0.01; 0.001 ])
+    (S.piecewise_constant_t ~boundaries:[ 10; 50 ] ~values:[ 0.1; 0.01; 0.001 ])
+
+let test_tensor_schedule_validation () =
+  raises (Invalid_argument "Schedule.linear_t: steps must be positive")
+    (fun () ->
+      ignore
+        (S.linear_t ~init_value:1.0 ~end_value:0.0 ~steps:0
+           (Nx.scalar Nx.int32 0l)));
+  raises
+    (Invalid_argument "Schedule.cosine_decay_t: decay_steps must be positive")
+    (fun () ->
+      ignore
+        (S.cosine_decay_t ~init_value:1.0 ~decay_steps:(-1)
+           (Nx.scalar Nx.int32 0l)));
+  raises
+    (Invalid_argument
+       "Schedule.piecewise_constant_t: expected 2 values for 1 boundaries, got \
+        1") (fun () ->
+      ignore
+        (S.piecewise_constant_t ~boundaries:[ 10 ] ~values:[ 0.1 ]
+           (Nx.scalar Nx.int32 0l)))
 
 let tests =
   [
@@ -482,6 +626,8 @@ let tests =
         test "converges on a quadratic bowl" test_adam_converges;
         test "converges under a cosine schedule"
           test_adam_with_schedule_converges;
+        test "corrections and counter advance as tensors"
+          test_adam_state_scalars_advance;
         test "zero gradients leave parameters unchanged" test_adam_zero_grads;
         test "stepping is pure in the threaded state" test_adam_step_is_pure;
       ];
@@ -491,6 +637,19 @@ let tests =
         test "zero gradients decay weights geometrically"
           test_adamw_decays_weights;
         test "converges on a quadratic bowl" test_adamw_converges;
+      ];
+    group "optimizer state as a parameter tree"
+      [
+        test "state traversals walk every leaf" test_state_traversals;
+        test "Make produces a Ptree.S that steps identically"
+          test_state_make_is_a_ptree;
+      ];
+    group "tensor schedules"
+      [
+        test "tensor schedules match the scalar family"
+          test_tensor_schedules_match_scalar;
+        test "tensor schedule constructors reject bad step counts"
+          test_tensor_schedule_validation;
       ];
     group "non-parameter leaves"
       [

--- a/packages/vega/test/test_vega_structural.ml
+++ b/packages/vega/test/test_vega_structural.ml
@@ -44,6 +44,11 @@ let check_vec ?(eps = 1e-9) ?msg expected actual =
   let t = if eps = 0. then float_exact else float eps in
   equal ?msg (array t) expected (Nx.to_array actual)
 
+(* The float64 analytic tests need the rate exact at float64; [Vega.lr] is
+   float32 (cast up, it would perturb the last digits). The [~lr] argument
+   takes any float dtype. *)
+let lr64 v = Nx.scalar Nx.float64 v
+
 (* Quadratic bowl over [Pair]: f p = ||p - target||^2, with analytic gradients,
    so tests exercise the optimizer alone. *)
 let bowl_target = lazy (pair [| 1.5; -0.5 |] [| 2.0 |])
@@ -65,61 +70,65 @@ let descend ~steps ~step params =
   let rec loop k acc = if k = 0 then acc else loop (k - 1) (step acc) in
   loop steps params
 
-(* Schedules *)
+(* Schedules. [S.eval] reads a schedule at a host counter; the values are
+   float32, so expectations carry float32 tolerances. *)
 
 let test_constant () =
   let sched = S.constant 0.1 in
-  equal float_exact 0.1 (sched 0);
-  equal float_exact 0.1 (sched 1000)
+  equal (float 1e-6) 0.1 (S.eval sched 0);
+  equal (float 1e-6) 0.1 (S.eval sched 1000)
 
 let test_exponential_decay () =
   let sched =
     S.exponential_decay ~init_value:0.5 ~decay_rate:0.1 ~decay_steps:100
   in
-  equal (float 1e-12) 0.5 (sched 0);
-  equal (float 1e-12) 0.05 (sched 100);
-  equal (float 1e-12) 0.005 (sched 200)
+  equal (float 1e-6) 0.5 (S.eval sched 0);
+  equal (float 1e-6) 0.05 (S.eval sched 100);
+  equal (float 1e-6) 0.005 (S.eval sched 200)
 
 let test_cosine_decay () =
   (* alpha = 0.1 makes the final value alpha * init_value = 0.01. *)
   let sched = S.cosine_decay ~init_value:0.1 ~decay_steps:100 ~alpha:0.1 () in
-  equal (float 1e-12) 0.1 (sched 0);
-  equal (float 1e-12) 0.055 (sched 50);
-  equal (float 1e-12) 0.01 (sched 100);
-  equal ~msg:"stays at final past steps" (float 1e-12) 0.01 (sched 250)
+  equal (float 1e-6) 0.1 (S.eval sched 0);
+  equal (float 1e-6) 0.055 (S.eval sched 50);
+  equal (float 1e-6) 0.01 (S.eval sched 100);
+  equal ~msg:"stays at final past steps" (float 1e-6) 0.01 (S.eval sched 250)
 
 let test_warmup_cosine () =
   let sched =
     S.warmup_cosine_decay ~init_value:0.0 ~peak_value:1.0 ~warmup_steps:10
       ~decay_steps:100 ()
   in
-  equal (float 1e-12) 0.0 (sched 0);
-  equal (float 1e-12) 0.5 (sched 5);
-  equal (float 1e-12) 1.0 (sched 10);
-  equal ~msg:"cosine midpoint" (float 1e-12) 0.5 (sched 60);
-  equal (float 1e-12) 0.0 (sched 110)
+  equal (float 1e-6) 0.0 (S.eval sched 0);
+  equal (float 1e-6) 0.5 (S.eval sched 5);
+  equal (float 1e-6) 1.0 (S.eval sched 10);
+  equal ~msg:"cosine midpoint" (float 1e-6) 0.5 (S.eval sched 60);
+  equal (float 1e-6) 0.0 (S.eval sched 110)
 
 let test_schedule_validation () =
   raises
     (Invalid_argument "Schedule.exponential_decay: decay_steps must be positive")
     (fun () ->
       ignore
-        (S.exponential_decay ~init_value:1.0 ~decay_rate:0.5 ~decay_steps:0 0));
+        (S.exponential_decay ~init_value:1.0 ~decay_rate:0.5 ~decay_steps:0
+          : S.t));
   raises
     (Invalid_argument "Schedule.cosine_decay: decay_steps must be positive")
-    (fun () -> ignore (S.cosine_decay ~init_value:1.0 ~decay_steps:(-1) () 0));
+    (fun () -> ignore (S.cosine_decay ~init_value:1.0 ~decay_steps:(-1) () : S.t));
   raises
     (Invalid_argument
        "Schedule.warmup_cosine_decay: warmup_steps must be positive") (fun () ->
       ignore
         (S.warmup_cosine_decay ~init_value:0.0 ~peak_value:1.0 ~warmup_steps:0
-           ~decay_steps:10 () 0));
+           ~decay_steps:10 ()
+          : S.t));
   raises
     (Invalid_argument
        "Schedule.warmup_cosine_decay: decay_steps must be positive") (fun () ->
       ignore
         (S.warmup_cosine_decay ~init_value:0.0 ~peak_value:1.0 ~warmup_steps:10
-           ~decay_steps:0 () 0))
+           ~decay_steps:0 ()
+          : S.t))
 
 (* Gradient transformations *)
 
@@ -167,7 +176,7 @@ let test_sgd_first_step () =
   let st = Vega.sgd_init (module Vec) params in
   (* Zero velocity: the first step is plain descent even with momentum. *)
   let params', st' =
-    Vega.sgd_step (module Vec) ~lr:(Vega.lr 0.1) ~momentum:0.9 st ~params ~grads
+    Vega.sgd_step (module Vec) ~lr:(lr64 0.1) ~momentum:0.9 st ~params ~grads
   in
   check_vec [| 0.95; -1.9 |] params';
   check_vec ~msg:"velocity is the gradient" [| 0.5; -1.0 |] st'.velocity
@@ -178,12 +187,12 @@ let test_sgd_velocity_threads () =
   let params, st =
     Vega.sgd_step
       (module Vec)
-      ~lr:(Vega.lr 0.1) ~momentum:0.5 st ~params ~grads:(vec [| 1.0 |])
+      ~lr:(lr64 0.1) ~momentum:0.5 st ~params ~grads:(vec [| 1.0 |])
   in
   let _, st =
     Vega.sgd_step
       (module Vec)
-      ~lr:(Vega.lr 0.1) ~momentum:0.5 st ~params ~grads:(vec [| 2.0 |])
+      ~lr:(lr64 0.1) ~momentum:0.5 st ~params ~grads:(vec [| 2.0 |])
   in
   (* v2 = 0.5 *. v1 +. g2 = 0.5 *. 1. +. 2. *)
   check_vec [| 2.5 |] st.velocity
@@ -230,7 +239,7 @@ let test_adam_first_step () =
   let params = vec [| 1.0; -2.0; 3.0 |] in
   let st = Vega.adam_init (module Vec) params in
   let params', st' =
-    Vega.adam_step (module Vec) ~lr:(Vega.lr lr) st ~params ~grads:(vec g)
+    Vega.adam_step (module Vec) ~lr:(lr64 lr) st ~params ~grads:(vec g)
   in
   (* First step analytically: mu = (1-b1) g, nu = (1-b2) g^2, and the
      bias-corrected direction is g / (|g| + eps). *)
@@ -266,7 +275,7 @@ let test_adam_reference_trajectory () =
     (fun i e ->
       let grads = Nx.mul_s (Nx.sub_s !params 1.0) 2.0 in
       let params', st' =
-        Vega.adam_step (module Vec) ~lr:(Vega.lr lr) !st ~params:!params ~grads
+        Vega.adam_step (module Vec) ~lr:(lr64 lr) !st ~params:!params ~grads
       in
       params := params';
       st := st';
@@ -285,15 +294,16 @@ let test_adam_converges () =
   is_true ~msg:"reaches the bottom of the bowl" (bowl_distance params < 0.05)
 
 let test_adam_with_schedule_converges () =
-  (* The learning rate comes from the state's own step counter via a tensor
+  (* The learning rate comes from the state's own step counter through the
      schedule — the jitted loop's shape, run eagerly. *)
+  let sched = S.cosine_decay ~init_value:0.1 ~decay_steps:300 () in
   let params = Lazy.force bowl_start in
   let state = ref (params, Vega.adam_init (module Pair) params) in
   for _k = 1 to 300 do
     let params, st = !state in
     let grads = bowl_grads params in
-    let lr = S.cosine_decay_t ~init_value:0.1 ~decay_steps:300 st.step in
-    state := Vega.adam_step (module Pair) ~lr st ~params ~grads
+    state :=
+      Vega.adam_step (module Pair) ~lr:(sched st.step) st ~params ~grads
   done;
   is_true ~msg:"decayed steps settle at the bottom"
     (bowl_distance (fst !state) < 0.02)
@@ -359,7 +369,7 @@ let test_adamw_decays_weights () =
     let params', st' =
       Vega.adamw_step
         (module Vec)
-        ~lr:(Vega.lr lr) ~weight_decay:wd !st ~params:!params
+        ~lr:(lr64 lr) ~weight_decay:wd !st ~params:!params
         ~grads:(vec [| 0.0; 0.0 |])
     in
     params := params';
@@ -460,64 +470,53 @@ let test_optimizers_carry_a_non_parameter_leaf () =
 
 (* Optimizer state as a parameter tree *)
 
-let test_adam_state_scalars_advance () =
+let test_adam_counter_advances () =
   let params = vec [| 1.0 |] in
   let grads = vec [| 1.0 |] in
   let st = ref (Vega.adam_init (module Vec) params) in
   let lr = Vega.lr 0.1 in
-  (* After k steps the corrections are the closed-form 1 - b^k. *)
-  let b1 = 0.9 and b2 = 0.999 in
-  List.iter
-    (fun k ->
-      (* Advance until the counter reads [k]. *)
-      while Int32.to_int (Nx.item [] !st.step) < k do
-        let _, st' = Vega.adam_step (module Vec) ~lr !st ~params ~grads in
-        st := st'
-      done;
-      equal
-        ~msg:(Printf.sprintf "step after %d" k)
-        int k
-        (Int32.to_int (Nx.item [] !st.step));
-      check_vec
-        ~msg:(Printf.sprintf "c1 at %d" k)
-        [| 1.0 -. (b1 ** float_of_int k) |]
-        !st.c1;
-      check_vec
-        ~msg:(Printf.sprintf "c2 at %d" k)
-        [| 1.0 -. (b2 ** float_of_int k) |]
-        !st.c2)
-    [ 1; 2; 5 ]
+  (* The counter is a tensor leaf, so it advances through the state alone —
+     the shape a compiled loop relies on. The bias corrections derive from it
+     inside each step (checked against the closed form by the reference
+     trajectory above). *)
+  for _ = 1 to 5 do
+    let _, st' = Vega.adam_step (module Vec) ~lr !st ~params ~grads in
+    st := st'
+  done;
+  equal ~msg:"counter reads 5 after 5 steps" int 5
+    (Int32.to_int (Nx.item [] !st.step))
 
 let test_state_traversals () =
-  (* Both state modules are parameter trees: map/map2/iter walk every tensor
-     leaf — payload leaves and the scalar leaves — in a fixed order. *)
+  (* Both state functors are parameter trees: map/map2/iter walk every tensor
+     leaf — payload leaves, then the counter — in a fixed order. *)
+  let module A = Vega.Adam_state (Pair) in
+  let module Sg = Vega.Sgd_state (Pair) in
   let double (type a b) (t : (a, b) Nx.t) : (a, b) Nx.t =
     Nx.cast (Nx.dtype t) (Nx.mul_s (Nx.cast Nx.float64 t) 2.0)
   in
   let params = pair [| 1.0; 2.0 |] [| 3.0 |] in
   let st = Vega.adam_init (module Pair) params in
   (* map doubles everything; iter counts the leaves it visits. *)
-  let doubled = Vega.Adam_state.map (module Pair) double st in
+  let doubled = A.map double st in
   check_vec ~msg:"mu doubled" [| 0.0; 0.0 |] doubled.mu.a;
-  equal ~msg:"c1 doubled" (float 1e-12) 0.0 (Nx.item [] doubled.c1);
   let n = ref 0 in
-  Vega.Adam_state.iter (module Pair) (fun _ -> incr n) st;
-  (* 2 mu leaves + 2 nu leaves + c1 + c2 + step. *)
-  equal ~msg:"adam leaf count" int 7 !n;
+  A.iter (fun _ -> incr n) st;
+  (* 2 mu leaves + 2 nu leaves + step. *)
+  equal ~msg:"adam leaf count" int 5 !n;
   (* map2 merges leafwise: take the right state everywhere. *)
-  let st' = Vega.Adam_state.map2 (module Pair) (fun _ r -> r) st doubled in
+  let st' = A.map2 (fun _ r -> r) st doubled in
   check_vec ~msg:"merged mu" [| 0.0 |] st'.mu.b;
   equal ~msg:"merged step" int32 0l (Nx.item [] st'.step);
   (* The sgd state's single payload leaf. *)
   let sst = Vega.sgd_init (module Pair) params in
   let n = ref 0 in
-  Vega.Sgd_state.iter (module Pair) (fun _ -> incr n) sst;
+  Sg.iter (fun _ -> incr n) sst;
   equal ~msg:"sgd leaf count" int 2 !n
 
-let test_state_make_is_a_ptree () =
-  (* [Make] produces an Nx.Ptree.S: the state can sit inside another tree — the
-     shape a jitted step's input record takes. *)
-  let module Opt = Vega.Adam_state.Make (Pair) in
+let test_state_functor_is_a_ptree () =
+  (* [Vega.Adam_state (P)] is an Nx.Ptree.S: the state can sit inside another
+     tree — the shape a jitted step's input record takes. *)
+  let module Opt = Vega.Adam_state (Pair) in
   let params = pair [| 1.0 |] [| 2.0 |] in
   let grads = pair [| 0.5 |] [| -0.5 |] in
   let st = Vega.adam_init (module Pair) params in
@@ -534,59 +533,6 @@ let test_state_make_is_a_ptree () =
   in
   check_vec ~msg:"roundtrip state steps identically" (Nx.to_array expected.a)
     params'.a
-
-(* Tensor schedules match the scalar family at integer steps. *)
-
-let parity ~msg sched sched_t =
-  List.iter
-    (fun k ->
-      let scalar = sched k in
-      let tensor = Nx.item [] (sched_t (Nx.scalar Nx.int32 (Int32.of_int k))) in
-      equal ~msg:(Printf.sprintf "%s at %d" msg k) (float 1e-6) scalar tensor)
-    [ 0; 1; 3; 7; 50; 99; 100; 250 ]
-
-let test_tensor_schedules_match_scalar () =
-  parity ~msg:"constant" (S.constant 0.1) (S.constant_t 0.1);
-  parity ~msg:"linear"
-    (S.linear ~init_value:0.2 ~end_value:0.001 ~steps:100)
-    (S.linear_t ~init_value:0.2 ~end_value:0.001 ~steps:100);
-  parity ~msg:"cosine decay"
-    (S.cosine_decay ~init_value:0.1 ~decay_steps:100 ~alpha:0.1 ())
-    (S.cosine_decay_t ~init_value:0.1 ~decay_steps:100 ~alpha:0.1);
-  parity ~msg:"warmup cosine"
-    (S.warmup_cosine ~init_value:0.0 ~peak_value:1.0 ~warmup_steps:50)
-    (S.warmup_cosine_t ~init_value:0.0 ~peak_value:1.0 ~warmup_steps:50);
-  parity ~msg:"warmup cosine decay"
-    (S.warmup_cosine_decay ~init_value:0.0 ~peak_value:1.0 ~warmup_steps:10
-       ~decay_steps:100 ())
-    (S.warmup_cosine_decay_t ~init_value:0.0 ~peak_value:1.0 ~warmup_steps:10
-       ~decay_steps:100);
-  parity ~msg:"one cycle"
-    (S.one_cycle ~max_value:0.1 ~total_steps:120 ())
-    (S.one_cycle_t ~max_value:0.1 ~total_steps:120);
-  parity ~msg:"piecewise constant"
-    (S.piecewise_constant ~boundaries:[ 10; 50 ] ~values:[ 0.1; 0.01; 0.001 ])
-    (S.piecewise_constant_t ~boundaries:[ 10; 50 ] ~values:[ 0.1; 0.01; 0.001 ])
-
-let test_tensor_schedule_validation () =
-  raises (Invalid_argument "Schedule.linear_t: steps must be positive")
-    (fun () ->
-      ignore
-        (S.linear_t ~init_value:1.0 ~end_value:0.0 ~steps:0
-           (Nx.scalar Nx.int32 0l)));
-  raises
-    (Invalid_argument "Schedule.cosine_decay_t: decay_steps must be positive")
-    (fun () ->
-      ignore
-        (S.cosine_decay_t ~init_value:1.0 ~decay_steps:(-1)
-           (Nx.scalar Nx.int32 0l)));
-  raises
-    (Invalid_argument
-       "Schedule.piecewise_constant_t: expected 2 values for 1 boundaries, got \
-        1") (fun () ->
-      ignore
-        (S.piecewise_constant_t ~boundaries:[ 10 ] ~values:[ 0.1 ]
-           (Nx.scalar Nx.int32 0l)))
 
 let tests =
   [
@@ -626,8 +572,7 @@ let tests =
         test "converges on a quadratic bowl" test_adam_converges;
         test "converges under a cosine schedule"
           test_adam_with_schedule_converges;
-        test "corrections and counter advance as tensors"
-          test_adam_state_scalars_advance;
+        test "the counter advances as a tensor" test_adam_counter_advances;
         test "zero gradients leave parameters unchanged" test_adam_zero_grads;
         test "stepping is pure in the threaded state" test_adam_step_is_pure;
       ];
@@ -641,15 +586,8 @@ let tests =
     group "optimizer state as a parameter tree"
       [
         test "state traversals walk every leaf" test_state_traversals;
-        test "Make produces a Ptree.S that steps identically"
-          test_state_make_is_a_ptree;
-      ];
-    group "tensor schedules"
-      [
-        test "tensor schedules match the scalar family"
-          test_tensor_schedules_match_scalar;
-        test "tensor schedule constructors reject bad step counts"
-          test_tensor_schedule_validation;
+        test "the state functor is a Ptree.S that steps identically"
+          test_state_functor_is_a_ptree;
       ];
     group "non-parameter leaves"
       [


### PR DESCRIPTION
Rune.jit2 and Rune.pmap2 require a training step's inputs and outputs to be Nx.Ptree.S structures, and every value that changes across calls to be a tensor leaf. Vega's structural optimizer state satisfied neither condition: sgd_state and adam_state were plain records with no traversals, so they could not ride a compiled step, and adam_state's step counter was a host int — under jit the Adam bias corrections 1 - b1^t and 1 - b2^t would be burned into the trace at compile time and replayed stale on every later call. The learning rate had the same shape of problem: a schedule value evaluated on the host is a compile-time constant, so no schedule could run inside a compiled program. clip_by_global_norm read the gradient norm on the host (Nx.item), which raises Jit_error under tracing. The consequence: users could jit their value_and_grad but the optimizer step then ran eagerly with per-step data transfers.

The structural tier is now jit-ready:

- Optimizer state is a parameter tree. `Sgd_state.Make (P)` and `Adam_state.Make (P)` turn the state over a parameter tree `P` into an `Nx.Ptree.S` (plus flat `map/map2/iter` taking `(module Nx.Ptree.S)`), so the state is one field of a compiled step's input and output records — walked by its own traversals, embeddable with ppx_ptree's `[@ptree.using]` — and threads across compiled calls as ordinary leaves. The leaf order (payload leaves, then the scalars) is part of a compiled step's leaf signature and is fixed.

- adam_state is `{ mu; nu; c1; c2; step }` (breaking). The bias corrections c1 = 1 - b1^step and c2 = 1 - b2^step are scalar float64 tensors and step is a scalar int32 tensor, advanced inside the step by affine recurrences (c' = (1 - b) + b*c), seeded at zero so the first step yields exactly 1 - b. The step is pure tensor arithmetic: no pow on tensor exponents, no int-to-float casts, nothing read on the host. The eager trajectory is preserved — float64 corrections keep analytic float64 paths exact, and float32 parameters see bit-identical updates.

- The structural step functions take the learning rate as a scalar tensor, ~lr : (float, 'b) Nx.t (breaking), cast to each leaf's dtype at use. Vega.lr v is the constant-rate helper (Nx.scalar Nx.float64 v). Hyperparameters that genuinely do not change across steps (b1, b2, eps, weight_decay, max_norm) remain floats — legitimate compile-time captures.

- Schedule gains tensor mirrors of the scalar family over a scalar int32 step counter — constant_t, linear_t, cosine_decay_t, warmup_cosine_t, warmup_cosine_decay_t, one_cycle_t, piecewise_constant_t — so the learning rate is derived inside the compiled program from the state's own step leaf. At every integer step the tensor value matches the scalar schedule's to float32 rounding. exponential_decay, polynomial_decay and cosine_decay_restarts remain scalar-only for now (they need pow and integer division on tensors).

- clip_by_global_norm computes its scale factor in tensor arithmetic and selects it with Nx.where — no host read — so it traces under jit. global_norm remains the host-float read for reporting.

A training step now reads as one function of (params, opt, batch):

```ocaml
module Opt = Vega.Adam_state.Make (Model)

type step_in = { params : Model.t; opt : Opt.t; x : ...; y : ... }
(* [@@deriving ptree], with [@ptree.using Opt] on the state field *)

let train_step { params; opt; x; y } =
  let loss, grads =
    Rune.value_and_grad (module Model) (loss_fn x y) params
  in
  let grads = Vega.clip_by_global_norm (module Model) ~max_norm:2.0 grads in
  let lr =
    Vega.Schedule.cosine_decay_t ~init_value:0.05 ~decay_steps:64 opt.step
  in
  let params', opt' =
    Vega.adam_step (module Model) ~lr opt ~params ~grads
  in
  { params'; opt'; loss }

let step =
  Rune.jit2 ~donate:true (module Step_in) (module Step_out) train_step
```

The step compiles once and replays: the state flows out and back in as leaves, the schedule derives from the state's counter inside the program, and `Rune.pmap2` with the state replicated turns the same code into data-parallel training. ~donate:true is the memory-lean default for such loops on a device: it releases the previous generation's device buffers once each call completes, so the loop holds about two generations instead of one per call awaiting the resident-budget collection — at the price of never reading the pre-step state again (donated handles become unusable). Without it, residency is still bounded by the budget; on the CPU device donate changes nothing.

Tests: new kaun/test/test_jit_state.ml — the jitted trajectory matches the eager one, the corrections and counter advance correctly across compiled calls (counter reads n after n calls; c1/c2 match the closed forms), and a pmap2 run with replicated state matches jit. vega's structural tests extend to the correction closed forms, the state traversals and Make round-trip, and scalar/tensor schedule parity; test_pmap_dp threads a real Sgd_state instead of a duplicated model option; kaun's checkpoint tests save and restore the new scalar leaves. All ~lr call sites across kaun, munin, fehu, ppx_ptree and bench migrate to Vega.lr. The jit training examples (gpt2, munin mnist-jit) run with ~donate:true.

Docs: vega's module docs carry the jit story, vega/doc a "Jit-compiled training steps" section, kaun's doc examples and checkpoint docs use the new signatures, and CHANGES records the breaking changes with migration notes.