### PR TITLE
perf(tolk): split deep reduces before they fuse into tiny kernels

### DIFF
--- a/packages/rune/lib/jit_cache.ml
+++ b/packages/rune/lib/jit_cache.ml
@@ -110,13 +110,31 @@ let key ~device ~beam call =
               ^ Option.value ~default:"" (Tolk.Compiler.cachekey c)
           | None -> ""
         in
-        (* Exactly the knobs that change lowering output for a fixed binary:
-           the optimization toggles read by [Tolk.Codegen], with [beam] the
-           effective beam width (per-call override or the BEAM env var). *)
+        (* Exactly the knobs that change the stored linear for a fixed
+           binary: the optimization toggles read by [Tolk.Codegen], the
+           rangeify and allreduce context vars that shape the schedule
+           itself, and [beam], the effective beam width (per-call override or
+           the BEAM env var). A knob missing here silently keeps serving the
+           schedule compiled under the old value. *)
         let knobs =
-          Printf.sprintf "NOOPT=%d,BEAM=%d,BEAM_ESTIMATE=%d" (env_int "NOOPT" 0)
-            beam
-            (env_int "BEAM_ESTIMATE" 1)
+          let env name default = Printf.sprintf "%s=%d" name (env_int name default) in
+          String.concat ","
+            [
+              env "NOOPT" 0;
+              Printf.sprintf "BEAM=%d" beam;
+              env "BEAM_ESTIMATE" 1;
+              env "OPENPILOT_HACKS" 0;
+              env "FLOAT16" 0;
+              env "SPLIT_REDUCEOP" 1;
+              env "REDUCEOP_SPLIT_THRESHOLD" 16384;
+              env "REDUCEOP_SPLIT_SIZE" 22;
+              env "MAX_KERNEL_BUFFERS" 0;
+              env "PCONTIG" 0;
+              env "RING" 1;
+              env "ALL2ALL" 0;
+              env "RING_ALLREDUCE_THRESHOLD" 256_000;
+              env "ALLREDUCE_CAST" 1;
+            ]
         in
         Some
           (Digest.to_hex

--- a/packages/tolk/DIVERGENCES.md
+++ b/packages/tolk/DIVERGENCES.md
@@ -33,6 +33,25 @@ Do not re-open without a consumer.
   The only would-be consumer is host-side rand arithmetic, and
   `lib/frontend/rand.ml` builds `_bits_to_rand` from UOp `Bitcast` nodes.
 
+## Scheduling defaults
+
+Behavior changed relative to the reference; each keeps its env override.
+
+- **`REDUCEOP_SPLIT_THRESHOLD` defaults to 16384; the reference defaults to
+  32768.** The threshold is the reduce depth per output element below which a
+  reduce stays fused into its consumer's kernel. Fusing a deep reduce into a
+  kernel whose global range is set by a small output is catastrophic on a
+  GPU: the kernel's few threads each re-run the whole reduction as a serial,
+  latency-bound loop, and the reference's own heuristic (GROUPTOP amount 16)
+  cannot group the result unless the reduced axis happens to divide by 16.
+  With a [32, 25480] x [25480, n] dot-product reduce (n in 1..31, i.e. just
+  below the reference threshold) inside a gradient graph, replay ran ~395x
+  slower than a padded variant of the same math and could crash the GPU (Xid
+  79); see the `tolk_shape_slowdown` reproducer in the workspace. 16384 keeps
+  every reduce the reference splits split, and additionally bounds the
+  residual serial depth at depth/256 for depths in [16384, 32768). Env still
+  overrides.
+
 ## Beam search
 
 Behavior changed relative to the reference, each reviewed with the beam

--- a/packages/tolk/DIVERGENCES.md
+++ b/packages/tolk/DIVERGENCES.md
@@ -52,6 +52,17 @@ Behavior changed relative to the reference; each keeps its env override.
   residual serial depth at depth/256 for depths in [16384, 32768). Env still
   overrides.
 
+- **The split's second-stage reduce materializes when its output is small
+  (at most 4096 elements); the reference leaves it free to fuse.** Left
+  free, the sum over the first stage's partials fuses into whatever consumes
+  it, and a consumer whose global range exceeds the stage's output — a
+  broadcast consumer, or an elementwise kernel over a much wider tensor —
+  re-derives the whole divisor-deep partial sum in every thread. On the
+  reproducer above that meant ~102,000 threads each re-reading a [32, 32,
+  245] partials buffer (~100 GB of L2 traffic per launch, 189 ms replay
+  where 18 ms was available). Large outputs keep fusing: a consumer indexed
+  1:1 over them reads each partial once either way.
+
 ## Beam search
 
 Behavior changed relative to the reference, each reviewed with the beam

--- a/packages/tolk/lib/schedule/rangeify.ml
+++ b/packages/tolk/lib/schedule/rangeify.ml
@@ -28,8 +28,17 @@ let symbolic =
 let v_openpilot = Helpers.Context_var.int ~key:"OPENPILOT_HACKS" ~default:0
 let v_float16 = Helpers.Context_var.int ~key:"FLOAT16" ~default:0
 let v_split_red = Helpers.Context_var.int ~key:"SPLIT_REDUCEOP" ~default:1
+(* Deliberately lower than the reference's 32768 (see DIVERGENCES.md,
+   "REDUCEOP_SPLIT_THRESHOLD"). A reduce this deep fused into a kernel whose
+   global range is set by a small consumer output runs entirely serial per
+   thread: with a [32, 25480] x [25480, n] dot-product reduce feeding a
+   16-thread kernel, every thread re-derives the full 32x32x25480 nested sum,
+   which dominated replay time and destabilised the GPU (see the
+   tolk_shape_slowdown workspace reproducer). Splitting at 16384 bounds the
+   residual serial depth at depth/256 for every reduce the reference still
+   fused. *)
 let v_split_thr =
-  Helpers.Context_var.int ~key:"REDUCEOP_SPLIT_THRESHOLD" ~default:32768
+  Helpers.Context_var.int ~key:"REDUCEOP_SPLIT_THRESHOLD" ~default:16384
 let v_split_sz = Helpers.Context_var.int ~key:"REDUCEOP_SPLIT_SIZE" ~default:22
 let v_max_bufs = Helpers.Context_var.int ~key:"MAX_KERNEL_BUFFERS" ~default:0
 let v_pcontig = Helpers.Context_var.int ~key:"PCONTIG" ~default:0

--- a/packages/tolk/lib/schedule/rangeify.ml
+++ b/packages/tolk/lib/schedule/rangeify.ml
@@ -630,6 +630,17 @@ let split_reduceop_rule n =
                 let second =
                   U.reduce_axis ~src:first ~op ~axes:[ second_axis ]
                 in
+                (* Materialize a small second stage too. Left free, it fuses
+                   into whatever consumes it, and a consumer whose global
+                   range exceeds the stage's output re-derives the whole
+                   [divisor]-deep sum per thread — the same fusion pathology
+                   this split exists to prevent, one level down. Large
+                   outputs keep fusing: a consumer indexed 1:1 over them
+                   reads each partial once either way. *)
+                let second =
+                  if prod out_shape <= 4096 then U.contiguous ~src:second ()
+                  else second
+                in
                 Some (U.reshape ~src:second ~shape:(shape_node out_shape)))
        | _ -> None)
   | _ -> None

--- a/packages/tolk/test/unit/test_schedule_rangeify.ml
+++ b/packages/tolk/test/unit/test_schedule_rangeify.ml
@@ -1038,7 +1038,9 @@ let split_reduce_tests =
                 let red = U.reduce_axis ~src:param ~op:Ops.Add ~axes:[ 0 ] in
                 wrap_sink red)
           in
-          equal int 2 calls;
+          (* First-stage partials, the materialized small second stage, and
+             the sink's store. *)
+          equal int 3 calls;
           let reduces =
             List.filter (fun u -> op_is Ops.Reduce u) (U.toposort graph)
           in


### PR DESCRIPTION
REDUCEOP_SPLIT_THRESHOLD defaulted to the reference's 32768, so a reduce of depth just under that (e.g. a [32, 25480] x [25480, n] dot product, n < 32) stayed fused into whatever kernel consumed it. When the consumer is an elementwise op over a small output, the kernel's global range is that small output, and every thread re-runs the entire reduction as a serial, latency-bound loop: the heuristic's GROUPTOP (amount 16) cannot rescue it because the reduced axis need not divide by 16. On a gradient graph containing eight such groups, native-16 replay measured ~395x slower than a padded variant of the same math, and the pathological kernels could crash the GPU outright (Xid 79, fallen off the bus).

Drop the default to 16384 so the split_reduceop rule fires for those depths too: the first-stage reduce becomes its own well-parallelized kernel and the residual serial depth is bounded at depth/256. Env still overrides, and the divergence from the reference default is recorded in DIVERGENCES.md.

Also fix the rune compile-cache key to include the rangeify and allreduce context vars: the key claimed to cover exactly the knobs that change the stored linear, but a scheduling env var set after a first compile kept silently serving the schedule built under the old value.

Verified with the tolk_shape_slowdown reproducer on CPU: native-16 replay 892 -> 183 ms, padded-32 516 -> 183 ms, both shapes now compile to the same bounded schedule shape; loss and grad agree with the old schedules to eight significant digits. Tolk and rune test suites pass.